### PR TITLE
Discontinuity insertion race

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "pkcs7": "^0.2.2",
-    "videojs-contrib-media-sources": "^0.3.0",
+    "videojs-contrib-media-sources": "^1.0.0",
     "videojs-swf": "^4.6.0"
   }
 }

--- a/src/flv-tag.js
+++ b/src/flv-tag.js
@@ -377,7 +377,10 @@ hls.FlvTag.durationFromTags = function(tags) {
     return 0;
   }
 
-  var first = tags[0], last = tags[tags.length - 1], frameDuration;
+  var
+    first = tags[0],
+    last = tags[tags.length - 1],
+    frameDuration;
 
   // use the interval between the last two tags or assume 24 fps
   frameDuration = last.pts - tags[tags.length - 2].pts || (1/24);

--- a/src/flv-tag.js
+++ b/src/flv-tag.js
@@ -1,3 +1,8 @@
+/**
+ * An object that stores the bytes of an FLV tag and methods for
+ * querying and manipulating that data.
+ * @see http://download.macromedia.com/f4v/video_file_format_spec_v10_1.pdf
+ */
 (function(window) {
 
 window.videojs = window.videojs || {};
@@ -356,6 +361,28 @@ hls.FlvTag.frameTime = function(tag) {
   pts |= tag[ 6] <<  0;
   pts |= tag[ 7] << 24;
   return pts;
+};
+
+/**
+ * Calculate the media timeline duration represented by an array of
+ * tags. This function assumes the tags are already pre-sorted by
+ * presentation timestamp (PTS), in ascending order. Returns zero if
+ * there are less than two FLV tags to inspect.
+ * @param tags {array} the FlvTag objects to query
+ * @return the number of milliseconds between the display time of the
+ * first tag and the last tag.
+ */
+hls.FlvTag.durationFromTags = function(tags) {
+  if (tags.length < 2) {
+    return 0;
+  }
+
+  var first = tags[0], last = tags[tags.length - 1], frameDuration;
+
+  // use the interval between the last two tags or assume 24 fps
+  frameDuration = last.pts - tags[tags.length - 2].pts || (1/24);
+
+  return (last.pts - first.pts) + frameDuration;
 };
 
 })(this);

--- a/test/flv-tag_test.js
+++ b/test/flv-tag_test.js
@@ -57,4 +57,32 @@ test('writeBytes grows the internal byte array dynamically', function() {
   }
 });
 
-})(this);  
+test('calculates the duration of a tag array from PTS values', function() {
+  var tags = [], count = 20, i;
+
+  for (i = 0; i < count; i++) {
+    tags[i] = new FlvTag(FlvTag.VIDEO_TAG);
+    tags[i].pts = i * 1000;
+  }
+
+  equal(FlvTag.durationFromTags(tags), count * 1000, 'calculated duration from PTS values');
+});
+
+test('durationFromTags() assumes 24fps if the last frame duration cannot be calculated', function() {
+  var tags = [
+    new FlvTag(FlvTag.VIDEO_TAG),
+    new FlvTag(FlvTag.VIDEO_TAG),
+    new FlvTag(FlvTag.VIDEO_TAG)
+  ];
+  tags[0].pts = 0;
+  tags[1].pts = tags[2].pts = 1000;
+
+  equal(FlvTag.durationFromTags(tags), 1000 + (1/24) , 'assumes 24fps video');
+});
+
+test('durationFromTags() returns zero if there are less than two frames', function() {
+  equal(FlvTag.durationFromTags([]), 0, 'returns zero for empty input');
+  equal(FlvTag.durationFromTags([new FlvTag(FlvTag.VIDEO_TAG)]), 0, 'returns zero for a singleton input');
+});
+
+})(this);


### PR DESCRIPTION
If segments are delivered very quickly, it's possible that a segment after a discontinuity will be ready before the previous segment is finished getting processed by the media source. Our current mechanism for signalling discontinuities is synchronous so this could lead to us injecting a discontinuity into the middle of the first segment instead of at the end. Instead, adopt a workflow more closely aligned to how real SourceBuffers work and don't append additional bytes until the previous append has been fully processed.

Also includes a fix for precise segment duration after discontinuities. Fixes #266 