### PR TITLE
Ignore nit

### DIFF
--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -437,6 +437,9 @@
           // rest of header + CRC = 9 + 4
           pmtSectionLength -= 13;
 
+          // capture the PID of PCR packets so we can ignore them if we see any
+          self.stream.programMapTable.pcrPid = (data[offset + 8] & 0x1f) << 8 | data[offset + 9];
+
           // align offset to the first entry in the PMT
           offset += 12 + pmtProgramDescriptorsLength;
 
@@ -479,6 +482,10 @@
         // Service Description Table
       } else if (0x1FFF === pid) {
         // NULL packet
+      } else if (self.stream.programMapTable.pcrPid) {
+        // program clock reference (PCR) PID for the primary program
+        // PTS values are sufficient to synchronize playback for us so
+        // we can safely ignore these
       } else {
         videojs.log("Unknown PID parsing TS packet: " + pid);
       }

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -221,6 +221,9 @@
         patTableId, // :int
         patCurrentNextIndicator, // Boolean
         patSectionLength, // :uint
+        patNumEntries, // :uint
+        patNumPrograms, // :uint
+        patProgramOffset, // :uint
 
         pesPacketSize, // :int,
         dataAlignmentIndicator, // :Boolean,
@@ -302,8 +305,21 @@
           // raise an exception if we encounter one
           // section_length = rest of header + (n * entry length) + CRC
           // = 5 + (n * 4) + 4
-          if ((patSectionLength - 5 - 4) / 4 !== 1) {
+          patNumEntries = (patSectionLength - 5 - 4) / 4;
+          patNumPrograms = 0;
+          patProgramOffset = offset;
+          for (var entryIndex = 0; entryIndex < patNumEntries; entryIndex++) {
+            // network PID program number equals 0 and can be ignored
+            if (((data[offset + 4*entryIndex]) << 8 | data[offset + 4*entryIndex + 1]) > 0) {
+                patNumPrograms++;
+                patProgramOffset = offset + 4*entryIndex;
+            }
+          }
+          if (patNumPrograms !== 1) {
             throw new Error("TS has more that 1 program");
+          }
+          else {
+            offset = patProgramOffset;
           }
 
           // the Program Map Table (PMT) associates the underlying


### PR DESCRIPTION
Cherry-picked and rebased version of the NIT fix in #279. Also, added handling for PCR PIDs so that a bunch of spurious warnings aren't generated.

@mikrohard I updated your change so that console warnings wouldn't be generated for NIT packets. This still look good to you?