### PR TITLE
Fixing discontinuity seek

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-hls",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "engines": {
     "node": ">= 0.10.12"
   },

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -611,12 +611,17 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   // until it empties before calling it when a discontinuity is
   // next in the buffer
   if (segment.discontinuity) {
-    if (event.type !== 'waiting') {
+    if (event.type === 'waiting') {
+      this.sourceBuffer.abort();
+      // tell the SWF where playback is continuing in the stitched timeline
+      this.el().vjs_setProperty('currentTime', segmentOffset * 0.001);
+    } else if (event.type === 'timeupdate') {
+      return;
+    } else if (typeof offset !== 'number') {
+      //if the discontinuity is reached under normal conditions, ie not a seek,
+      //the buffer already contains data and does not need to be refilled,
       return;
     }
-    this.sourceBuffer.abort();
-    // tell the SWF where playback is continuing in the stitched timeline
-    this.el().vjs_setProperty('currentTime', segmentOffset * 0.001);
   }
 
   // transmux the segment data from MP2T to FLV

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1186,7 +1186,7 @@ test('waits until the buffer is empty before appending bytes at a discontinuity'
   var aborts = 0, setTime, currentTime, bufferEnd;
 
   player.src({
-    src: 'disc.m3u8',
+    src: 'discontinuity.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
@@ -1233,7 +1233,7 @@ test('clears the segment buffer on seek', function() {
   videojs.Hls.SegmentParser = mockSegmentParser(tags);
 
   player.src({
-    src: 'disc.m3u8',
+    src: 'discontinuity.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
@@ -1261,14 +1261,14 @@ test('clears the segment buffer on seek', function() {
   standardXHRResponse(requests.pop());
 
   // play to 6s to trigger the next segment request
-  currentTime = 6;
+  currentTime = 1;
   bufferEnd = 10;
   player.trigger('timeupdate');
 
   standardXHRResponse(requests.pop());
 
-  // seek back to the beginning
-  player.currentTime(0);
+  // seek to the discontinuity
+  player.currentTime(10);
   tags.push({ pts: 0, bytes: 0 });
   standardXHRResponse(requests.pop());
   strictEqual(aborts, 1, 'aborted once for the seek');

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1261,6 +1261,56 @@ test('clears the segment buffer on seek', function() {
   standardXHRResponse(requests.pop());
 
   // play to 6s to trigger the next segment request
+  currentTime = 6;
+  bufferEnd = 10;
+  player.trigger('timeupdate');
+
+  standardXHRResponse(requests.pop());
+
+  // seek back to the beginning
+  player.currentTime(0);
+  tags.push({ pts: 0, bytes: 0 });
+  standardXHRResponse(requests.pop());
+  strictEqual(aborts, 1, 'aborted once for the seek');
+
+  // the source buffer empties. is 2.ts still in the segment buffer?
+  player.trigger('waiting');
+  strictEqual(aborts, 1, 'cleared the segment buffer on a seek');
+});
+
+test('continues playing after seek to discontinuity', function() {
+  var aborts = 0, tags = [], currentTime, bufferEnd, oldCurrentTime;
+
+  videojs.Hls.SegmentParser = mockSegmentParser(tags);
+
+  player.src({
+    src: 'discontinuity.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  openMediaSource(player);
+  oldCurrentTime = player.currentTime;
+  player.currentTime = function(time) {
+    if (time !== undefined) {
+      return oldCurrentTime.call(player, time);
+    }
+    return currentTime;
+  };
+  player.buffered = function() {
+    return videojs.createTimeRange(0, bufferEnd);
+  };
+  player.hls.sourceBuffer.abort = function() {
+    aborts++;
+  };
+
+  requests.pop().respond(200, null,
+    '#EXTM3U\n' +
+    '#EXTINF:10,0\n' +
+    '1.ts\n' +
+    '#EXT-X-DISCONTINUITY\n' +
+    '#EXTINF:10,0\n' +
+    '2.ts\n');
+  standardXHRResponse(requests.pop());
+
   currentTime = 1;
   bufferEnd = 10;
   player.trigger('timeupdate');


### PR DESCRIPTION
On seeking to a discontinuity point, the buffer would not refill and
the player would stop working. This commit fixes that issue, and
adjusts the test to catch the previous failure.