### PR TITLE
Clean up in flight playlist request aborts better

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -118,7 +118,9 @@
        */
       loader.dispose = function() {
         if (request) {
+          request.onreadystatechange = null;
           request.abort();
+          request = null;
         }
         window.clearTimeout(mediaUpdateTimeout);
         dispose.call(this);
@@ -161,6 +163,7 @@
         if (loader.master.playlists[playlist.uri].endList) {
           // abort outstanding playlist requests
           if (request) {
+            request.onreadystatechange = null;
             request.abort();
             request = null;
           }
@@ -188,6 +191,7 @@
             // has no effect after the first
             return;
           }
+          request.onreadystatechange = null;
           request.abort();
           request = null;
         }

--- a/test/playlist-loader_test.js
+++ b/test/playlist-loader_test.js
@@ -331,6 +331,7 @@
     clock.tick(10 * 1000);
     loader.media('high.m3u8');
     strictEqual(requests[0].aborted, true, 'aborted refresh request');
+    ok(!requests[0].onreadystatechange, 'onreadystatechange handlers should be removed on abort');
     strictEqual(loader.state, 'SWITCHING_MEDIA', 'updated the state');
   });
 
@@ -417,6 +418,7 @@
 
     strictEqual(requests.length, 1, 'requested high playlist');
     ok(requests[0].aborted, 'aborted playlist request');
+    ok(!requests[0].onreadystatechange, 'onreadystatechange handlers should be removed on abort');
     strictEqual(loader.state, 'HAVE_METADATA', 'returned to loaded playlist');
     strictEqual(loader.media(), loader.master.playlists[0], 'switched to loaded playlist');
   });
@@ -498,6 +500,7 @@
 
     loader.dispose();
     ok(requests[0].aborted, 'refresh request aborted');
+    ok(!requests[0].onreadystatechange, 'onreadystatechange handler should not exist after dispose called');
   });
 
   test('errors if requests take longer than 45s', function() {


### PR DESCRIPTION
We were seeing issues with requests throwing errors if a requests readystate changed after calling player.dispose().  Our tests were using sinon, which has [this code](https://github.com/cjohansen/Sinon.JS/blob/2b5584872c45bab5700d30ba6100d16d19ebd79c/lib/sinon/util/fake_xml_http_request.js#L444-L464) for the fake abort method.  Basically, anytime the ready state was anything but 0 (UNSENT), it sets the readystate to 4 (DONE). I thought that might be a problem in that library as most of what I could find on the web suggested that readyState should not changed after calling abort() it should "just abandon the request".  However, to my surprise that doesn't appear to be true.  I ran this code in the chrome console while on a google search result page.

```javascript
  var request = new window.XMLHttpRequest();
  var isaborted = '';
  request.onreadystatechange = function() {
    console.log('rsc fired' + isaborted +': ', this.readyState);
    if (this.readyState == i) {
      isaborted = ' after abort'
      console.log('readyState on abort = ', this.readyState);
      request.abort();
    } 
  }
  request.open('GET', 'https://www.google.com');
  request.send(null);
```
And here was the output when aborting at different values of i:

Results aborting when readyState == 1:
>rsc fired:  1
>readyState on abort =  1
>Uncaught DOMException: Failed to execute 'send' on 'XMLHttpRequest': The object's state must be OPENED.

Results aborting when readyState == 2:
>rsc fired:  1
>rsc fired:  2
>readyState on abort =  2
>rsc fired after abort:  4

Results aborting when readyState == 3:
>rsc fired:  1
>rsc fired:  2
>rsc fired:  3
>readyState on abort =  3
>rsc fired after abort:  4

Results aborting when readyState == 4:
>rsc fired:  1
>rsc fired:  2
>rsc fired:  3
>rsc fired:  4
>readyState on abort =  4

So turns out that I think we do need to remove the onreadystate listeners ourselves if aborting requests.  Otherwise, they will get a DONE response if they were in flight,  [ready states 2 or 3](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#Properties) when we aborted them.

This matches what you are [already doing for the KEY and SEGMENT requests](https://github.com/videojs/videojs-contrib-hls/blob/master/src/videojs-hls.js#L383-L398)