### PR TITLE
Validate existence of h264Frame where needed

### DIFF
--- a/src/h264-stream.js
+++ b/src/h264-stream.js
@@ -192,7 +192,7 @@
         } else {
           // If we get here we have 00 00 00 or 00 00 01
           if (data[offset + 2] === 1) {
-            if (offset > start) {
+            if (this._h264Frame && offset > start) {
               this._h264Frame.writeBytes(data, start, offset - start);
             }
             this._state = 3;
@@ -203,7 +203,7 @@
           if (end - offset >= 4 &&
               data[offset + 2] === 0 &&
               data[offset + 3] === 1) {
-            if (offset > start) {
+            if (this._h264Frame && offset > start) {
               this._h264Frame.writeBytes(data, start, offset - start);
             }
             this._state = 3;


### PR DESCRIPTION
Sometimes HLS crashes due to not existing h264Frame. Validate it before writing data to it and it plays/works properly afterwards.