### PR TITLE
Fix discontinuities

### DIFF
--- a/example.html
+++ b/example.html
@@ -70,7 +70,7 @@
        type="application/x-mpegURL">
   </video>
   <script>
-    videojs.options.flash.swf = 'node_modules/video.js/dist/video-js/video-js.swf';
+    videojs.options.flash.swf = 'node_modules/videojs-swf/dist/video-js.swf';
     // initialize the player
     var player = videojs('video');
   </script>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "pkcs7": "^0.2.2",
-    "videojs-contrib-media-sources": "^0.3.0"
+    "videojs-contrib-media-sources": "^0.3.0",
+    "videojs-swf": "^4.6.0"
   }
 }


### PR DESCRIPTION
Never match media indices on playlist reload based on segment URI because some streams may re-use the same segment in multiple positions. Change fetchKeys() so that it operates on buffered segments instead of directly modifying a version of the playlist. Before that change, live playlists with low segment durations could stall because the key would be applied to the previous version of the live playlist and segments would get blocked up forever in the queue waiting for their key to arrive. Use a much less destructive mechanism for playing across discontinuities. vjs_discontinuity() on the SWF allows us to signal a timestamp discontinuity without flushing the playback buffer. That means we don't have to wait until the buffer is empty when a discontinuity is encountered and feeding data to the SWF doesn't have to block either. Update tests to reflect new key-segment request ordering.