### PR TITLE
remove event handlers from player before switching src

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -61,7 +61,7 @@ videojs.Hls.prototype.src = function(src) {
 
   // if there is already a source loaded, clean it up
   if (this.src_) {
-    this.resetSrc_();
+    this.reset_();
   }
 
   this.src_ = src;
@@ -305,10 +305,7 @@ videojs.Hls.prototype.cancelSegmentXhr = function() {
   }
 };
 
-/**
- * Abort all outstanding work and cleanup.
- */
-videojs.Hls.prototype.dispose = function() {
+videojs.Hls.prototype.reset_ = function () {
   var player = this.player();
 
   // remove event handlers
@@ -321,7 +318,13 @@ videojs.Hls.prototype.dispose = function() {
   }
 
   this.resetSrc_();
+};
 
+/**
+ * Abort all outstanding work and cleanup.
+ */
+videojs.Hls.prototype.dispose = function() {
+  this.reset_();
   videojs.Flash.prototype.dispose.call(this);
 };
 


### PR DESCRIPTION
When you switch sources you get into trouble with still bound event-handlers. After switching src, on every "timeupdate" the fillBuffer-function gets called, pointing to a gone playlist.

[See this example](http://jsbin.com/jixizi) to highlight the issue. (Skip close to the end of the first video to make it switch to the next)