### PR TITLE
enable support for "ffmpeg -reset_timestamps 1" segments

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -671,6 +671,9 @@ videojs.Hls.prototype.loadSegment = function(segmentUri, offset) {
 
 videojs.Hls.prototype.drainBuffer = function(event) {
   var
+    player = this.player(),
+    settings = player.options().hls || {},
+  
     i = 0,
     mediaIndex,
     playlist,
@@ -732,7 +735,7 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   }
 
   // transmux the segment data from MP2T to FLV
-  this.segmentParser_.parseSegmentBinaryData(bytes);
+  this.segmentParser_.parseSegmentBinaryData(bytes, settings.resetTimestamps ? segmentOffset : 0);
   this.segmentParser_.flushTags();
 
   tags = [];


### PR DESCRIPTION
This patch allow you to play segments with "ffmpeg -reset_timestamps 1". It's very useful in case if you want to generate dynamic random-ordered m3u8 lists from predefined set of segments and play it in gapless maner.

Usage example:

var player = videojs('video', {
    hls: {
        resetTimestamps: true
    }
});
player.play();