### PR TITLE
prevent the segment xhr error handler from being called during seek

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -164,9 +164,7 @@ videojs.Hls.prototype.setCurrentTime = function(currentTime) {
   this.sourceBuffer.abort();
 
   // cancel outstanding requests and buffer appends
-  if (this.segmentXhr_) {
-    this.segmentXhr_.abort();
-  }
+  this.cancelSegmentXhr();
 
   // clear out any buffered segments
   this.segmentBuffer_ = [];
@@ -197,14 +195,20 @@ videojs.Hls.prototype.updateDuration = function(playlist) {
   }
 };
 
+videojs.Hls.prototype.cancelSegmentXhr = function() {
+  if (this.segmentXhr_) {
+    // Prevent error handler from running.
+    this.segmentXhr_.onreadystatechange = null;
+    this.segmentXhr_.abort();
+    this.segmentXhr_ = null;
+  }
+};
+
 /**
  * Abort all outstanding work and cleanup.
  */
 videojs.Hls.prototype.dispose = function() {
-  if (this.segmentXhr_) {
-    this.segmentXhr_.onreadystatechange = null;
-    this.segmentXhr_.abort();
-  }
+  this.cancelSegmentXhr();
   if (this.playlists) {
     this.playlists.dispose();
   }


### PR DESCRIPTION
When an XHR is aborted, the error handler is called. The error handler for the
segment loader increments the mediaIndex of the player. This is undesired
because setCurrentTime has already set the mediaIndex to the proper target
segment.
