### PR TITLE
Allow customization of goalBufferLength (#63)

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -11,6 +11,7 @@
 var
 
   // the desired length of video to maintain in the buffer, in seconds
+  // can be customized with hls option goalbufferLength
   goalBufferLength = 5,
 
   // a fudge factor to apply to advertised playlist bitrates to account for
@@ -185,7 +186,7 @@ var
       segmentParser = new videojs.Hls.SegmentParser(),
 
       segmentXhr,
-      settings = videojs.util.mergeOptions({}, player.options().hls),
+      settings = videojs.util.mergeOptions({goalBufferLength: goalBufferLength}, player.options().hls),
       fillBuffer,
       updateDuration;
 
@@ -325,7 +326,7 @@ var
       }
 
       // if there is plenty of content in the buffer, relax for awhile
-      if (bufferedTime >= goalBufferLength) {
+      if (bufferedTime >= settings.goalBufferLength) {
         return;
       }
 

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -688,6 +688,41 @@ test('downloads the next segment if the buffer is getting low', function() {
               'made segment request');
 });
 
+test('downloads the next segment if the buffer is getting low - customized goalBufferLength', function() {
+  player.dispose();
+  player = createPlayer({
+    goalBufferLength: 10
+  });
+  player.src({
+    src: 'manifest/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  player.hls.mediaSource.trigger({
+    type: 'sourceopen'
+  });
+
+  standardXHRResponse(requests[0]);
+  standardXHRResponse(requests[1]);
+
+  strictEqual(requests.length, 2, 'did not make a request');
+  player.currentTime = function() {
+    return 10;
+  };
+  player.buffered = function() {
+    return videojs.createTimeRange(0, 19.999);
+  };
+  player.trigger('timeupdate');
+
+  standardXHRResponse(requests[2]);
+
+  strictEqual(requests.length, 3, 'made a request');
+  strictEqual(requests[2].url,
+              window.location.origin +
+              window.location.pathname.split('/').slice(0, -1).join('/') +
+              '/manifest/00002.ts',
+              'made segment request');
+});
+
 test('stops downloading segments at the end of the playlist', function() {
   player.src({
     src: 'manifest/media.m3u8',


### PR DESCRIPTION
goalBufferLength controls how early the request for the next segment is made.
The current value of 5 is chosen arbitrarily and might need to be changed by
users, e.g. in case where larger segments are used (which take longer to
download).
It might be a further enhancement to allow an "auto" mode which takes
EXT-X-TARGETDURATION and download speed into consideration.
