### PR TITLE
IE8 compatibility fixes

### DIFF
--- a/example.html
+++ b/example.html
@@ -12,8 +12,13 @@
   <!-- Media Sources plugin -->
   <script src="node_modules/videojs-media-sources/videojs-media-sources.js"></script>
 
+  <!-- browser compatibility -->
+  <script src="src/typed-arrays.js"></script>
+  <script src="src/base64.js"></script>
+
   <!-- HLS plugin -->
   <script src="src/video-js-hls.js"></script>
+  <script src="src/binary-xhr.js"></script>
 
   <!-- segment handling -->
   <script src="src/flv-tag.js"></script>
@@ -35,7 +40,7 @@
   <!-- bipbop -->
   <!-- <script src="test/tsSegment.js"></script> -->
   <!-- bunnies -->
-  <script src="test/tsSegment-bc.js"></script>
+  <!-- <script src="test/tsSegment-bc.js"></script> -->
 
 </head>
 <body>

--- a/src/base64.js
+++ b/src/base64.js
@@ -1,0 +1,64 @@
+/**
+ * Polyfill for window.btoa and window.atob in IE8
+ * https://github.com/davidchambers/Base64.js
+ */
+;(function () {
+
+  var object = typeof exports != 'undefined' ? exports : this; // #8: web workers
+  var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+
+  function InvalidCharacterError(message) {
+    this.message = message;
+  }
+  InvalidCharacterError.prototype = new Error;
+  InvalidCharacterError.prototype.name = 'InvalidCharacterError';
+
+  // encoder
+  // [https://gist.github.com/999166] by [https://github.com/nignag]
+  object.btoa || (
+  object.btoa = function (input) {
+    for (
+      // initialize result and counter
+      var block, charCode, idx = 0, map = chars, output = '';
+      // if the next input index does not exist:
+      //   change the mapping table to "="
+      //   check if d has no fractional digits
+      input.charAt(idx | 0) || (map = '=', idx % 1);
+      // "8 - idx % 1 * 8" generates the sequence 2, 4, 6, 8
+      output += map.charAt(63 & block >> 8 - idx % 1 * 8)
+    ) {
+      charCode = input.charCodeAt(idx += 3/4);
+      if (charCode > 0xFF) {
+        throw new InvalidCharacterError("'btoa' failed: The string to be encoded contains characters outside of the Latin1 range.");
+      }
+      block = block << 8 | charCode;
+    }
+    return output;
+  });
+
+  // decoder
+  // [https://gist.github.com/1020396] by [https://github.com/atk]
+  object.atob || (
+  object.atob = function (input) {
+    input = input.replace(/=+$/, '')
+    if (input.length % 4 == 1) {
+      throw new InvalidCharacterError("'atob' failed: The string to be decoded is not correctly encoded.");
+    }
+    for (
+      // initialize result and counters
+      var bc = 0, bs, buffer, idx = 0, output = '';
+      // get next character
+      buffer = input.charAt(idx++);
+      // character found in table? initialize bit storage and add its ascii value;
+      ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer,
+        // and if not first of each 4 characters,
+        // convert the first 8 bits to one ascii character
+        bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0
+    ) {
+      // try to find character in table (0-63, not found => -1)
+      buffer = chars.indexOf(buffer);
+    }
+    return output;
+  });
+
+}());

