### PR TITLE
Live playlist loading improvements

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -94,6 +94,7 @@
 
           // refresh live playlists after a target duration passes
           if (!loader.media().endList) {
+            window.clearTimeout(mediaUpdateTimeout);
             mediaUpdateTimeout = window.setTimeout(function() {
               loader.trigger('mediaupdatetimeout');
             }, refreshDelay);

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1035,7 +1035,7 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
   // bitrate switches should be happening here.
   translatedMediaIndex = (mediaIndex + (original.mediaSequence - update.mediaSequence));
 
-  if (translatedMediaIndex >= update.segments.length || translatedMediaIndex < 0) {
+  if (translatedMediaIndex > update.segments.length || translatedMediaIndex < 0) {
     // recalculate the live point if the streams are too far out of sync
     return videojs.Hls.getMediaIndexForLive_(update) + 1;
   }


### PR DESCRIPTION
We managed to fix the problems described in #236. This PR consists of two commits.

The repetition of chunks was caused because media index didn't need to be translated when changing quality. The playlist was the same and translation should not occur.

The second commit fixes crazy loading of playlists and chunks after several quality changes as timeouts accumulated and produced more and more requests.
