### PR TITLE
Allow a user-provided initial bandwidth estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,15 @@ This value is updated after each segment download completes.
 Type: `number`
 
 The number of bits downloaded per second in the last segment download.
-This value is used by the default implementation of `selectPlaylist` 
+This value is used by the default implementation of `selectPlaylist`
 to select an appropriate bitrate to play.
+
+Before the first video segment has been downloaded, it's hard to
+estimate bandwidth accurately. The HLS tech uses a heuristic based on
+the playlist download times to do this estimation by default. If you
+have a more accurate source of bandwidth information, you can override
+this value as soon as the HLS tech has loaded to provide an initial
+bandwidth estimate.
 
 #### player.hls.bytesReceived
 Type: `number`

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -138,14 +138,21 @@ videojs.Hls.prototype.handleSourceOpen = function() {
     };
 
     oldMediaPlaylist = this.playlists.media();
-    // the bandwidth estimate for the first segment is based on round trip
-    // time for the master playlist. the master playlist is almost always
-    // tiny so the round trip time is dominated by latency and so the
-    // computed bandwidth is much lower than steady-state. to account for
-    // this, we scale the bandwidth estimate from the master playlist.
-    this.setBandwidth({
-      bandwidth: this.playlists.bandwidth * 5
-    });
+
+    // the bandwidth estimate for the first segment is based on round
+    // trip time for the master playlist. the master playlist is
+    // almost always tiny so the round-trip time is dominated by
+    // latency and the computed bandwidth is much lower than
+    // steady-state. if the the downstream developer has a better way
+    // of detecting bandwidth and provided a number, use that instead.
+    if (this.bandwidth === undefined) {
+      // we're going to have to estimate initial bandwidth
+      // ourselves. scale the bandwidth estimate to account for the
+      // relatively high round-trip time from the master playlist.
+      this.setBandwidth({
+        bandwidth: this.playlists.bandwidth * 5
+      });
+    }
 
     selectedPlaylist = this.selectPlaylist();
     oldBitrate = oldMediaPlaylist.attributes &&


### PR DESCRIPTION
If the downstream developer has a better way of estimating bandwidth for the initial playlist, use that value.