### PR TITLE
Remove incorrect file headers.

### DIFF
--- a/src/aac-stream.js
+++ b/src/aac-stream.js
@@ -1,11 +1,3 @@
-/*
- * aac-stream
- *
- *
- * Copyright (c) 2013 Brightcove
- * All rights reserved.
- */
-
 (function(window) {
 var
   FlvTag = window.videojs.Hls.FlvTag,

--- a/src/decrypter.js
+++ b/src/decrypter.js
@@ -1,8 +1,4 @@
 /*
- * videojs-hls
- *
- * Copyright (c) 2014 Brightcove
- * All rights reserved.
  *
  * This file contains an adaptation of the AES decryption algorithm
  * from the Standford Javascript Cryptography Library. That work is

--- a/src/h264-stream.js
+++ b/src/h264-stream.js
@@ -1,11 +1,3 @@
-/*
- * h264-stream
- *
- *
- * Copyright (c) 2013 Brightcove
- * All rights reserved.
- */
-
 (function(window) {
   var
     ExpGolomb = window.videojs.Hls.ExpGolomb,

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1,10 +1,8 @@
 /*
  * videojs-hls
- *
- * Copyright (c) 2014 Brightcove
- * All rights reserved.
+ * The main file for the HLS project.
+ * License: https://github.com/videojs/videojs-contrib-hls/blob/master/LICENSE
  */
-
 (function(window, videojs, document, undefined) {
 'use strict';
 


### PR DESCRIPTION
The old headers were claiming full copyright and no license.
The videojs-hls.js header was modified to include a link to the main
license from the repo.
Fix #200 