### PR TITLE
Id3 enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,19 @@ embedded as [ID3 tags](http://id3.org/id3v2.3.0). When a stream is
 encountered with embedded metadata, an [in-band metadata text
 track](https://html.spec.whatwg.org/multipage/embedded-content.html#text-track-in-band-metadata-track-dispatch-type)
 will automatically be created and populated with cues as they are
-encountered in the stream. Only UTF-8 encoded
+encountered in the stream. UTF-8 encoded
 [TXXX](http://id3.org/id3v2.3.0#User_defined_text_information_frame)
 and [WXXX](http://id3.org/id3v2.3.0#User_defined_URL_link_frame) ID3
-frames are currently mapped to cue points. There are lots of guides
-and references to using text tracks [around the
-web](http://www.html5rocks.com/en/tutorials/track/basics/).
+frames are mapped to cue points and their values set as the cue
+text. Cues are created for all other frame types and the data is
+attached to the generated cue:
+
+```js
+cue.frame.data
+```
+
+There are lots of guides and references to using text tracks [around
+the web](http://www.html5rocks.com/en/tutorials/track/basics/).
 
 ### Testing
 

--- a/src/metadata-stream.js
+++ b/src/metadata-stream.js
@@ -152,6 +152,7 @@
       for (i = 0; i < tagSize;) {
         tag.data.set(buffer[0].data, i);
         i += buffer[0].data.byteLength;
+        bufferSize -= buffer[0].data.byteLength;
         buffer.shift();
       }
 

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -368,12 +368,6 @@
             aacStream.setNextTimeStamp(pts,
                                        pesPacketSize,
                                        dataAlignmentIndicator);
-          } else {
-            self.metadataStream.push({
-              pts: pts,
-              dts: dts,
-              data: data.subarray(offset)
-            });
           }
         }
 
@@ -381,6 +375,12 @@
           aacStream.writeBytes(data, offset, end - offset);
         } else if (pid === self.stream.programMapTable[STREAM_TYPES.h264]) {
           h264Stream.writeBytes(data, offset, end - offset);
+        } else if (pid === self.stream.programMapTable[STREAM_TYPES.metadata]) {
+          self.metadataStream.push({
+            pts: pts,
+            dts: dts,
+            data: data.subarray(offset)
+          });
         }
       } else if (self.stream.pmtPid === pid) {
         // similarly to the PAT, jump to the first byte of the section

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -99,7 +99,7 @@ videojs.Hls.prototype.src = function(src) {
     }
 
     metadataStream.on('data', function(metadata) {
-      var i, frame, time, hexDigit;
+      var i, cue, frame, time, hexDigit;
 
       // create the metadata track if this is the first ID3 tag we've
       // seen
@@ -118,7 +118,9 @@ videojs.Hls.prototype.src = function(src) {
       for (i = 0; i < metadata.frames.length; i++) {
         frame = metadata.frames[i];
         time = metadata.pts / 1000;
-        textTrack.addCue(new window.VTTCue(time, time, frame.value || frame.url || frame.id === 'PRIV' && String.fromCharCode.apply(null, frame.data)));
+        cue = new window.VTTCue(time, time, frame.value || frame.url || '');
+        cue.frame = frame;
+        textTrack.addCue(cue);
       }
     });
   })();

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -118,7 +118,7 @@ videojs.Hls.prototype.src = function(src) {
       for (i = 0; i < metadata.frames.length; i++) {
         frame = metadata.frames[i];
         time = metadata.pts / 1000;
-        textTrack.addCue(new window.VTTCue(time, time, frame.value || frame.url));
+        textTrack.addCue(new window.VTTCue(time, time, frame.value || frame.url || frame.id === 'PRIV' && String.fromCharCode.apply(null, frame.data)));
       }
     });
   })();

--- a/test/metadata-stream_test.js
+++ b/test/metadata-stream_test.js
@@ -206,7 +206,7 @@
     equal(events[0].dts, 100, 'translated dts');
   });
 
