### PR TITLE
Flush the parser at the end of each m3u8 download

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -74,6 +74,7 @@
 
           parser = new videojs.m3u8.Parser();
           parser.push(xhr.responseText);
+          parser.end();
           parser.manifest.uri = url;
 
           // merge this playlist into the master
@@ -232,6 +233,7 @@
 
         parser = new videojs.m3u8.Parser();
         parser.push(this.responseText);
+        parser.end();
 
         loader.state = 'HAVE_MASTER';
 

--- a/test/playlist-loader_test.js
+++ b/test/playlist-loader_test.js
@@ -551,4 +551,15 @@
     loader.media('low.m3u8');
     strictEqual(mediaChanges, 2, 'ignored a no-op media change');
   });
+
+  test('does not misintrepret playlists missing newlines at the end', function() {
+    var loader = new videojs.Hls.PlaylistLoader('media.m3u8');
+    requests.shift().respond(200, null,
+                             '#EXTM3U\n' +
+                             '#EXT-X-MEDIA-SEQUENCE:0\n' +
+                             '#EXTINF:10,\n' +
+                             'low-0.ts\n' +
+                             '#EXT-X-ENDLIST'); // no newline
+     ok(loader.media().endList, 'flushed the final line of input');
+  });
 })(window);


### PR DESCRIPTION
If an m3u8 was missing a trailing newline, the last line of input would remain buffered in the parser. This could cause VOD playlists to be misinterpreted as live or a final segment to be switched. Fixes #113.
