### PR TITLE
Support custom-IV when decrypting segments

### DIFF
--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -442,7 +442,7 @@
                 method: entry.attributes.METHOD || 'AES-128',
                 uri: entry.attributes.URI
               };
-	      
+
               if (entry.attributes.IV !== undefined) {
                 key.iv = entry.attributes.IV;
               }

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -440,9 +440,12 @@
               // setup an encryption key for upcoming segments
               key = {
                 method: entry.attributes.METHOD || 'AES-128',
-                uri: entry.attributes.URI,
-                iv: entry.attributes.IV || null
+                uri: entry.attributes.URI
               };
+	      
+	      if (entry.attributes.IV !== undefined) {
+	      	key.iv = entry.attributes.IV
+	      }
             },
             'media-sequence': function() {
               if (!isFinite(entry.number)) {

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -305,8 +305,9 @@
         event.attributes = parseAttributes(match[1]);
         // parse the IV string into a Uint32Array
         if (event.attributes.IV) {
-          if (event.attributes.IV.substring(0,2) == '0x')
+          if (event.attributes.IV.substring(0,2) === '0x') {	
             event.attributes.IV = event.attributes.IV.substring(2);
+          }
 
           event.attributes.IV = event.attributes.IV.match(/.{8}/g);
           event.attributes.IV[0] = parseInt(event.attributes.IV[0], 16);

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -305,6 +305,9 @@
         event.attributes = parseAttributes(match[1]);
         // parse the IV string into a Uint32Array
         if (event.attributes.IV) {
+          if (event.attributes.IV.substring(0,2) == '0x')
+            event.attributes.IV = event.attributes.IV.substring(2);
+
           event.attributes.IV = event.attributes.IV.match(/.{8}/g);
           event.attributes.IV[0] = parseInt(event.attributes.IV[0], 16);
           event.attributes.IV[1] = parseInt(event.attributes.IV[1], 16);
@@ -436,7 +439,8 @@
               // setup an encryption key for upcoming segments
               key = {
                 method: entry.attributes.METHOD || 'AES-128',
-                uri: entry.attributes.URI
+                uri: entry.attributes.URI,
+                iv: entry.attributes.IV || null
               };
             },
             'media-sequence': function() {

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -443,9 +443,9 @@
                 uri: entry.attributes.URI
               };
 	      
-	      if (entry.attributes.IV !== undefined) {
-	      	key.iv = entry.attributes.IV
-	      }
+              if (entry.attributes.IV !== undefined) {
+                key.iv = entry.attributes.IV;
+              }
             },
             'media-sequence': function() {
               if (!isFinite(entry.number)) {

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -601,11 +601,13 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     } else {
       // if the media sequence is greater than 2^32, the IV will be incorrect
       // assuming 10s segments, that would be about 1300 years
+      var theIv = segment.key.iv;
+      if (theIv === null) {
+        theIv = new Uint32Array([0, 0, 0, mediaIndex + playlist.mediaSequence]);
+      }
       bytes = videojs.Hls.decrypt(bytes,
                                   segment.key.bytes,
-                                  new Uint32Array([
-                                    0, 0, 0,
-                                    mediaIndex + playlist.mediaSequence]));
+                                  theIv);
     }
   }
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -601,13 +601,10 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     } else {
       // if the media sequence is greater than 2^32, the IV will be incorrect
       // assuming 10s segments, that would be about 1300 years
-      var theIv = segment.key.iv;
-      if (theIv === null) {
-        theIv = new Uint32Array([0, 0, 0, mediaIndex + playlist.mediaSequence]);
-      }
+      var segIv = segment.key.iv || new Uint32Array([0, 0, 0, mediaIndex + playlist.mediaSequence]);
       bytes = videojs.Hls.decrypt(bytes,
                                   segment.key.bytes,
-                                  theIv);
+                                  segIv);
     }
   }
 

--- a/test/manifest/encrypted.json
+++ b/test/manifest/encrypted.json
@@ -6,7 +6,8 @@
       "duration": 2.833,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52"
+        "uri": "https://priv.example.com/key.php?r=52",
+        "iv": null	
       },
       "uri": "http://media.example.com/fileSequence52-A.ts"
     },
@@ -14,7 +15,8 @@
       "duration": 15,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52"
+        "uri": "https://priv.example.com/key.php?r=52",
+        "iv": null
       },
       "uri": "http://media.example.com/fileSequence52-B.ts"
     },
@@ -22,7 +24,8 @@
       "duration": 13.333,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52"
+        "uri": "https://priv.example.com/key.php?r=52",
+        "iv": null
       },
       "uri": "http://media.example.com/fileSequence52-C.ts"
     },
@@ -30,9 +33,19 @@
       "duration": 15,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=53"
+        "uri": "https://priv.example.com/key.php?r=53",
+        "iv": null
       },
       "uri": "http://media.example.com/fileSequence53-A.ts"
+    },
+    {
+      "duration": 14,
+      "key": {
+        "method": "AES-128",
+        "uri": "https://priv.example.com/key.php?r=54",
+        "iv": new Uint32Array([0, 0, 331, 3063767524])
+      },
+      "uri": "http://media.example.com/fileSequence53-B.ts"
     },
     {
       "duration": 15,

--- a/test/manifest/encrypted.json
+++ b/test/manifest/encrypted.json
@@ -6,8 +6,7 @@
       "duration": 2.833,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52",
-        "iv": null	
+        "uri": "https://priv.example.com/key.php?r=52"
       },
       "uri": "http://media.example.com/fileSequence52-A.ts"
     },
@@ -15,8 +14,7 @@
       "duration": 15,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52",
-        "iv": null
+        "uri": "https://priv.example.com/key.php?r=52"
       },
       "uri": "http://media.example.com/fileSequence52-B.ts"
     },
@@ -24,8 +22,7 @@
       "duration": 13.333,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=52",
-        "iv": null
+        "uri": "https://priv.example.com/key.php?r=52"
       },
       "uri": "http://media.example.com/fileSequence52-C.ts"
     },
@@ -33,8 +30,7 @@
       "duration": 15,
       "key": {
         "method": "AES-128",
-        "uri": "https://priv.example.com/key.php?r=53",
-        "iv": null
+        "uri": "https://priv.example.com/key.php?r=53"
       },
       "uri": "http://media.example.com/fileSequence53-A.ts"
     },

--- a/test/manifest/encrypted.m3u8
+++ b/test/manifest/encrypted.m3u8
@@ -17,6 +17,11 @@ http://media.example.com/fileSequence52-C.ts
 #EXTINF:15.0,
 http://media.example.com/fileSequence53-A.ts
 
+#EXT-X-KEY:METHOD=AES-128,URI="https://priv.example.com/key.php?r=54",IV=0x00000000000000000000014BB69D61E4
+
+#EXTINF:14.0,
+http://media.example.com/fileSequence53-B.ts
+
 #EXT-X-KEY:METHOD=NONE
 
 #EXTINF:15.0,


### PR DESCRIPTION
The m3u8 parser was parsing the IV attribute, but didn't account for the case when they are prefixed by 0x, this fixes that, and also uses the IV if it's present
With this change, nginx-rtmp aes encrypted hls streams work.