### PR TITLE
Use presentation time stamp to calculate playlist duration

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -734,13 +734,23 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   this.segmentParser_.flushTags();
 
   tags = [];
-  segment.preciseTimestamp = null;
 
   while (this.segmentParser_.tagsAvailable()) {
     tags.push(this.segmentParser_.getNextTag());
-    if (!tags[tags.length - 1].counted && tags[tags.length-1].pts) {
-      segment.preciseTimestamp = segment.preciseTimestamp > tags[tags.length-1].pts ? segment.preciseTimestamp : tags[tags.length-1].pts;
-      tags[tags.length - 1].counted = true;
+  }
+
+  if (tags.length > 0) {
+    segment.preciseTimestamp = tags[tags.length - 1].pts;
+
+    if (playlist.segments[mediaIndex - 1]) {
+      if (playlist.segments[mediaIndex - 1].preciseTimestamp) {
+        durationOffset = playlist.segments[mediaIndex - 1].preciseTimestamp;
+      } else {
+        durationOffset = (playlist.targetDuration * (mediaIndex - 1) + playlist.segments[mediaIndex - 1].duration) * 1000;
+      }
+      segment.preciseDuration = (segment.preciseTimestamp - durationOffset) / 1000;
+    } else if (mediaIndex === 0) {
+      segment.preciseDuration = segment.preciseTimestamp / 1000;
     }
   }
 
@@ -921,7 +931,6 @@ videojs.Hls.canPlaySource = function(srcObj) {
  */
 videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
   var dur = 0,
-      offset = 0,
       segment,
       i;
 
@@ -931,22 +940,7 @@ videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
 
   for (; i >= startIndex; i--) {
     segment = playlist.segments[i];
-    if (segment.preciseDuration || segment.preciseTimestamp) {
-      offset = 0;
-      if (!segment.preciseDuration) {
-        if (playlist.segments[i - 1]) {
-          if (playlist.segments[i - 1].preciseTimestamp) {
-            offset = playlist.segments[i - 1].preciseTimestamp;
-          } else {
-            offset = (playlist.targetDuration * (i - 1) + playlist.segments[i - 1].duration) * 1000;
-          }
-          segment.preciseDuration = (segment.preciseTimestamp - offset) / 1000;
-        } else if (i === 0) {
-          segment.preciseDuration = segment.preciseTimestamp / 1000;
-        } else {
-          segment.preciseDuration = segment.duration;
-        }
-      }
+    if (segment.preciseDuration) {
       dur += segment.preciseDuration;
     } else {
       dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -691,9 +691,10 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     tags,
     bytes,
     segment,
+    durationOffset,
 
     ptsTime,
-    segmentOffset,
+    segmentOffset = 0,
     segmentBuffer = this.segmentBuffer_;
 
   if (!segmentBuffer.length || !this.sourceBuffer) {
@@ -733,13 +734,23 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   this.segmentParser_.flushTags();
 
   tags = [];
-  segment.preciseTimestamp = null;
 
   while (this.segmentParser_.tagsAvailable()) {
     tags.push(this.segmentParser_.getNextTag());
-    if (!tags[tags.length - 1].counted && tags[tags.length-1].pts) {
-      segment.preciseTimestamp = segment.preciseTimestamp > tags[tags.length-1].pts ? segment.preciseTimestamp : tags[tags.length-1].pts;
-      tags[tags.length - 1].counted = true;
+  }
+
+  if (tags.length > 0) {
+    segment.preciseTimestamp = tags[tags.length - 1].pts;
+
+    if (playlist.segments[mediaIndex - 1]) {
+      if (playlist.segments[mediaIndex - 1].preciseTimestamp) {
+        durationOffset = playlist.segments[mediaIndex - 1].preciseTimestamp;
+      } else {
+        durationOffset = (playlist.targetDuration * (mediaIndex - 1) + playlist.segments[mediaIndex - 1].duration) * 1000;
+      }
+      segment.preciseDuration = (segment.preciseTimestamp - durationOffset) / 1000;
+    } else if (mediaIndex === 0) {
+      segment.preciseDuration = segment.preciseTimestamp / 1000;
     }
   }
 
@@ -905,7 +916,6 @@ videojs.Hls.canPlaySource = function(srcObj) {
  */
 videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
   var dur = 0,
-      offset = 0,
       segment,
       i;
 
@@ -915,22 +925,7 @@ videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
 
   for (; i >= startIndex; i--) {
     segment = playlist.segments[i];
-    if (segment.preciseDuration || segment.preciseTimestamp) {
-      offset = 0;
-      if (!segment.preciseDuration) {
-        if (playlist.segments[i - 1]) {
-          if (playlist.segments[i - 1].preciseTimestamp) {
-            offset = playlist.segments[i - 1].preciseTimestamp;
-          } else {
-            offset = (playlist.targetDuration * (i - 1) + playlist.segments[i - 1].duration) * 1000;
-          }
-          segment.preciseDuration = (segment.preciseTimestamp - offset) / 1000;
-        } else if (i === 0) {
-          segment.preciseDuration = segment.preciseTimestamp / 1000;
-        } else {
-          segment.preciseDuration = segment.duration;
-        }
-      }
+    if (segment.preciseDuration) {
       dur += segment.preciseDuration;
     } else {
       dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -739,6 +739,10 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     tags.push(this.segmentParser_.getNextTag());
   }
 
+  // This block of code uses the presentation timestamp of the ts segment to calculate its exact duration, since this
+  // may differ by fractions of a second from what is reported. Using the exact, calculated 'preciseDuration' allows
+  // for smoother seeking and calculation of the total playlist duration, which previously (especially in short videos)
+  // was reported erroneously and made the play head overrun the end of the progress bar.
   if (tags.length > 0) {
     segment.preciseTimestamp = tags[tags.length - 1].pts;
 
@@ -940,11 +944,7 @@ videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
 
   for (; i >= startIndex; i--) {
     segment = playlist.segments[i];
-    if (segment.preciseDuration) {
-      dur += segment.preciseDuration;
-    } else {
-      dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;
-    }
+    dur += segment.preciseDuration || segment.duration || playlist.targetDuration || 0;
   }
 
   return dur;

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -758,6 +758,8 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     }
   }
 
+  this.updateDuration(this.playlists.media());
+
   // if we're refilling the buffer after a seek, scan through the muxed
   // FLV tags until we find the one that is closest to the desired
   // playback time

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -733,8 +733,14 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   this.segmentParser_.flushTags();
 
   tags = [];
+  segment.preciseTimestamp = -1;
+
   while (this.segmentParser_.tagsAvailable()) {
     tags.push(this.segmentParser_.getNextTag());
+    if (!tags[tags.length - 1].counted && tags[tags.length-1].pts) {
+      segment.preciseTimestamp = segment.preciseTimestamp > tags[tags.length-1].pts ? segment.preciseTimestamp : tags[tags.length-1].pts;
+      tags[tags.length - 1].counted = true;
+    }
   }
 
   // if we're refilling the buffer after a seek, scan through the muxed
@@ -908,7 +914,19 @@ videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
 
   for (; i >= startIndex; i--) {
     segment = playlist.segments[i];
-    dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;
+    if (segment.preciseTimestamp && segment.preciseTimestamp >= 0) {
+      var offset = 0;
+      if (playlist.segments[i - 1]) {
+        if (playlist.segments[i - 1].preciseTimestamp) {
+          offset = playlist.segments[i - 1].preciseTimestamp;
+        } else {
+          offset = (playlist.targetDuration * (i - 1) + playlist.segments[i - 1].duration) * 1000;
+        }
+      }
+      dur += (segment.preciseTimestamp - offset) / 1000;
+    } else {
+      dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;
+    }
   }
 
   return dur;

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -734,7 +734,7 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   this.segmentParser_.flushTags();
 
   tags = [];
-  segment.preciseTimestamp = -1;
+  segment.preciseTimestamp = null;
 
   while (this.segmentParser_.tagsAvailable()) {
     tags.push(this.segmentParser_.getNextTag());
@@ -921,6 +921,7 @@ videojs.Hls.canPlaySource = function(srcObj) {
  */
 videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
   var dur = 0,
+      offset = 0,
       segment,
       i;
 
@@ -930,16 +931,23 @@ videojs.Hls.getPlaylistDuration = function(playlist, startIndex, endIndex) {
 
   for (; i >= startIndex; i--) {
     segment = playlist.segments[i];
-    if (segment.preciseTimestamp && segment.preciseTimestamp >= 0) {
-      var offset = 0;
-      if (playlist.segments[i - 1]) {
-        if (playlist.segments[i - 1].preciseTimestamp) {
-          offset = playlist.segments[i - 1].preciseTimestamp;
+    if (segment.preciseDuration || segment.preciseTimestamp) {
+      offset = 0;
+      if (!segment.preciseDuration) {
+        if (playlist.segments[i - 1]) {
+          if (playlist.segments[i - 1].preciseTimestamp) {
+            offset = playlist.segments[i - 1].preciseTimestamp;
+          } else {
+            offset = (playlist.targetDuration * (i - 1) + playlist.segments[i - 1].duration) * 1000;
+          }
+          segment.preciseDuration = (segment.preciseTimestamp - offset) / 1000;
+        } else if (i === 0) {
+          segment.preciseDuration = segment.preciseTimestamp / 1000;
         } else {
-          offset = (playlist.targetDuration * (i - 1) + playlist.segments[i - 1].duration) * 1000;
+          segment.preciseDuration = segment.duration;
         }
       }
-      dur += (segment.preciseTimestamp - offset) / 1000;
+      dur += segment.preciseDuration;
     } else {
       dur += (segment.duration !== undefined ? segment.duration : playlist.targetDuration) || 0;
     }

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -271,7 +271,7 @@ test('sets the duration if one is available on the playlist', function() {
   standardXHRResponse(requests[0]);
   strictEqual(calls, 1, 'duration is set');
   standardXHRResponse(requests[1]);
-  strictEqual(calls, 1, 'duration is set');
+  strictEqual(calls, 2, 'duration is set');
 });
 
 test('calculates the duration if needed', function() {

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1063,9 +1063,11 @@ test('calculates preciseTimestamp and preciseDuration for a new segment', functi
   openMediaSource(player);
 
   standardXHRResponse(requests[0]);
+  strictEqual(player.duration(), 40, 'player duration is read from playlist on load');
   standardXHRResponse(requests[1]);
   strictEqual(player.hls.playlists.media().segments[0].preciseTimestamp, 200000, 'preciseTimestamp is calculated and stored');
   strictEqual(player.hls.playlists.media().segments[0].preciseDuration, 200, 'preciseDuration is calculated and stored');
+  strictEqual(player.duration(), 230, 'player duration is calculated using preciseDuration');
 });
 
 test('exposes in-band metadata events as cues', function() {

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1039,6 +1039,35 @@ test('flushes the parser after each segment', function() {
   strictEqual(flushes, 1, 'tags are flushed at the end of a segment');
 });
 
+test('calculates preciseTimestamp and preciseDuration for a new segment', function() {
+  // mock out the segment parser
+  videojs.Hls.SegmentParser = function() {
+    var tagsAvailable = true,
+        tag = { pts : 200000 };
+    this.getFlvHeader = function() {
+      return [];
+    };
+    this.parseSegmentBinaryData = function() {};
+    this.flushTags = function() {};
+    this.tagsAvailable = function() { return tagsAvailable; };
+    this.getNextTag = function() { tagsAvailable = false; return tag; };
+    this.metadataStream = {
+      on: Function.prototype
+    };
+  };
+
+  player.src({
+    src: 'manifest/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  openMediaSource(player);
+
+  standardXHRResponse(requests[0]);
+  standardXHRResponse(requests[1]);
+  strictEqual(player.hls.playlists.media().segments[0].preciseTimestamp, 200000, 'preciseTimestamp is calculated and stored');
+  strictEqual(player.hls.playlists.media().segments[0].preciseDuration, 200, 'preciseDuration is calculated and stored');
+});
+
 test('exposes in-band metadata events as cues', function() {
   var track;
   player.src({


### PR DESCRIPTION
This code uses the presentation timestamp of the ts segment to calculate its exact duration, since this may differ by fractions of a second from what is reported. Using the exact, calculated 'preciseDuration' allows for smoother seeking and calculation of the total playlist duration, which previously (especially in short videos) was reported erroneously and made the play head overrun the end of the progress bar.