### PR TITLE
Don't blow up if the tech is disposed before player.ready(). For #88.

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -211,6 +211,10 @@ var
       if (lastSeekedTime) {
         return lastSeekedTime;
       }
+      // currentTime is zero while the tech is initializing
+      if (!this.el() || !this.el().vjs_getProperty) {
+        return 0;
+      }
       return this.el().vjs_getProperty('currentTime');
     };
 
@@ -640,6 +644,11 @@ videojs.Hls.prototype.src = function(src) {
     this.mediaSource = mediaSource;
     initSource(player, mediaSource, src);
     this.player().ready(function() {
+      // do nothing if the tech has been disposed already
+      // this can occur if someone sets the src in player.ready(), for instance
+      if (!self.el()) {
+        return;
+      }
       self.el().vjs_src(source.src);
     });
   }

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1278,4 +1278,28 @@ test('re-emits mediachange events', function() {
   strictEqual(mediaChanges, 1, 'fired mediachange');
 });
 
+test('can be disposed before finishing initialization', function() {
+  var player = createPlayer(), readyHandlers = [];
+  player.ready = function(callback) {
+    readyHandlers.push(callback);
+  };
+  player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  player.src({
+    src: 'http://example.com/media.mp4',
+    type: 'video/mp4'
+  });
+  ok(readyHandlers.length > 0, 'registered a ready handler');
+  try {
+    while (readyHandlers.length) {
+      readyHandlers.shift()();
+    }
+    ok(true, 'did not throw an exception');
+  } catch (e) {
+    ok(false, 'threw an exception');
+  }
+});
+
 })(window, window.videojs);


### PR DESCRIPTION
The HLS tech waits until `ready` before setting the source to be sure that Flash has time to finish loading. If a user changed the src and triggered a tech unload before that time, the ready handler would be invoked, throw an exception, and leave the tech in a transitionary state. Instead, double check that the object element is still alive before setting the src in the `ready` handler.
