### PR TITLE
Don't add metadata at random access indicators

### DIFF
--- a/src/h264-stream.js
+++ b/src/h264-stream.js
@@ -48,11 +48,9 @@
 
     this._state = 0; // :uint;
 
-    this._nextFrameKeyFrame = false;
-
     this.tags = [];
-
   };
+
   //(pts:uint):void
   H264Stream.prototype.setTimeStampOffset = function(pts) {
     this._pts_offset = pts;
@@ -95,11 +93,6 @@
     this._h264Frame = null;
     this._nalUnitType = -1;
     this._state = 0;
-  };
-
-
-  H264Stream.prototype.setNextFrameKeyFrame = function() {
-    this._nextFrameKeyFrame = true;
   };
 
   // (data:ByteArray, o:int, l:int):void
@@ -263,11 +256,6 @@
         this._h264Frame = new FlvTag(FlvTag.VIDEO_TAG);
         this._h264Frame.pts = this._next_pts;
         this._h264Frame.dts = this._next_dts;
-
-        if (this._nextFrameKeyFrame) {
-          this._h264Frame.keyFrame = true;
-          this._nextFrameKeyFrame = false;
-        }
       }
 
       this._h264Frame.startNalUnit();

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -214,9 +214,6 @@
         // adaptation_field_control, whether this header is followed by an
         // adaptation field, a payload, or both
         afflag = (data[offset + 3] & 0x30 ) >>> 4,
-        adaptationFieldLength,
-        afftemp,
-        randomAccessIndicator,
 
         patTableId, // :int
         patCurrentNextIndicator, // Boolean
@@ -253,19 +250,7 @@
       // used to specify some forms of timing and control data that we
       // do not currently use.
       if (afflag > 0x01) {
-        adaptationFieldLength = data[offset];
-
-        if (adaptationFieldLength > 0) {
-          afftemp = data[offset + 1];
-
-          randomAccessIndicator = (afftemp & 0x40) >>> 6;
-
-          if (randomAccessIndicator === 1) {
-            h264Stream.setNextFrameKeyFrame();
-          }
-        }
-
-        offset += adaptationFieldLength + 1;
+        offset += data[offset] + 1;
       }
 
       // Handle a Program Association Table (PAT). PATs map PIDs to


### PR DESCRIPTION
A metadata tag injected into the generated FLV when a random access indicator was encountered in the adaptation field of a TS packet causes Firefox 38 on OSX to apply frame diffs against the wrong keyframe. This leads to ugly artifacts for a few seconds after seeking. Now metadata tags are only generated at the start of a segment and IDRs. Fixes #289.