### PR TITLE
don't skip filling buffer if we are seeking

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -335,8 +335,8 @@ videojs.Hls.prototype.fillBuffer = function(offset) {
     segment,
     segmentUri;
 
-  // if there is a request already in flight, do nothing
-  if (this.segmentXhr_) {
+  // if there is a request already in flight, do nothing, unless we are seeking
+  if (this.segmentXhr_ && offset !== 'number') {
     return;
   }
 


### PR DESCRIPTION
when we are seeking, segmentXhr might not be null, but we still want to
fill the buffer - otherwise the playback does not resume.
