### PR TITLE
Only support HLS MIME types. Fixes #82.

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -529,7 +529,7 @@ videojs.Hls.isSupported = function() {
 };
 
 videojs.Hls.canPlaySource = function(srcObj) {
-  return mpegurlRE.test(srcObj.type) || videojs.Flash.canPlaySource.call(this, srcObj);
+  return mpegurlRE.test(srcObj.type);
 };
 
 /**

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1066,4 +1066,20 @@ test('disposes the playlist loader', function() {
   strictEqual(disposes, 1, 'disposed playlist loader');
 });
 
+test('only supports HLS MIME types', function() {
+  ok(videojs.Hls.canPlaySource({
+    type: 'aPplicatiOn/x-MPegUrl'
+  }), 'supports x-mpegurl');
+  ok(videojs.Hls.canPlaySource({
+    type: 'aPplicatiOn/VnD.aPPle.MpEgUrL'
+  }), 'supports vnd.apple.mpegurl');
+
+  ok(!videojs.Hls.canPlaySource({
+    type: 'video/mp4'
+  }), 'does not support mp4');
+  ok(!videojs.Hls.canPlaySource({
+    type: 'video/x-flv'
+  }), 'does not support flv');
+});
+
 })(window, window.videojs);


### PR DESCRIPTION
Do not advertise support for MIME types that the underlying Flash tech happens to support.

@heff: review?
