### PR TITLE
Manifest with MBR streams and different #EXT-X-MEDIA-SEQUENCE indices 

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -736,8 +736,8 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
 
   // try to sync based on URI
   i = update.segments.length;
-  if ( mediaIndex < 1 || mediaIndex > origSegmentLength ) {
-    mediaIndex = origSegmentLength;
+  if ( mediaIndex < 1 || mediaIndex > original.segments.length ) {
+    mediaIndex = original.segments.length;
   }
   originalSegment = original.segments[mediaIndex - 1];
   while (i--) {


### PR DESCRIPTION
When streaming with a server such as WowzaStremaingEngine the MBR feeds could get out of sync and the #EXT-X-MEDIA-SEQUENCE can have different values. This will generate an error in the player. This update will fix this issue and will still allow MBR switching.
