### PR TITLE
shutdown the sourceBuffer in dispose()

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -208,6 +208,9 @@ videojs.Hls.prototype.dispose = function() {
   if (this.playlists) {
     this.playlists.dispose();
   }
+  if (this.sourceBuffer) {
+    this.sourceBuffer.abort();
+  }
   videojs.Flash.prototype.dispose.call(this);
 };
 


### PR DESCRIPTION
This prevents the source buffer from trying to call into Flash after the plugin is shutdown.
