### PR TITLE
Trigger duration updates indirectly so that live is correctly detected b...

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -227,8 +227,13 @@ var
      * Update the player duration
      */
     updateDuration = function(playlist) {
-      // update the duration
-      player.duration(totalDuration(playlist));
+      var oldDuration = player.duration(),
+          newDuration = totalDuration(playlist);
+
+      // if the duration has changed, invalidate the cached value
+      if (oldDuration !== newDuration) {
+        player.trigger('durationchange');
+      }
     };
 
     /**

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -915,6 +915,7 @@ test('duration is Infinity for live playlists', function() {
   standardXHRResponse(requests[0]);
 
   strictEqual(player.duration(), Infinity, 'duration is infinity');
+  ok((' ' + player.el().className + ' ').indexOf(' vjs-live ') >= 0, 'added vjs-live class');
 });
 
 test('updates the media index when a playlist reloads', function() {


### PR DESCRIPTION
...y the player

Since HLS has overridden the Flash tech's duration method, durationchange is no longer automatically fired. Whenever duration needs to be updated, trigger durationchange on the player instead of setting it directly. The player code calls back to the tech to pick up the new duration and applies styling for live playback if necessary.

@seniorflexdeveloper: review?
