### PR TITLE
Update video.js to fix seeking and autoplay

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-safari-launcher": "~0.1.1",
     "karma-sauce-launcher": "~0.1.8",
     "sinon": "1.10.2",
-    "video.js": "git+https://github.com/dmlap/video-js.git#0.6.1-alpha"
+    "video.js": "^4.7.2"
   },
   "dependencies": {
     "videojs-contrib-media-sources": "^0.3.0"

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -121,6 +121,13 @@ videojs.Hls.prototype.handleSourceOpen = function() {
   this.playlists.on('mediachange', function() {
     player.trigger('mediachange');
   });
+
+  // if autoplay is enabled, begin playback. This is duplicative of
+  // code in video.js but is required because play() must be invoked
+  // *after* the media source has opened.
+  if (player.options().autoplay) {
+    player.play();
+  }
 };
 
 /**

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -160,14 +160,15 @@ module('HLS', {
 
 test('starts playing if autoplay is specified', function() {
   var plays = 0;
-  player.play = function() {
-    plays++;
-  };
   player.options().autoplay = true;
   player.src({
     src: 'manifest/playlist.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
+  // make sure play() is called *after* the media source opens
+  player.play = function() {
+    plays++;
+  };
   openMediaSource(player);
 
   standardXHRResponse(requests[0]);


### PR DESCRIPTION
Bump the required version of video.js up to 4.7.2 because the earlier version built the SWF for a version of Flash that had issues with appendBytes. Handle autoplay inside the tech itself because video.js support calls play before the Media Source has opened and the call ended up ignored. Fixes #112. Fixes #128.
