### PR TITLE
Fix timeouts

### DIFF
--- a/test/videojs-hls.html
+++ b/test/videojs-hls.html
@@ -58,6 +58,7 @@
   <script src="m3u8_test.js"></script>
   <script src="playlist-loader_test.js"></script>
   <script src="decrypter_test.js"></script>
+  <script src="xhr_test.js"></script>
 </head>
 <body>
   <div id="qunit"></div>

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1108,20 +1108,6 @@ test('resets the switching algorithm if a request times out', function() {
               'reset to the lowest bitrate playlist');
 });
 
-test('handles xhr timeouts correctly', function () {
-  var error;
-  var clock = sinon.useFakeTimers();
-  videojs.Hls.xhr({
-    url: 'http://example.com',
-    timeout: 1
-  }, function(innerError) {
-    error = innerError;
-  });
-  clock.tick(1);
-  strictEqual(error, 'timeout', 'called with timeout error');
-  clock.restore();
-});
-
 test('disposes the playlist loader', function() {
   var disposes = 0, player, loaderDispose;
   player = createPlayer();

--- a/test/xhr_test.js
+++ b/test/xhr_test.js
@@ -1,0 +1,34 @@
+(function(window, videojs, undefined) {
+  'use strict';
+
+  /*
+    XHR test suite
+  */
+
+  var xhr;
+
+  module('XHR', {
+    setup: function() {
+      xhr = sinon.useFakeXMLHttpRequest();
+    },
+
+    teardown: function() {
+      xhr.restore();
+    }
+  });
+
+  test('handles xhr timeouts correctly', function () {
+    var error;
+    var clock = sinon.useFakeTimers();
+    videojs.Hls.xhr({
+      url: 'http://example.com',
+      timeout: 1
+    }, function(innerError) {
+      error = innerError;
+    });
+    clock.tick(1);
+    strictEqual(error, 'timeout', 'called with timeout error');
+    clock.restore();
+  });
+
+})(window, window.videojs);


### PR DESCRIPTION
This is a fix for issue #142 

Basically using the polyfill function ensures that request.timedout is set to true before onreadystatechange is called (this is not guaranteed with ontimeout).
