### PR TITLE
Trim whitespace in playlist

### DIFF
--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -70,7 +70,7 @@
       nextNewline = buffer.indexOf('\n');
 
       for (; nextNewline > -1; nextNewline = buffer.indexOf('\n')) {
-        this.trigger('data', buffer.substring(0, nextNewline).replace(/^\s+|\s+$/g, ''));
+        this.trigger('data', buffer.substring(0, nextNewline));
         buffer = buffer.substring(nextNewline + 1);
       }
     };
@@ -108,6 +108,9 @@
    */
   ParseStream.prototype.push = function(line) {
     var match, event;
+
+    //strip whitespace
+    line = line.replace(/^\s+|\s+$/g, '');
     if (line.length === 0) {
       // ignore empty lines
       return;

--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -70,7 +70,7 @@
       nextNewline = buffer.indexOf('\n');
 
       for (; nextNewline > -1; nextNewline = buffer.indexOf('\n')) {
-        this.trigger('data', buffer.substring(0, nextNewline));
+        this.trigger('data', buffer.substring(0, nextNewline).replace(/^\s+|\s+$/g, ''));
         buffer = buffer.substring(nextNewline + 1);
       }
     };

--- a/test/manifest/whiteSpace.js
+++ b/test/manifest/whiteSpace.js
@@ -1,0 +1,25 @@
+{
+  "allowCache": true,
+  "mediaSequence": 0,
+  "playlistType": "VOD",
+  "segments": [
+    {
+      "duration": 10,
+      "uri": "http://example.com/00001.ts"
+    },
+    {
+      "duration": 10,
+      "uri": "https://example.com/00002.ts"
+    },
+    {
+      "duration": 10,
+      "uri": "//example.com/00003.ts"
+    },
+    {
+      "duration": 10,
+      "uri": "http://example.com/00004.ts"
+    }
+  ],
+  "targetDuration": 10,
+  "endList": true
+}

--- a/test/manifest/whiteSpace.m3u8
+++ b/test/manifest/whiteSpace.m3u8
@@ -1,0 +1,14 @@
+#EXTM3U
+#EXT-X-PLAYLIST-TYPE:VOD
+#EXT-X-TARGETDURATION:10
+    
+#EXTINF:10,
+http://example.com/00001.ts 
+#EXTINF:10,
+ https://example.com/00002.ts
+#EXTINF:10,
+ //example.com/00003.ts 
+#EXTINF:10,
+	http://example.com/00004.ts
+#ZEN-TOTAL-DURATION:57.9911
+#EXT-X-ENDLIST


### PR DESCRIPTION
Fix from #279. 

> If playlists contain "\r\n" line endings or even whitespace lines the m3u8 parser falsely detects those lines as "empty" segment URI-s. This results in faulty duration calculation and possible failure at playback start. By trimming line data before feeding it into the parser this issue is fixed.