-  test('parses TXXX tags', function() {
+  test('parses TXXX frames', function() {
     var events = [];
     metadataStream.on('data', function(event) {
       events.push(event);
@@ -232,7 +232,7 @@
     equal(events[0].frames[0].value, '{ "key": "value" }', 'parsed the value');
   });
 
-  test('parses WXXX tags', function() {
+  test('parses WXXX frames', function() {
     var events = [], url = 'http://example.com/path/file?abc=7&d=4#ty';
     metadataStream.on('data', function(event) {
       events.push(event);
@@ -258,7 +258,7 @@
     equal(events[0].frames[0].url, url, 'parsed the value');
   });
 
-  test('parses TXXX tags with characters that have a single-digit hexadecimal representation', function() {
+  test('parses TXXX frames with characters that have a single-digit hexadecimal representation', function() {
     var events = [], value = String.fromCharCode(7);
     metadataStream.on('data', function(event) {
       events.push(event);
@@ -282,7 +282,7 @@
           'parsed the single-digit character');
   });
 
-  test('parses PRIV tags', function() {
+  test('parses PRIV frames', function() {
     var
       events = [],
       payload = stringToInts('arbitrary data may be included in the payload ' +
@@ -311,6 +311,88 @@
               new Uint8Array(payload),
               'parsed the frame private data');
 
+  });
+
+  test('parses tags split across pushes', function() {
+    var
+      events = [],
+      owner = stringToCString('owner@example.com'),
+      payload = stringToInts('A TS packet is 188 bytes in length so that it can' +
+                             ' be easily transmitted over ATM networks, an ' +
+                             'important medium at one time. We want to be sure' +
+                             ' that ID3 frames larger than a TS packet are ' +
+                             'properly re-assembled.'),
+      tag = new Uint8Array(id3Tag(id3Frame('PRIV', owner, payload))),
+      front = tag.subarray(0, 100),
+      back = tag.subarray(100);
+
+    metadataStream.on('data', function(event) {
+      events.push(event);
+    });
+
+    metadataStream.push({
+      trackId: 7,
+      pts: 1000,
+      dts: 900,
+      data: front
+    });
+
+    equal(events.length, 0, 'parsed zero tags');
+
+    metadataStream.push({
+      trackId: 7,
+      pts: 1000,
+      dts: 900,
+      data: back
+    });
+
+    equal(events.length, 1, 'parsed a tag');
+    equal(events[0].frames.length, 1, 'parsed a frame');
+    equal(events[0].frames[0].data.byteLength,
+          owner.length + payload.length,
+          'collected data across pushes');
+  });
+
+  test('ignores tags when the header is fragmented', function() {
+
+    var
+      events = [],
+      tag = new Uint8Array(id3Tag(id3Frame('PRIV',
+                                           stringToCString('owner@example.com'),
+                                           stringToInts('payload')))),
+      // split the 10-byte ID3 tag header in half
+      front = tag.subarray(0, 5),
+      back = tag.subarray(5);
+
+    metadataStream.on('data', function(event) {
+      events.push(event);
+    });
+
+    metadataStream.push({
+      trackId: 7,
+      pts: 1000,
+      dts: 900,
+      data: front
+    });
+    metadataStream.push({
+      trackId: 7,
+      pts: 1000,
+      dts: 900,
+      data: back
+    });
+
+    equal(events.length, 0, 'parsed zero tags');
+
+    metadataStream.push({
+      trackId: 7,
+      pts: 1500,
+      dts: 1500,
+      data: new Uint8Array(id3Tag(id3Frame('PRIV',
+                                           stringToCString('owner2'),
+                                           stringToInts('payload2'))))
+    });
+    equal(events.length, 1, 'parsed one tag');
+    equal(events[0].frames[0].owner, 'owner2', 'dropped the first tag');
   });
 
   // https://html.spec.whatwg.org/multipage/embedded-content.html#steps-to-expose-a-media-resource-specific-text-track

--- a/test/metadata-stream_test.js
+++ b/test/metadata-stream_test.js
@@ -227,6 +227,7 @@
 
     equal(events.length, 1, 'parsed one tag');
     equal(events[0].frames.length, 1, 'parsed one frame');
+    equal(events[0].frames[0].id, 'TXXX', 'parsed the frame id');
     equal(events[0].frames[0].description, 'get done', 'parsed the description');
     equal(events[0].frames[0].value, '{ "key": "value" }', 'parsed the value');
   });
@@ -252,6 +253,7 @@
 
     equal(events.length, 1, 'parsed one tag');
     equal(events[0].frames.length, 1, 'parsed one frame');
+    equal(events[0].frames[0].id, 'WXXX', 'parsed the frame id');
     equal(events[0].frames[0].description, '', 'parsed the description');
     equal(events[0].frames[0].url, url, 'parsed the value');
   });
@@ -278,6 +280,37 @@
     equal(events[0].frames[0].value,
           value,
           'parsed the single-digit character');
+  });
+
+  test('parses PRIV tags', function() {
+    var
+      events = [],
+      payload = stringToInts('arbitrary data may be included in the payload ' +
+                             'of a PRIV frame');
+
+    metadataStream.on('data', function(event) {
+      events.push(event);
+    });
+
+    metadataStream.push({
+      trackId: 7,
+      pts: 1000,
+      dts: 900,
+
+      // header
+      data: new Uint8Array(id3Tag(id3Frame('PRIV',
+                                           stringToCString('priv-owner@example.com'),
+                                           payload)))
+    });
+
+    equal(events.length, 1, 'parsed a tag');
+    equal(events[0].frames.length, 1, 'parsed a frame');
+    equal(events[0].frames[0].id, 'PRIV', 'frame id is PRIV');
+    equal(events[0].frames[0].owner, 'priv-owner@example.com', 'parsed the owner');
+    deepEqual(events[0].frames[0].privateData,
+              new Uint8Array(payload),
+              'parsed the frame private data');
+
   });
 
   // https://html.spec.whatwg.org/multipage/embedded-content.html#steps-to-expose-a-media-resource-specific-text-track

--- a/test/metadata-stream_test.js
+++ b/test/metadata-stream_test.js
@@ -309,7 +309,7 @@
     equal(events[0].frames.length, 1, 'parsed a frame');
     equal(events[0].frames[0].id, 'PRIV', 'frame id is PRIV');
     equal(events[0].frames[0].owner, 'priv-owner@example.com', 'parsed the owner');
-    deepEqual(events[0].frames[0].privateData,
+    deepEqual(new Uint8Array(events[0].frames[0].privateData),
               new Uint8Array(payload),
               'parsed the frame private data');
 

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1112,11 +1112,15 @@ test('exposes in-band metadata events as cues', function() {
       pts: 2000,
       data: new Uint8Array([]),
       frames: [{
-        type: 'TXXX',
+        id: 'TXXX',
         value: 'cue text'
       }, {
-        type: 'WXXX',
+        id: 'WXXX',
         url: 'http://example.com'
+      }, {
+        id: 'PRIV',
+        owner: 'owner@example.com',
+        privateData: new Uint8Array([1, 2, 3])
       }]
     });
   };
@@ -1128,7 +1132,7 @@ test('exposes in-band metadata events as cues', function() {
   track = player.textTracks()[0];
   equal(track.kind, 'metadata', 'kind is metadata');
   equal(track.inBandMetadataTrackDispatchType, '15010203BB', 'set the dispatch type');
-  equal(track.cues.length, 2, 'created two cues');
+  equal(track.cues.length, 3, 'created three cues');
   equal(track.cues[0].startTime, 2, 'cue starts at 2 seconds');
   equal(track.cues[0].endTime, 2, 'cue ends at 2 seconds');
   equal(track.cues[0].pauseOnExit, false, 'cue does not pause on exit');
@@ -1138,6 +1142,15 @@ test('exposes in-band metadata events as cues', function() {
   equal(track.cues[1].endTime, 2, 'cue ends at 2 seconds');
   equal(track.cues[1].pauseOnExit, false, 'cue does not pause on exit');
   equal(track.cues[1].text, 'http://example.com', 'set cue text');
+
+  equal(track.cues[2].startTime, 2, 'cue starts at 2 seconds');
+  equal(track.cues[2].endTime, 2, 'cue ends at 2 seconds');
+  equal(track.cues[2].pauseOnExit, false, 'cue does not pause on exit');
+  equal(track.cues[2].text, '', 'did not set cue text');
+  equal(track.cues[2].frame.owner, 'owner@example.com', 'set the owner');
+  deepEqual(track.cues[2].frame.privateData,
+            new Uint8Array([1, 2, 3]),
+            'set the private data');
 });
 
 test('drops tags before the target timestamp when seeking', function() {


### PR DESCRIPTION
Rebased #258. Added a bit more first-class parsing for PRIV frames and exposed the bytes of all frames on the generated VTTCue so that they could be parsed upstream if we don't have explicit support for a particular frame type. Added buffering in metadata stream and fixed an issue in packet parsing so that ID3 tags that span multiple TS packets are reformed before being parsed.