### PR TITLE
Don't throw an exception if there are no segments in a media playlist

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -204,13 +204,8 @@ var
   totalDuration = function(playlist) {
     var
       duration = 0,
-      i,
-      segment;
-
-    if (!playlist.segments) {
-      return 0;
-    }
-    i = playlist.segments.length;
+      segment,
+      i = (playlist.segments || []).length;
 
     // if present, use the duration specified in the playlist
     if (playlist.totalDuration) {
@@ -585,7 +580,7 @@ var
       var
         buffered = player.buffered(),
         bufferedTime = 0,
-        segment = player.hls.media.segments[player.hls.mediaIndex],
+        segment,
         segmentUri,
         startTime;
 
@@ -594,7 +589,13 @@ var
         return;
       }
 
+      // if no segments are available, do nothing
+      if (!player.hls.media.segments) {
+        return;
+      }
+
       // if the video has finished downloading, stop trying to buffer
+      segment = player.hls.media.segments[player.hls.mediaIndex];
       if (!segment) {
         return;
       }

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1109,4 +1109,28 @@ test('only reloads the active media playlist', function() {
               'refreshed the active playlist');
 });
 
+test('does not break if the playlist has no segments', function() {
+  window.XMLHttpRequest = function () {
+    this.open = function () {};
+    this.send = function () {
+      this.readyState = 4;
+      this.status = 200;
+      this.responseText = '#EXTM3U\n' +
+        '#EXT-X-PLAYLIST-TYPE:VOD\n' +
+        '#EXT-X-TARGETDURATION:10\n';
+      this.onreadystatechange();
+    };
+  };
+  player.hls('manifest/master.m3u8');
+  try {
+    videojs.mediaSources[player.currentSrc()].trigger({
+      type: 'sourceopen'
+    });
+  } catch(e) {
+    ok(false, 'an error was thrown');
+    throw e;
+  }
+  ok(true, 'no error was thrown');
+});
+
 })(window, window.videojs);


### PR DESCRIPTION
A poorly operating live stream might publish media playlist before any segments are available. If that happens, keep checking back for updates instead of throwing an exception and dying.

@seniorflexdeveloper: this overlaps with one of the fixes in #38. If you are going to capture all this in your PR, I'm happy to close this one.
