### PR TITLE
Add some explanation text to the example page. Fixes #15.

### DIFF
--- a/example.html
+++ b/example.html
@@ -33,8 +33,24 @@
   <!-- bunnies -->
   <script src="test/tsSegment-bc.js"></script>
 
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+    }
+    .info {
+      background-color: #eee;
+      border: thin solid #333;
+      border-radius: 3px;
+      padding: 0 5px;
+    }
+  </style>
+
 </head>
 <body>
+  <div class="info">
+    <p>The video below is an <a href="https://developer.apple.com/library/ios/documentation/networkinginternet/conceptual/streamingmediaguide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40008332-CH1-SW1">HTTP Live Stream</a>. On desktop browsers other than Safari, the HLS plugin will polyfill support for the format on top of the video.js Flash tech.</p>
+    <p>Due to security restrictions in Flash, you will have to load this page over HTTP(S) to see the example in action.</p>
+  </div>
   <video id="video"
          class="video-js vjs-default-skin"
          height="300"


### PR DESCRIPTION
Describe the HLS plugin. Note the restrictions with Flash and using the example page over the file protocol.
