### PR TITLE
fix invalid index error for hls live streaming

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -802,8 +802,10 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
 
   // sync on media sequence
   var ret = (original.mediaSequence + mediaIndex) - update.mediaSequence;
-  if(ret < 0) 
+  if(ret < 0) {
       ret = 0;
+  }
+  
   return ret; 
 };
 


### PR DESCRIPTION
In some situation(such as slow downloading of a http live stream),  (original.mediaSequence + mediaIndex) - update.mediaSequence may be < 0,
It will cause exceptions in place such as: videojs.Hls.prototype.fetchKeys = function(playlist, index)
