### PR TITLE
Close off all FLV tags at the end of a segment

### DIFF
--- a/src/h264-stream.js
+++ b/src/h264-stream.js
@@ -292,7 +292,7 @@
 
     //(pts:uint, dts:uint, dataAligned:Boolean):void
     this.setNextTimeStamp = function(pts, dts, dataAligned) {
-      if (0>pts_delta) {
+      if (pts_delta < 0) {
         // We assume the very first pts is less than 0x8FFFFFFF (max signed
         // int32)
         pts_delta = pts;
@@ -310,7 +310,7 @@
 
     this.finishFrame = function() {
       if (h264Frame) {
-        // Push SPS before EVERY IDR frame fo seeking
+        // Push SPS before EVERY IDR frame for seeking
         if (newExtraData.extraDataExists()) {
           oldExtraData = newExtraData;
           newExtraData = new H264ExtraData();

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -358,9 +358,6 @@
           offset += pesHeaderLength;
 
           if (pid === self.stream.programMapTable[STREAM_TYPES.h264]) {
-            // Stash this frame for future use.
-            // console.assert(videoFrames.length < 3);
-
             h264Stream.setNextTimeStamp(pts,
                                         dts,
                                         dataAlignmentIndicator);


### PR DESCRIPTION
The segment parser allows fragmentary input to the muxing process so it's not always clear when a tag should be finalized at the end of the input. By calling segmentParser.flushTags(), the parser is instructed to wrap up whatever input it currently has buffered into an FLV tag. Before this change, the last tag of the video stream would be buffered in the parser, waiting for additional input (i.e. another segment download) to flush it out. When you seeked within a segment, that last tag would have a timestamp greater than your seek point and we were assuming that timestamp values were sorted in ascending order. We would see the timestamp value greater than the desired seek location and start feeding tags into the media source, which resulted in the segment appearing to restart. Now, we close off any tags that are buffered at the end of a segment so the inter-segment seeking routine can assume that tags are delivered in the order of playback.
