### PR TITLE
Fixed not increment mediaIndex when segmentXhr_ is aborted in setCurrentTime

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -190,7 +190,7 @@ videojs.Hls.prototype.setCurrentTime = function(currentTime) {
   if (this.segmentXhr_) {
     var mediaIndexBeforeAbort = this.mediaIndex;
     this.segmentXhr_.abort();
-    if (mediaIndexBeforeAbort != this.mediaIndex) {
+    if (mediaIndexBeforeAbort !== this.mediaIndex) {
       this.mediaIndex = mediaIndexBeforeAbort;
     }
   }


### PR DESCRIPTION
When I call setCurrentTime(seconds), the player wouldn't seek the specified value since mediaIndex is wrong (then, next segment file would be sought). It seems mediaindex is incremented when segmentXhr_ is aborted.

``` javascript
videojs.Hls.prototype.loadSegment = function(segmentUri, offset) {
    ...
    if (error) {
      // if a segment request times out, we may have better luck with another playlist
      if (error === 'timeout') {
        tech.bandwidth = 1;
        return tech.playlists.media(tech.selectPlaylist());
      }
      // otherwise, try jumping ahead to the next segment
      tech.error = {
        status: this.status,
        message: 'HLS segment request error at URL: ' + url,
        code: (this.status >= 500) ? 4 : 2
      };

      // try moving on to the next segment
      tech.mediaIndex++;
      return;
    }
```
