### PR TITLE
Only run saucelabs if PR initiated in main repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ node_js:
 - '0.10'
 before_script:
 - npm install -g grunt-cli
-- curl https://gist.githubusercontent.com/santiycr/5139565/raw/sauce_connect_setup.sh
-  | bash
+- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then curl https://gist.githubusercontent.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash; fi
 notifications:
   hipchat:
     rooms:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -270,7 +270,9 @@ module.exports = function(grunt) {
 
     grunt.task.run(['jshint', 'manifests-to-js']);
 
-    if (process.env.TRAVIS) {
+    if (process.env.TRAVIS_PULL_REQUEST) {
+      grunt.task.run(['karma:phantomjs']);
+    } else if (process.env.TRAVIS) {
       grunt.task.run(['karma:saucelabs']);
     } else {
       if (tasks.length === 0) {


### PR DESCRIPTION
Travis CI [doesn't export secure credentials in PRs and branches that don't originate in the main repository](http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests), thus we need to run the tests in phantomjs for those PRs.
