### PR TITLE
fix Live stream will stop playing

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -828,6 +828,7 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
     return videojs.Hls.setMediaIndexForLive(update) + 1;
   }
 
+  // sync
   return translatedMediaIndex;
 };
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -828,7 +828,6 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
     return videojs.Hls.setMediaIndexForLive(update) + 1;
   }
 
-  // sync on media sequence
   return translatedMediaIndex;
 };
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -644,7 +644,7 @@ videojs.Hls.prototype.drainBuffer = function(event) {
 
   // transition the sourcebuffer to the ended state if we've hit the end of
   // the playlist
-  if (mediaIndex + 1 === playlist.segments.length) {
+  if (this.duration() != Infinity && mediaIndex + 1 === playlist.segments.length) {
     this.mediaSource.endOfStream();
   }
 };

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -828,7 +828,7 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
     return videojs.Hls.setMediaIndexForLive(update) + 1;
   }
 
-  // sync
+  // sync on media sequence
   return translatedMediaIndex;
 };
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -644,7 +644,7 @@ videojs.Hls.prototype.drainBuffer = function(event) {
 
   // transition the sourcebuffer to the ended state if we've hit the end of
   // the playlist
-  if (this.duration() != Infinity && mediaIndex + 1 === playlist.segments.length) {
+  if (this.duration() !== Infinity && mediaIndex + 1 === playlist.segments.length) {
     this.mediaSource.endOfStream();
   }
 };

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1944,4 +1944,22 @@ test('treats invalid keys as a key request failure', function() {
   equal(1, bytes[1], 'skipped to the second segment');
 });
 
+test('live stream should not call endOfStream', function(){
+  player.src({
+    src: 'https://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  openMediaSource(player);
+  requests[0].respond(200, null,
+                      '#EXTM3U\n' +
+                      '#EXT-X-MEDIA-SEQUENCE:0\n' +
+                      '#EXTINF:1\n' +
+                      '0.ts\n'
+                     );
+  requests[1].response = window.bcSegment;
+  requests[1].respondd(200, null, "");
+  equal("open", player.hls.mediaSource.readyState,
+        "media source should be in open state, not ended state for live stream after the last segment in m3u8 downloaded");
+});
+
 })(window, window.videojs);

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1957,7 +1957,7 @@ test('live stream should not call endOfStream', function(){
                       '0.ts\n'
                      );
   requests[1].response = window.bcSegment;
-  requests[1].respondd(200, null, "");
+  requests[1].respond(200, null, "");
   equal("open", player.hls.mediaSource.readyState,
         "media source should be in open state, not ended state for live stream after the last segment in m3u8 downloaded");
 });


### PR DESCRIPTION
If mediaSource.endOfStream() is called in http hls LIVE mode,
in https://github.com/videojs/video-js-swf/blob/8c03e650b9be9bccd9ecef9e7520def56cde1e5f/src/com/videojs/providers/HTTPVideoProvider.as

```
case "NetStream.Buffer.Empty":
                    // should not fire if ended/paused. issue #38
                    if(!_isPlaying){ return; }

                    // reaching the end of the buffer after endOfStream has been called means we've
                    // hit the end of the video
                    if (_ending) {
                        _ending = false;
                        _isPlaying = false;
                        _isPaused = true;
                        _hasEnded = true;
                        _model.broadcastEvent(new VideoPlaybackEvent(VideoPlaybackEvent.ON_STREAM_CLOSE, {info:e.info}));
                        _model.broadcastEventExternally(ExternalEventName.ON_PAUSE);
                        _model.broadcastEventExternally(ExternalEventName.ON_PLAYBACK_COMPLETE);

                        _startOffset = 0;
                        _pausedSeekValue = 0;
                        break;
                    }
```

It will issue ON_PAUSE and ON_PLAYBACK_COMPLETE event to this plugin, and eventually cause
player in bad state.

So for hls LIVE mode, endOfStream should not be called