--- a/src/binary-xhr.js
+++ b/src/binary-xhr.js
@@ -1,0 +1,112 @@
+/**
+ * Utilities for making XMLHttpRequests for binary data and handling related browser-compatibility issues.
+ */
+(function(window, undefined) {
+  
+  var
+    vbarrayToUint8 = function(vbarray) {
+      var
+        rawbytes = VideoJS_vbarrayToString(vbarray),
+        lastChar = VideoJS_vbarrayLastByteToString(vbarray),
+        result = new Uint8Array((rawbytes.length * 2) + lastChar.length),
+        i = rawbytes.length,
+        charCode,
+        resultIndex;
+
+      // copy the bytes of each double-byte character
+      while (i--) {
+        resultIndex = i * 2;
+        charCode = rawbytes.charCodeAt(i);
+        result[resultIndex + 1] = charCode >> 8;
+        result[resultIndex] = charCode && 0xFF;
+      }
+      // copy over the last byte
+      if (lastChar) {
+        result[result.byteLength - 1] = lastChar.charCodeAt(0);
+      }
+
+      return result;
+    },
+
+    /**
+     * Perform the initialization necessary to retrieve data from the `
+     * responseBody` property of an XMLHttpRequest. This is only necessary on
+     * IE < 10.
+     */
+    initResponseBodyParsing = function() {
+      // write out the helper VBScript to export the responseBody to javascript
+      var script = document.createElement('script');
+      script.type = 'text/vbscript'
+      script.text =
+        "Function VideoJS_vbarrayToString(Binary)\n" +
+        "  VideoJS_vbarrayToString = CStr(Binary)\n" +
+        "End Function\n" +
+        "Function VideoJS_vbarrayLastByteToString(Binary)\n" +
+        "  Dim lastIndex\n" +
+        "  lastIndex = LenB(Binary)\n" +
+        "  if lastIndex mod 2 Then\n" +
+        "    VideoJS_vbarrayLastByteToString = Chr(AscB(MidB(Binary, lastIndex, 1)))\n" +
+        "  Else\n" +
+        "    VideoJS_vbarrayLastByteToString = \"\"\n" +
+        "  End If\n" +
+        "End Function\n";
+      document.documentElement.firstChild.appendChild(script);
+    },
+
+    /**
+     * Transform the `responseBody` property of an XMLHttpRequest into a
+     * Uint8Array.
+     * @param responseBody {object}
+     * @return {object} a Uint8Array
+     */
+    responseBodyToUint8 = function(responseBody) {
+      // the first time this function is called, initialize the responseBody
+      // parsing machinery
+      initResponseBodyParsing();
+
+      // subsequent calls do not need to re-initialize the parsing utilities
+      responseBodyToUint8 = vbarrayToUint8;
+
+      // return the result
+      return vbarrayToUint8(responseBody);
+    };
+
+  /**
+   * Request a URL with a GET. Handles the complications of fetching binary
+   * data in older browsers that do not support response type `arraybuffer`.
+   * @param url the URL to request. This URL must be accessible and configured
+   * to allow XMLHttpRequests from the browser downloading the segment. For
+   * newer browsers, this probably means configuring CORS support.
+   * @param callback a function that to be invoked when the request is
+   * finished. Its first parameter, if truthy, describes any errors that
+   * occurred performing the request. If the request was successful, the second
+   * parameter is a Uint8Array of the response body and the third is the
+   * XMLHttpRequest object.
+   */
+  window.videojs.hls.xhrGet = function(url, callback) {
+    var request = new XMLHttpRequest();
+    request.open('GET', url, true);
+    request.responseType = 'arraybuffer';
+
+    // report errors node.js style
+    request.onerror = function(error) {
+      callback(error, null, request);
+    };
+
+    // report results when the request finishes
+    request.onreadystatechange = function() {
+      if (request.readyState === 4) {
+        if (request.responseBody !== undefined) {
+          // jump through hoops to get usable data from XHR in IE8
+          return callback(null,
+                          responseBodyToUint8(request.responseBody),
+                          request);
+        }
+        callback(null, new Uint8Array(request.response), request);
+      }
+    };
+
+    // send the request
+    request.send(null);
+  };
+})(window);

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -1,4 +1,5 @@
 (function(window) {
+  'use strict';
   var M3U8 = window.videojs.hls.M3U8;
 
   window.videojs.hls.M3U8Parser = function() {
@@ -25,6 +26,115 @@
     };
 
     self.parse = function(rawDataString) {
+      var
+        line,
+        parseLine = function(value,index) {
+          var segment, rendition, attributes;
+
+          switch (self.getTagType(value)) {
+          case tagTypes.EXTM3U:
+            data.hasValidM3UTag = (index === 0);
+            if (!data.hasValidM3UTag) {
+              data.invalidReasons.push("Invalid EXTM3U Tag");
+            }
+            break;
+
+          case tagTypes.DISCONTINUITY:
+            break;
+
+          case tagTypes.PLAYLIST_TYPE:
+            if (self.getTagValue(value) === "VOD" ||
+                self.getTagValue(value) === "EVENT") {
+              data.playlistType = self.getTagValue(value);
+
+            } else {
+              data.invalidReasons.push("Invalid Playlist Type Value");
+            }
+            break;
+
+          case tagTypes.EXTINF:
+            segment = {
+              url: "unknown",
+              byterange: -1,
+              targetDuration: data.targetDuration
+            };
+
+            if (self.getTagType(lines[index + 1]) === tagTypes.BYTERANGE) {
+              segment.byterange = self.getTagValue(lines[index + 1]).split('@');
+              segment.url = lines[index + 2];
+            } else {
+              segment.url = lines[index + 1];
+            }
+
+            if (segment.url.indexOf("http") === -1 && self.directory) {
+              if (data.directory[data.directory.length-1] === segment.url[0] &&
+                  segment.url[0] === "/") {
+                segment.url = segment.url.substr(1);
+              }
+              segment.url = self.directory + segment.url;
+            }
+            data.mediaItems.push(segment);
+            break;
+
+          case tagTypes.STREAM_INF:
+            rendition = {};
+            attributes = value.substr(tagTypes.STREAM_INF.length).split(',');
+
+            attributes.forEach(function(attrValue) {
+              if (isNaN(attrValue.split('=')[1])) {
+                rendition[attrValue.split('=')[0].toLowerCase()] = attrValue.split('=')[1];
+
+                if (rendition[attrValue.split('=')[0].toLowerCase()].split('x').length === 2) {
+                  rendition.resolution = {
+                    width: parseInt(rendition[attrValue.split('=')[0].toLowerCase()].split('x')[0],10),
+                    height: parseInt(rendition[attrValue.split('=')[0].toLowerCase()].split('x')[1],10)
+                  };
+                }
+              } else {
+                rendition[attrValue.split('=')[0].toLowerCase()] = parseInt(attrValue.split('=')[1],10);
+              }
+            });
+
+            if (self.getTagType(lines[index + 1]) === tagTypes.BYTERANGE) {
+              rendition.byterange = self.getTagValue(lines[index + 1]).split('@');
+              rendition.url = lines[index + 2];
+            } else {
+              rendition.url = lines[index + 1];
+            }
+
+            data.isPlaylist = true;
+            data.playlistItems.push(rendition);
+            break;
+
+          case tagTypes.TARGETDURATION:
+            data.targetDuration = parseFloat(self.getTagValue(value).split(',')[0]);
+            break;
+
+          case tagTypes.ZEN_TOTAL_DURATION:
+            data.totalDuration = parseFloat(self.getTagValue(value));
+            break;
+
+          case tagTypes.VERSION:
+            data.version = parseFloat(self.getTagValue(value));
+            break;
+
+          case tagTypes.MEDIA_SEQUENCE:
+            data.mediaSequence = parseInt(self.getTagValue(value),10);
+            break;
+
+          case tagTypes.ALLOW_CACHE:
+            if (self.getTagValue(value) === "YES" || self.getTagValue(value) === "NO") {
+              data.allowCache = self.getTagValue(value);
+            } else {
+              data.invalidReasons.push("Invalid ALLOW_CACHE Value");
+            }
+            break;
+
+          case tagTypes.ENDLIST:
+            data.hasEndTag = true;
+            break;
+          }
+        };
       data = new M3U8();
 
       if (self.directory) {
@@ -37,113 +147,9 @@
       }
       lines = rawDataString.split('\n');
 
-      lines.forEach(function(value,index) {
-        var segment, rendition, attributes;
-
-        switch (self.getTagType(value)) {
-        case tagTypes.EXTM3U:
-          data.hasValidM3UTag = (index === 0);
-          if (!data.hasValidM3UTag) {
-            data.invalidReasons.push("Invalid EXTM3U Tag");
-          }
-          break;
-
-        case tagTypes.DISCONTINUITY:
-          break;
-
-        case tagTypes.PLAYLIST_TYPE:
-          if (self.getTagValue(value) === "VOD" ||
-              self.getTagValue(value) === "EVENT") {
-            data.playlistType = self.getTagValue(value);
-
-          } else {
-            data.invalidReasons.push("Invalid Playlist Type Value");
-          }
-          break;
-
-        case tagTypes.EXTINF:
-          segment = {
-            url: "unknown",
-            byterange: -1,
-            targetDuration: data.targetDuration
-          };
-
-          if (self.getTagType(lines[index + 1]) === tagTypes.BYTERANGE) {
-            segment.byterange = self.getTagValue(lines[index + 1]).split('@');
-            segment.url = lines[index + 2];
-          } else {
-            segment.url = lines[index + 1];
-          }
-
-          if (segment.url.indexOf("http") === -1 && self.directory) {
-            if (data.directory[data.directory.length-1] === segment.url[0] &&
-                segment.url[0] === "/") {
-              segment.url = segment.url.substr(1);
-            }
-            segment.url = self.directory + segment.url;
-          }
-          data.mediaItems.push(segment);
-          break;
-
-        case tagTypes.STREAM_INF:
-          rendition = {};
-          attributes = value.substr(tagTypes.STREAM_INF.length).split(',');
-
-          attributes.forEach(function(attrValue) {
-            if (isNaN(attrValue.split('=')[1])) {
-              rendition[attrValue.split('=')[0].toLowerCase()] = attrValue.split('=')[1];
-
-              if (rendition[attrValue.split('=')[0].toLowerCase()].split('x').length === 2) {
-                rendition.resolution = {
-                  width: parseInt(rendition[attrValue.split('=')[0].toLowerCase()].split('x')[0],10),
-                  height: parseInt(rendition[attrValue.split('=')[0].toLowerCase()].split('x')[1],10)
-                };
-              }
-            } else {
-              rendition[attrValue.split('=')[0].toLowerCase()] = parseInt(attrValue.split('=')[1],10);
-            }
-          });
-
-          if (self.getTagType(lines[index + 1]) === tagTypes.BYTERANGE) {
-            rendition.byterange = self.getTagValue(lines[index + 1]).split('@');
-            rendition.url = lines[index + 2];
-          } else {
-            rendition.url = lines[index + 1];
-          }
-
-          data.isPlaylist = true;
-          data.playlistItems.push(rendition);
-          break;
-
-        case tagTypes.TARGETDURATION:
-          data.targetDuration = parseFloat(self.getTagValue(value).split(',')[0]);
-          break;
-
-        case tagTypes.ZEN_TOTAL_DURATION:
-          data.totalDuration = parseFloat(self.getTagValue(value));
-          break;
-
-        case tagTypes.VERSION:
-          data.version = parseFloat(self.getTagValue(value));
-          break;
-
-        case tagTypes.MEDIA_SEQUENCE:
-          data.mediaSequence = parseInt(self.getTagValue(value),10);
-          break;
-
-        case tagTypes.ALLOW_CACHE:
-          if (self.getTagValue(value) === "YES" || self.getTagValue(value) === "NO") {
-            data.allowCache = self.getTagValue(value);
-          } else {
-            data.invalidReasons.push("Invalid ALLOW_CACHE Value");
-          }
-          break;
-
-        case tagTypes.ENDLIST:
-          data.hasEndTag = true;
-          break;
-        }
-      });
+      for (line in lines) {
+        parseLine(lines[line], +line);
+      }
 
       return data;
     };

--- a/src/segment-controller.js
+++ b/src/segment-controller.js
@@ -1,24 +1,19 @@
 (function(window) {
 
+  var xhrGet = window.videojs.hls.xhrGet;
+
   window.videojs.hls.SegmentController = function() {
     var self = this;
 
     self.loadSegment = function(segmentUrl, onDataCallback, onErrorCallback, onUpdateCallback) {
-      var request = new XMLHttpRequest();
-
-      self.url = segmentUrl;
       self.onDataCallback = onDataCallback;
-      self.onErrorCallback = onErrorCallback;
-      self.onUpdateCallback = onUpdateCallback;
-      self.requestTimestamp = +new Date();
 
-      request.open('GET', segmentUrl, true);
-      request.responseType = 'arraybuffer';
-      request.onload = function() {
-        self.onSegmentLoadComplete(new Uint8Array(request.response));
-      };
-
-      request.send(null);
+      xhrGet(segmentUrl, function(error, data, request) {
+        if (error) {
+          return onErrorCallback(error);
+        }
+        return self.onSegmentLoadComplete(data);
+      });
     };
 
     self.parseSegment = function(incomingData) {
@@ -48,16 +43,6 @@
 
       if (self.onDataCallback !== undefined) {
         self.onDataCallback(output);
-      }
-    };
-
-    self.onSegmentLoadError = function(error) {
-      if (error) {
-        throw error;
-      }
-
-      if (self.onErrorCallback !== undefined) {
-        self.onErrorCallback(error);
       }
     };
   };

--- a/src/typed-arrays.js
+++ b/src/typed-arrays.js
@@ -1,0 +1,664 @@
+/*
+ Copyright (c) 2010, Linden Research, Inc.
+ Copyright (c) 2012, Joshua Bell
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ $/LicenseInfo$
+ */
+
+// Original can be found at:
+//   https://bitbucket.org/lindenlab/llsd
+// Modifications by Joshua Bell inexorabletash@gmail.com
+//   https://github.com/inexorabletash/polyfill
+
+// ES3/ES5 implementation of the Krhonos Typed Array Specification
+//   Ref: http://www.khronos.org/registry/typedarray/specs/latest/
+//   Date: 2011-02-01
+//
+// Variations:
+//  * Allows typed_array.get/set() as alias for subscripts (typed_array[])
+
+
+(function(global) {
+  "use strict";
+  var undefined = (void 0); // Paranoia
+
+  // Beyond this value, index getters/setters (i.e. array[0], array[1]) are so slow to
+  // create, and consume so much memory, that the browser appears frozen.
+  var MAX_ARRAY_LENGTH = 1e7;
+
+  // Approximations of internal ECMAScript conversion functions
+  var ECMAScript = (function() {
+    // Stash a copy in case other scripts modify these
+    var opts = Object.prototype.toString,
+        ophop = Object.prototype.hasOwnProperty;
+
+    return {
+      // Class returns internal [[Class]] property, used to avoid cross-frame instanceof issues:
+      Class: function(v) { return opts.call(v).replace(/^\[object *|\]$/g, ''); },
+      HasProperty: function(o, p) { return p in o; },
+      HasOwnProperty: function(o, p) { return ophop.call(o, p); },
+      IsCallable: function(o) { return typeof o === 'function'; },
+      ToInt32: function(v) { return v >> 0; },
+      ToUint32: function(v) { return v >>> 0; }
+    };
+  }());
+
+  // Snapshot intrinsics
+  var LN2 = Math.LN2,
+      abs = Math.abs,
+      floor = Math.floor,
+      log = Math.log,
+      min = Math.min,
+      pow = Math.pow,
+      round = Math.round;
+
+  // ES5: lock down object properties
+  function configureProperties(obj) {
+    if (Object.getOwnPropertyNames && Object.defineProperty) {
+      var props = Object.getOwnPropertyNames(obj), i;
+      for (i = 0; i < props.length; i += 1) {
+        Object.defineProperty(obj, props[i], {
+          value: obj[props[i]],
+          writable: false,
+          enumerable: false,
+          configurable: false
+        });
+      }
+    }
+  }
+
+  // emulate ES5 getter/setter API using legacy APIs
+  // http://blogs.msdn.com/b/ie/archive/2010/09/07/transitioning-existing-code-to-the-es5-getter-setter-apis.aspx
+  // (second clause tests for Object.defineProperty() in IE<9 that only supports extending DOM prototypes, but
+  // note that IE<9 does not support __defineGetter__ or __defineSetter__ so it just renders the method harmless)
+  if (!Object.defineProperty ||
+       !(function() { try { Object.defineProperty({}, 'x', {}); return true; } catch (e) { return false; } }())) {
+    Object.defineProperty = function(o, p, desc) {
+      if (!o === Object(o)) throw new TypeError("Object.defineProperty called on non-object");
+      if (ECMAScript.HasProperty(desc, 'get') && Object.prototype.__defineGetter__) { Object.prototype.__defineGetter__.call(o, p, desc.get); }
+      if (ECMAScript.HasProperty(desc, 'set') && Object.prototype.__defineSetter__) { Object.prototype.__defineSetter__.call(o, p, desc.set); }
+      if (ECMAScript.HasProperty(desc, 'value')) { o[p] = desc.value; }
+      return o;
+    };
+  }
+
+  if (!Object.getOwnPropertyNames) {
+    Object.getOwnPropertyNames = function getOwnPropertyNames(o) {
+      if (o !== Object(o)) throw new TypeError("Object.getOwnPropertyNames called on non-object");
+      var props = [], p;
+      for (p in o) {
+        if (ECMAScript.HasOwnProperty(o, p)) {
+          props.push(p);
+        }
+      }
+      return props;
+    };
+  }
+
+  // ES5: Make obj[index] an alias for obj._getter(index)/obj._setter(index, value)
+  // for index in 0 ... obj.length
+  function makeArrayAccessors(obj) {
+    if (!Object.defineProperty) { return; }
+
+    if (obj.length > MAX_ARRAY_LENGTH) throw new RangeError("Array too large for polyfill");
+
+    function makeArrayAccessor(index) {
+      Object.defineProperty(obj, index, {
+        'get': function() { return obj._getter(index); },
+        'set': function(v) { obj._setter(index, v); },
+        enumerable: true,
+        configurable: false
+      });
+    }
+
+    var i;
+    for (i = 0; i < obj.length; i += 1) {
+      makeArrayAccessor(i);
+    }
+  }
+
+  // Internal conversion functions:
+  //    pack<Type>()   - take a number (interpreted as Type), output a byte array
+  //    unpack<Type>() - take a byte array, output a Type-like number
+
+  function as_signed(value, bits) { var s = 32 - bits; return (value << s) >> s; }
+  function as_unsigned(value, bits) { var s = 32 - bits; return (value << s) >>> s; }
+
+  function packI8(n) { return [n & 0xff]; }
+  function unpackI8(bytes) { return as_signed(bytes[0], 8); }
+
+  function packU8(n) { return [n & 0xff]; }
+  function unpackU8(bytes) { return as_unsigned(bytes[0], 8); }
+
+  function packU8Clamped(n) { n = round(Number(n)); return [n < 0 ? 0 : n > 0xff ? 0xff : n & 0xff]; }
+
+  function packI16(n) { return [(n >> 8) & 0xff, n & 0xff]; }
+  function unpackI16(bytes) { return as_signed(bytes[0] << 8 | bytes[1], 16); }
+
+  function packU16(n) { return [(n >> 8) & 0xff, n & 0xff]; }
+  function unpackU16(bytes) { return as_unsigned(bytes[0] << 8 | bytes[1], 16); }
+
+  function packI32(n) { return [(n >> 24) & 0xff, (n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]; }
+  function unpackI32(bytes) { return as_signed(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3], 32); }
+
+  function packU32(n) { return [(n >> 24) & 0xff, (n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff]; }
+  function unpackU32(bytes) { return as_unsigned(bytes[0] << 24 | bytes[1] << 16 | bytes[2] << 8 | bytes[3], 32); }
+
+  function packIEEE754(v, ebits, fbits) {
+
+    var bias = (1 << (ebits - 1)) - 1,
+        s, e, f, ln,
+        i, bits, str, bytes;
+
+    function roundToEven(n) {
+      var w = floor(n), f = n - w;
+      if (f < 0.5)
+        return w;
+      if (f > 0.5)
+        return w + 1;
+      return w % 2 ? w + 1 : w;
+    }
+
+    // Compute sign, exponent, fraction
+    if (v !== v) {
+      // NaN
+      // http://dev.w3.org/2006/webapi/WebIDL/#es-type-mapping
+      e = (1 << ebits) - 1; f = pow(2, fbits - 1); s = 0;
+    } else if (v === Infinity || v === -Infinity) {
+      e = (1 << ebits) - 1; f = 0; s = (v < 0) ? 1 : 0;
+    } else if (v === 0) {
+      e = 0; f = 0; s = (1 / v === -Infinity) ? 1 : 0;
+    } else {
+      s = v < 0;
+      v = abs(v);
+
+      if (v >= pow(2, 1 - bias)) {
+        e = min(floor(log(v) / LN2), 1023);
+        f = roundToEven(v / pow(2, e) * pow(2, fbits));
+        if (f / pow(2, fbits) >= 2) {
+          e = e + 1;
+          f = 1;
+        }
+        if (e > bias) {
+          // Overflow
+          e = (1 << ebits) - 1;
+          f = 0;
+        } else {
+          // Normalized
+          e = e + bias;
+          f = f - pow(2, fbits);
+        }
+      } else {
+        // Denormalized
+        e = 0;
+        f = roundToEven(v / pow(2, 1 - bias - fbits));
+      }
+    }
+
+    // Pack sign, exponent, fraction
+    bits = [];
+    for (i = fbits; i; i -= 1) { bits.push(f % 2 ? 1 : 0); f = floor(f / 2); }
+    for (i = ebits; i; i -= 1) { bits.push(e % 2 ? 1 : 0); e = floor(e / 2); }
+    bits.push(s ? 1 : 0);
+    bits.reverse();
+    str = bits.join('');
+
+    // Bits to bytes
+    bytes = [];
+    while (str.length) {
+      bytes.push(parseInt(str.substring(0, 8), 2));
+      str = str.substring(8);
+    }
+    return bytes;
+  }
+
+  function unpackIEEE754(bytes, ebits, fbits) {
+
+    // Bytes to bits
+    var bits = [], i, j, b, str,
+        bias, s, e, f;
+
+    for (i = bytes.length; i; i -= 1) {
+      b = bytes[i - 1];
+      for (j = 8; j; j -= 1) {
+        bits.push(b % 2 ? 1 : 0); b = b >> 1;
+      }
+    }
+    bits.reverse();
+    str = bits.join('');
+
+    // Unpack sign, exponent, fraction
+    bias = (1 << (ebits - 1)) - 1;
+    s = parseInt(str.substring(0, 1), 2) ? -1 : 1;
+    e = parseInt(str.substring(1, 1 + ebits), 2);
+    f = parseInt(str.substring(1 + ebits), 2);
+
+    // Produce number
+    if (e === (1 << ebits) - 1) {
+      return f !== 0 ? NaN : s * Infinity;
+    } else if (e > 0) {
+      // Normalized
+      return s * pow(2, e - bias) * (1 + f / pow(2, fbits));
+    } else if (f !== 0) {
+      // Denormalized
+      return s * pow(2, -(bias - 1)) * (f / pow(2, fbits));
+    } else {
+      return s < 0 ? -0 : 0;
+    }
+  }
+
+  function unpackF64(b) { return unpackIEEE754(b, 11, 52); }
+  function packF64(v) { return packIEEE754(v, 11, 52); }
+  function unpackF32(b) { return unpackIEEE754(b, 8, 23); }
+  function packF32(v) { return packIEEE754(v, 8, 23); }
+
+
+  //
+  // 3 The ArrayBuffer Type
+  //
+
+  (function() {
+
+    /** @constructor */
+    var ArrayBuffer = function ArrayBuffer(length) {
+      length = ECMAScript.ToInt32(length);
+      if (length < 0) throw new RangeError('ArrayBuffer size is not a small enough positive integer.');
+
+      this.byteLength = length;
+      this._bytes = [];
+      this._bytes.length = length;
+
+      var i;
+      for (i = 0; i < this.byteLength; i += 1) {
+        this._bytes[i] = 0;
+      }
+
+      configureProperties(this);
+    };
+
+    global.ArrayBuffer = global.ArrayBuffer || ArrayBuffer;
+
+    //
+    // 4 The ArrayBufferView Type
+    //
+
+    // NOTE: this constructor is not exported
+    /** @constructor */
+    var ArrayBufferView = function ArrayBufferView() {
+      //this.buffer = null;
+      //this.byteOffset = 0;
+      //this.byteLength = 0;
+    };
+
+    //
+    // 5 The Typed Array View Types
+    //
+
+    function makeConstructor(bytesPerElement, pack, unpack) {
+      // Each TypedArray type requires a distinct constructor instance with
+      // identical logic, which this produces.
+
+      var ctor;
+      ctor = function(buffer, byteOffset, length) {
+        var array, sequence, i, s;
+
+        if (!arguments.length || typeof arguments[0] === 'number') {
+          // Constructor(unsigned long length)
+          this.length = ECMAScript.ToInt32(arguments[0]);
+          if (length < 0) throw new RangeError('ArrayBufferView size is not a small enough positive integer.');
+
+          this.byteLength = this.length * this.BYTES_PER_ELEMENT;
+          this.buffer = new ArrayBuffer(this.byteLength);
+          this.byteOffset = 0;
+        } else if (typeof arguments[0] === 'object' && arguments[0].constructor === ctor) {
+          // Constructor(TypedArray array)
+          array = arguments[0];
+
+          this.length = array.length;
+          this.byteLength = this.length * this.BYTES_PER_ELEMENT;
+          this.buffer = new ArrayBuffer(this.byteLength);
+          this.byteOffset = 0;
+
+          for (i = 0; i < this.length; i += 1) {
+            this._setter(i, array._getter(i));
+          }
+        } else if (typeof arguments[0] === 'object' &&
+                   !(arguments[0] instanceof ArrayBuffer || ECMAScript.Class(arguments[0]) === 'ArrayBuffer')) {
+          // Constructor(sequence<type> array)
+          sequence = arguments[0];
+
+          this.length = ECMAScript.ToUint32(sequence.length);
+          this.byteLength = this.length * this.BYTES_PER_ELEMENT;
+          this.buffer = new ArrayBuffer(this.byteLength);
+          this.byteOffset = 0;
+
+          for (i = 0; i < this.length; i += 1) {
+            s = sequence[i];
+            this._setter(i, Number(s));
+          }
+        } else if (typeof arguments[0] === 'object' &&
+                   (arguments[0] instanceof ArrayBuffer || ECMAScript.Class(arguments[0]) === 'ArrayBuffer')) {
+          // Constructor(ArrayBuffer buffer,
+          //             optional unsigned long byteOffset, optional unsigned long length)
+          this.buffer = buffer;
+
+          this.byteOffset = ECMAScript.ToUint32(byteOffset);
+          if (this.byteOffset > this.buffer.byteLength) {
+            throw new RangeError("byteOffset out of range");
+          }
+
+          if (this.byteOffset % this.BYTES_PER_ELEMENT) {
+            // The given byteOffset must be a multiple of the element
+            // size of the specific type, otherwise an exception is raised.
+            throw new RangeError("ArrayBuffer length minus the byteOffset is not a multiple of the element size.");
+          }
+
+          if (arguments.length < 3) {
+            this.byteLength = this.buffer.byteLength - this.byteOffset;
+
+            if (this.byteLength % this.BYTES_PER_ELEMENT) {
+              throw new RangeError("length of buffer minus byteOffset not a multiple of the element size");
+            }
+            this.length = this.byteLength / this.BYTES_PER_ELEMENT;
+          } else {
+            this.length = ECMAScript.ToUint32(length);
+            this.byteLength = this.length * this.BYTES_PER_ELEMENT;
+          }
+
+          if ((this.byteOffset + this.byteLength) > this.buffer.byteLength) {
+            throw new RangeError("byteOffset and length reference an area beyond the end of the buffer");
+          }
+        } else {
+          throw new TypeError("Unexpected argument type(s)");
+        }
+
+        this.constructor = ctor;
+
+        configureProperties(this);
+        makeArrayAccessors(this);
+      };
+
+      ctor.prototype = new ArrayBufferView();
+      ctor.prototype.BYTES_PER_ELEMENT = bytesPerElement;
+      ctor.prototype._pack = pack;
+      ctor.prototype._unpack = unpack;
+      ctor.BYTES_PER_ELEMENT = bytesPerElement;
+
+      // getter type (unsigned long index);
+      ctor.prototype._getter = function(index) {
+        if (arguments.length < 1) throw new SyntaxError("Not enough arguments");
+
+        index = ECMAScript.ToUint32(index);
+        if (index >= this.length) {
+          return undefined;
+        }
+
+        var bytes = [], i, o;
+        for (i = 0, o = this.byteOffset + index * this.BYTES_PER_ELEMENT;
+             i < this.BYTES_PER_ELEMENT;
+             i += 1, o += 1) {
+          bytes.push(this.buffer._bytes[o]);
+        }
+        return this._unpack(bytes);
+      };
+
+      // NONSTANDARD: convenience alias for getter: type get(unsigned long index);
+      ctor.prototype.get = ctor.prototype._getter;
+
+      // setter void (unsigned long index, type value);
+      ctor.prototype._setter = function(index, value) {
+        if (arguments.length < 2) throw new SyntaxError("Not enough arguments");
+
+        index = ECMAScript.ToUint32(index);
+        if (index >= this.length) {
+          return undefined;
+        }
+
+        var bytes = this._pack(value), i, o;
+        for (i = 0, o = this.byteOffset + index * this.BYTES_PER_ELEMENT;
+             i < this.BYTES_PER_ELEMENT;
+             i += 1, o += 1) {
+          this.buffer._bytes[o] = bytes[i];
+        }
+      };
+
+      // void set(TypedArray array, optional unsigned long offset);
+      // void set(sequence<type> array, optional unsigned long offset);
+      ctor.prototype.set = function(index, value) {
+        if (arguments.length < 1) throw new SyntaxError("Not enough arguments");
+        var array, sequence, offset, len,
+            i, s, d,
+            byteOffset, byteLength, tmp;
+
+        if (typeof arguments[0] === 'object' && arguments[0].constructor === this.constructor) {
+          // void set(TypedArray array, optional unsigned long offset);
+          array = arguments[0];
+          offset = ECMAScript.ToUint32(arguments[1]);
+
+          if (offset + array.length > this.length) {
+            throw new RangeError("Offset plus length of array is out of range");
+          }
+
+          byteOffset = this.byteOffset + offset * this.BYTES_PER_ELEMENT;
+          byteLength = array.length * this.BYTES_PER_ELEMENT;
+
+          if (array.buffer === this.buffer) {
+            tmp = [];
+            for (i = 0, s = array.byteOffset; i < byteLength; i += 1, s += 1) {
+              tmp[i] = array.buffer._bytes[s];
+            }
+            for (i = 0, d = byteOffset; i < byteLength; i += 1, d += 1) {
+              this.buffer._bytes[d] = tmp[i];
+            }
+          } else {
+            for (i = 0, s = array.byteOffset, d = byteOffset;
+                 i < byteLength; i += 1, s += 1, d += 1) {
+              this.buffer._bytes[d] = array.buffer._bytes[s];
+            }
+          }
+        } else if (typeof arguments[0] === 'object' && typeof arguments[0].length !== 'undefined') {
+          // void set(sequence<type> array, optional unsigned long offset);
+          sequence = arguments[0];
+          len = ECMAScript.ToUint32(sequence.length);
+          offset = ECMAScript.ToUint32(arguments[1]);
+
+          if (offset + len > this.length) {
+            throw new RangeError("Offset plus length of array is out of range");
+          }
+
+          for (i = 0; i < len; i += 1) {
+            s = sequence[i];
+            this._setter(offset + i, Number(s));
+          }
+        } else {
+          throw new TypeError("Unexpected argument type(s)");
+        }
+      };
+
+      // TypedArray subarray(long begin, optional long end);
+      ctor.prototype.subarray = function(start, end) {
+        function clamp(v, min, max) { return v < min ? min : v > max ? max : v; }
+
+        start = ECMAScript.ToInt32(start);
+        end = ECMAScript.ToInt32(end);
+
+        if (arguments.length < 1) { start = 0; }
+        if (arguments.length < 2) { end = this.length; }
+
+        if (start < 0) { start = this.length + start; }
+        if (end < 0) { end = this.length + end; }
+
+        start = clamp(start, 0, this.length);
+        end = clamp(end, 0, this.length);
+
+        var len = end - start;
+        if (len < 0) {
+          len = 0;
+        }
+
+        return new this.constructor(
+          this.buffer, this.byteOffset + start * this.BYTES_PER_ELEMENT, len);
+      };
+
+      return ctor;
+    }
+
+    var Int8Array = makeConstructor(1, packI8, unpackI8);
+    var Uint8Array = makeConstructor(1, packU8, unpackU8);
+    var Uint8ClampedArray = makeConstructor(1, packU8Clamped, unpackU8);
+    var Int16Array = makeConstructor(2, packI16, unpackI16);
+    var Uint16Array = makeConstructor(2, packU16, unpackU16);
+    var Int32Array = makeConstructor(4, packI32, unpackI32);
+    var Uint32Array = makeConstructor(4, packU32, unpackU32);
+    var Float32Array = makeConstructor(4, packF32, unpackF32);
+    var Float64Array = makeConstructor(8, packF64, unpackF64);
+
+    global.Int8Array = global.Int8Array || Int8Array;
+    global.Uint8Array = global.Uint8Array || Uint8Array;
+    global.Uint8ClampedArray = global.Uint8ClampedArray || Uint8ClampedArray;
+    global.Int16Array = global.Int16Array || Int16Array;
+    global.Uint16Array = global.Uint16Array || Uint16Array;
+    global.Int32Array = global.Int32Array || Int32Array;
+    global.Uint32Array = global.Uint32Array || Uint32Array;
+    global.Float32Array = global.Float32Array || Float32Array;
+    global.Float64Array = global.Float64Array || Float64Array;
+  }());
+
+  //
+  // 6 The DataView View Type
+  //
+
+  (function() {
+    function r(array, index) {
+      return ECMAScript.IsCallable(array.get) ? array.get(index) : array[index];
+    }
+
+    var IS_BIG_ENDIAN = (function() {
+      var u16array = new Uint16Array([0x1234]),
+          u8array = new Uint8Array(u16array.buffer);
+      return r(u8array, 0) === 0x12;
+    }());
+
+    // Constructor(ArrayBuffer buffer,
+    //             optional unsigned long byteOffset,
+    //             optional unsigned long byteLength)
+    /** @constructor */
+    var DataView = function DataView(buffer, byteOffset, byteLength) {
+      if (arguments.length === 0) {
+        buffer = new ArrayBuffer(0);
+      } else if (!(buffer instanceof ArrayBuffer || ECMAScript.Class(buffer) === 'ArrayBuffer')) {
+        throw new TypeError("TypeError");
+      }
+
+      this.buffer = buffer || new ArrayBuffer(0);
+
+      this.byteOffset = ECMAScript.ToUint32(byteOffset);
+      if (this.byteOffset > this.buffer.byteLength) {
+        throw new RangeError("byteOffset out of range");
+      }
+
+      if (arguments.length < 3) {
+        this.byteLength = this.buffer.byteLength - this.byteOffset;
+      } else {
+        this.byteLength = ECMAScript.ToUint32(byteLength);
+      }
+
+      if ((this.byteOffset + this.byteLength) > this.buffer.byteLength) {
+        throw new RangeError("byteOffset and length reference an area beyond the end of the buffer");
+      }
+
+      configureProperties(this);
+    };
+
+    function makeGetter(arrayType) {
+      return function(byteOffset, littleEndian) {
+
+        byteOffset = ECMAScript.ToUint32(byteOffset);
+
+        if (byteOffset + arrayType.BYTES_PER_ELEMENT > this.byteLength) {
+          throw new RangeError("Array index out of range");
+        }
+        byteOffset += this.byteOffset;
+
+        var uint8Array = new Uint8Array(this.buffer, byteOffset, arrayType.BYTES_PER_ELEMENT),
+            bytes = [], i;
+        for (i = 0; i < arrayType.BYTES_PER_ELEMENT; i += 1) {
+          bytes.push(r(uint8Array, i));
+        }
+
+        if (Boolean(littleEndian) === Boolean(IS_BIG_ENDIAN)) {
+          bytes.reverse();
+        }
+
+        return r(new arrayType(new Uint8Array(bytes).buffer), 0);
+      };
+    }
+
+    DataView.prototype.getUint8 = makeGetter(Uint8Array);
+    DataView.prototype.getInt8 = makeGetter(Int8Array);
+    DataView.prototype.getUint16 = makeGetter(Uint16Array);
+    DataView.prototype.getInt16 = makeGetter(Int16Array);
+    DataView.prototype.getUint32 = makeGetter(Uint32Array);
+    DataView.prototype.getInt32 = makeGetter(Int32Array);
+    DataView.prototype.getFloat32 = makeGetter(Float32Array);
+    DataView.prototype.getFloat64 = makeGetter(Float64Array);
+
+    function makeSetter(arrayType) {
+      return function(byteOffset, value, littleEndian) {
+
+        byteOffset = ECMAScript.ToUint32(byteOffset);
+        if (byteOffset + arrayType.BYTES_PER_ELEMENT > this.byteLength) {
+          throw new RangeError("Array index out of range");
+        }
+
+        // Get bytes
+        var typeArray = new arrayType([value]),
+            byteArray = new Uint8Array(typeArray.buffer),
+            bytes = [], i, byteView;
+
+        for (i = 0; i < arrayType.BYTES_PER_ELEMENT; i += 1) {
+          bytes.push(r(byteArray, i));
+        }
+
+        // Flip if necessary
+        if (Boolean(littleEndian) === Boolean(IS_BIG_ENDIAN)) {
+          bytes.reverse();
+        }
+
+        // Write them
+        byteView = new Uint8Array(this.buffer, byteOffset, arrayType.BYTES_PER_ELEMENT);
+        byteView.set(bytes);
+      };
+    }
+
+    DataView.prototype.setUint8 = makeSetter(Uint8Array);
+    DataView.prototype.setInt8 = makeSetter(Int8Array);
+    DataView.prototype.setUint16 = makeSetter(Uint16Array);
+    DataView.prototype.setInt16 = makeSetter(Int16Array);
+    DataView.prototype.setUint32 = makeSetter(Uint32Array);
+    DataView.prototype.setInt32 = makeSetter(Int32Array);
+    DataView.prototype.setFloat32 = makeSetter(Float32Array);
+    DataView.prototype.setFloat64 = makeSetter(Float64Array);
+
+    global.DataView = global.DataView || DataView;
+
+  }());
+
+}(this));

--- a/test/video-js-hls.html
+++ b/test/video-js-hls.html
@@ -12,6 +12,7 @@
 
   <!-- HLS plugin -->
   <script src="../src/video-js-hls.js"></script>
+  <script src="../src/binary-xhr.js"></script>
   <script src="../src/flv-tag.js"></script>
   <script src="../src/exp-golomb.js"></script>
   <script src="../src/h264-stream.js"></script>


### PR DESCRIPTION
Backfill in support for typed arrays and `btoa`. Use a very frightening technique to get binary data from an AJAX request. This runs extremely slowly right now and bipbop still doesn't play but segment data is being delivered to the parser and the output shuttled into the Flash tech.

This PR _isn't intended to be actually merged_, just as a record of the level of difficulty required to extend support to IE8.
