### PR TITLE
Switching selectPlaylist's fallback chain to bandwidth over resolution

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -282,7 +282,7 @@ videojs.Hls.prototype.selectPlaylist = function () {
   }
 
   // fallback chain of variants
-  return resolutionBestVariant || bandwidthBestVariant || sortedPlaylists[0];
+  return  bandwidthBestVariant || resolutionBestVariant || sortedPlaylists[0];
 };
 
 /**

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -583,8 +583,11 @@ test('selects the correct rendition by player dimensions', function() {
 
   playlist = player.hls.selectPlaylist();
 
-  deepEqual(playlist.attributes.RESOLUTION, {width:396,height:224},'should return the correct resolution by player dimensions');
-  equal(playlist.attributes.BANDWIDTH, 440000, 'should have the expected bandwidth in case of multiple');
+  // The bias is now BANDWIDTH over RESOLUTION
+  // deepEqual(playlist.attributes.RESOLUTION, {width:396,height:224},'should return the correct resolution by player dimensions');
+  // equal(playlist.attributes.BANDWIDTH, 440000, 'should have the expected bandwidth in case of multiple');
+  deepEqual(playlist.attributes.RESOLUTION, {width:960,height:540},'should return the correct resolution by player dimensions');
+  equal(playlist.attributes.BANDWIDTH, 1928000, 'should have the expected bandwidth in case of multiple');
 
   player.width(1920);
   player.height(1080);


### PR DESCRIPTION
This PR is a proposal for changing the priority from selectPlaylist's fallback chain from to resolution over bandwidth to bandwidth over resolution.

This might be best explained by using a real life example. BigBucksBunny has two channels:
```
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=560000,RESOLUTION=560x320
chunklist_w1591926520_b560000.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=280000,RESOLUTION=280x160
chunklist_w1591926520_b280000.m3u8
```

One serves high bandwidth at 560x320, the other one serves low bandwidth at 280x160. The current implementation of selectPlaylist decides that smaller resolutions, i.e. 600x300 is closer to 280x160 than to 560x320 and therefore picks the low bandwidth channel even though the network conditions allow for high bandwidth presentation.

As a result we'll get this result for 600x300 using the 280000 bandwidth channel:

![original small](https://cloud.githubusercontent.com/assets/1578115/3882152/8a5ee6e4-2194-11e4-9c5d-39f446a06dda.png)

instead of this one, which is of higher quality using the 560000 bandwidth channel:

![flashls small](https://cloud.githubusercontent.com/assets/1578115/3882166/acbb9908-2194-11e4-96b1-7c7b5df81ce8.png)

I am arguing that bandwidth should always take precedence over resolution when selecting playlists.



