### PR TITLE
Expose more diagnostic info

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ The number of bits downloaded per second in the last segment download.
 This value is used by the default implementation of `selectPlaylist` 
 to select an appropriate bitrate to play.
 
+#### player.hls.bytesReceived
+Type: `number`
+
+The total number of content bytes downloaded by the HLS tech.
+
 #### player.hls.selectPlaylist
 Type: `function`
 
@@ -135,6 +140,13 @@ Fired after the first media playlist is downloaded for a stream.
 Fired immediately after a new master or media playlist has been
 downloaded. By default, the tech only downloads playlists as they
 are needed.
+
+#### mediachange
+
+Fired when a new playlist becomes the active media playlist. Note that
+the actual rendering quality change does not occur simultaneously with
+this event; a new segment must be requested and the existing buffer
+depleted first.
 
 ### Testing
 

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -131,6 +131,7 @@
        * object to switch to
        */
       loader.media = function(playlist) {
+        var mediaChange = false;
         // getter
         if (!playlist) {
           return media;
@@ -150,19 +151,27 @@
           playlist = loader.master.playlists[playlist];
         }
 
+        mediaChange = playlist.uri !== media.uri;
+
         // switch to fully loaded playlists immediately
         if (loader.master.playlists[playlist.uri].endList) {
+          // abort outstanding playlist requests
           if (request) {
             request.abort();
             request = null;
           }
           loader.state = 'HAVE_METADATA';
           media = playlist;
+
+          // trigger media change if the active media has been updated
+          if (mediaChange) {
+            loader.trigger('mediachange');
+          }
           return;
         }
 
         // switching to the active playlist is a no-op
-        if (playlist.uri === media.uri) {
+        if (!mediaChange) {
           return;
         }
 
@@ -185,6 +194,7 @@
           withCredentials: withCredentials
         }, function(error) {
           haveMetadata(error, this, playlist.uri);
+          loader.trigger('mediachange');
         });
       };
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -433,6 +433,7 @@ var
         // calculate the download bandwidth
         player.hls.segmentXhrTime = (+new Date()) - startTime;
         player.hls.bandwidth = (this.response.byteLength / player.hls.segmentXhrTime) * 8 * 1000;
+        player.hls.bytesReceived += this.response.byteLength;
 
         // transmux the segment data from MP2T to FLV
         segmentParser.parseSegmentBinaryData(new Uint8Array(this.response));
@@ -575,6 +576,9 @@ var
                                                     updatedPlaylist);
         oldMediaPlaylist = updatedPlaylist;
       });
+      player.hls.playlists.on('mediachange', function() {
+        player.trigger('mediachange');
+      });
     });
   };
 
@@ -591,6 +595,8 @@ videojs.Hls = videojs.Flash.extend({
     options.swf = settings.flash.swf;
     videojs.Flash.call(this, player, options, ready);
     options.source = source;
+    this.bytesReceived = 0;
+
     videojs.Hls.prototype.src.call(this, options.source && options.source.src);
   }
 });


### PR DESCRIPTION
Keep track of total content bytes received and make it accessible from outside the tech. Trigger an event whenever a new playlist is activated. For #93.
