### PR TITLE
fix for safari end of stream spinner. BUG-0010

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -288,6 +288,9 @@ var
       fillBuffer(currentTime * 1000);
     });
 
+    player.on('ended', function() {
+      player.loadingSpinner.hide();
+    });
 
     /**
      * Chooses the appropriate media playlist based on the current


### PR DESCRIPTION
Safari does fire the ended event as expected, however a moment behind when it happens. I assume this part of the native HLS. This PR has added functionality to manually remove the loading spinner in those instances. Resolution for BUG-0010 in player beta.
