### PR TITLE
Fixes for HLS

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -791,6 +791,8 @@ videojs.Hls.prototype.drainBuffer = function(event) {
     decrypter,
     segIv,
     ptsTime,
+    tagPts,
+    tagIndex,
     segmentOffset = 0,
     segmentBuffer = this.segmentBuffer_;
 
@@ -889,14 +891,23 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   if (typeof offset === 'number') {
     ptsTime = offset - segmentOffset + tags[0].pts;
 
-    while (tags[i].pts < ptsTime) {
+    tagPts = tags[i].pts;
+    tagIndex = i;
+    while (tagPts < ptsTime) {
       i++;
+      if (tags[i] !== undefined) {
+        tagPts = tags[i].pts;
+        tagIndex = i;
+      }
+      else {
+        break;
+      }
     }
 
     // tell the SWF where we will be seeking to
-    this.el().vjs_setProperty('currentTime', (tags[i].pts - tags[0].pts + segmentOffset) * 0.001);
+    this.el().vjs_setProperty('currentTime', (tagPts - tags[0].pts + segmentOffset) * 0.001);
 
-    tags = tags.slice(i);
+    tags = tags.slice(tagIndex);
 
     this.lastSeekedTime_ = null;
   }
@@ -1125,14 +1136,15 @@ videojs.Hls.getMediaIndexByTime = function() {
  * @returns {number} The current time to that point, or 0 if none appropriate.
  */
 videojs.Hls.prototype.getCurrentTimeByMediaIndex_ = function(playlist, mediaIndex) {
-  var index, time = 0;
+  var index, time = 0, segment;
 
   if (!playlist.segments || mediaIndex === 0) {
     return 0;
   }
 
   for (index = 0; index < mediaIndex; index++) {
-    time += playlist.segments[index].duration;
+    segment = playlist.segments[index];
+    time += segment.preciseDuration || segment.duration || playlist.targetDuration || 0;
   }
 
   return time;


### PR DESCRIPTION
Let me explain what (and why) these fixes are necessary.

All these issues can be reproduced and checked with this sample content:
https://dl.dropboxusercontent.com/u/8261657/hls-vod-sample.zip

1.) There could be content with only one program (PMT) and with a non-standard network PID (NIT). In these cases there can be more than one PAT entry and I don't see why we shouldn't be able to play such content. In the first commit I check wether the PAT entry is a PMT or NIT pid and throw an error only if there are multiple PMT-s.

2.) I'm not sure why... but it appears that finishFrame can be called when the stream extraData hasn't been parsed yet. The issue has been introduced with the commit https://github.com/videojs/videojs-contrib-hls/commit/ce689aec49cc4e4234f98e3fdf0a501c6104be5d The additional check for existing extra data prevents crashing at playback start.

3.) If playlists contain "\r\n" line endings or even whitespace lines the m3u8 parser falsely detects those lines as "empty" segment URI-s. This results in faulty duration calculation and possible failure at playback start. By trimming line data before feeding it into the parser this issue is fixed.

4.) Once again... I'm not sure why. But sometimes during seeking within the sample content provided above there are no tags with desired pts values. This commit prevents crashing and fixes seeking in the provided sample. But there may be a problem in the logic somewhere else.