### PR TITLE
Always write out metadata at the start of segments and refactor of h264stream

### DIFF
--- a/src/h264-stream.js
+++ b/src/h264-stream.js
@@ -283,7 +283,9 @@
           newExtraData = new H264ExtraData();
         }
 
-        if (h264Frame.keyFrame) {
+        // Check if keyframe and the length of tags.
+        // This makes sure we write metadata on the first frame of a segment.
+        if (h264Frame.keyFrame || this.tags.length === 0) {
           // Push extra data on every IDR frame in case we did a stream change + seek
           this.tags.push(oldExtraData.metaDataTag(h264Frame.pts));
           this.tags.push(oldExtraData.extraDataTag(h264Frame.pts));

--- a/test/h264-stream_test.js
+++ b/test/h264-stream_test.js
@@ -70,6 +70,9 @@ test('starting PTS values can be negative', function() {
       nalUnitTypes.access_unit_delimiter_rbsp
     ]);
 
+  // add a "tag" to the stream so that it doesn't try and parse metadata
+  h264Stream.tags.push('spacer tag');
+
   h264Stream.setTimeStampOffset(-100);
   h264Stream.setNextTimeStamp(-100, -100, true);
   h264Stream.writeBytes(accessUnitDelimiter, 0, accessUnitDelimiter.byteLength);
@@ -79,6 +82,8 @@ test('starting PTS values can be negative', function() {
   h264Stream.writeBytes(accessUnitDelimiter, 0, accessUnitDelimiter.byteLength);
   // flush out the last tag
   h264Stream.writeBytes(accessUnitDelimiter, 0, accessUnitDelimiter.byteLength);
+
+  h264Stream.tags.shift();
 
   strictEqual(h264Stream.tags.length, 3, 'three tags are ready');
   strictEqual(h264Stream.tags[0].pts, 0, 'the first PTS is zero');


### PR DESCRIPTION
In some cases (most likely badly encoded video), segments didn't start
with a keyframe so they ended up getting squished because flash didn't
know how to play them.