### PR TITLE
Fix seek after end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+_(none)_
+
+--------------------
+
+## 0.17.3 (2015-06-29)
 * @dmlap improved video duration calculation. ([view](https://github.com/videojs/videojs-contrib-hls/pull/321))
 * Clamp seeks to the seekable range ([view](https://github.com/videojs/videojs-contrib-hls/pull/327))
 * Use getComputedStyle for player dimensions when filtering variants ([view](https://github.com/videojs/videojs-contrib-hls/pull/326))
 * Add a functional test that runs in SauceLabs ([view](https://github.com/videojs/videojs-contrib-hls/pull/323))
-
---------------------
 
 ## 0.17.2 (2015-06-15)
 * @dmlap fix seeking in live streams ([view](https://github.com/videojs/videojs-contrib-hls/pull/308))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-hls",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "engines": {
     "node": ">= 0.10.12"
   },

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -318,7 +318,13 @@ videojs.Hls.prototype.setupMetadataCueTranslation_ = function() {
  */
 videojs.Hls.prototype.play = function() {
   if (this.ended()) {
-    this.mediaIndex = 0;
+    if (this.currentTime() === 0 || this.currentTime() === undefined || this.currentTime() === this.duration()) {
+      this.mediaIndex = 0;
+      this.setCurrentTime(0);
+    } else {
+      this.mediaIndex = videojs.Hls.getMediaIndexByTime(this.playlists.media(), this.currentTime());
+      this.setCurrentTime(this.currentTime());
+    }
   }
 
   // we may need to seek to begin playing safely for live playlists

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -318,17 +318,15 @@ videojs.Hls.prototype.setupMetadataCueTranslation_ = function() {
  */
 videojs.Hls.prototype.play = function() {
   if (this.ended()) {
-    // When the video ends and the 'ended' event fires, current time is set to 0. If the video is in this state, or the
-    // current time is equal to the duration (ie, play head is at the end position), reset the video to the beginning on
-    // a play event.
-    if (this.currentTime() === 0 || this.currentTime() === this.duration()) {
-      this.mediaIndex = 0;
-      this.setCurrentTime(0);
-    // Otherwise, if the user has seeked to another point in the video after the 'ended' event, it is likely the case
-    // that they wish to restart playback from that point, so play from the play head's position.
-    } else {
+    // If this.lastSeekedTime_ is defined, a seek has happened after playback ended, as it is set undefined at video end.
+    // We should begin playback from that point.
+    if (this.lastSeekedTime_ !== undefined) {
       this.mediaIndex = videojs.Hls.getMediaIndexByTime(this.playlists.media(), this.currentTime());
       this.setCurrentTime(this.currentTime());
+    // Otherwise, reset the playback point to 0 so that a video restarts from the beginning
+    } else {
+      this.mediaIndex = 0;
+      this.setCurrentTime(0);
     }
   }
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -320,12 +320,7 @@ videojs.Hls.prototype.play = function() {
   if (this.ended()) {
     // If this.lastSeekedTime_ is defined, a seek has happened after playback ended, as it is set undefined at video end.
     // We should begin playback from that point.
-    if (this.lastSeekedTime_ !== undefined) {
-      this.mediaIndex = videojs.Hls.getMediaIndexByTime(this.playlists.media(), this.currentTime());
-      this.setCurrentTime(this.currentTime());
-    // Otherwise, reset the playback point to 0 so that a video restarts from the beginning
-    } else {
-      this.mediaIndex = 0;
+    if (this.lastSeekedTime_ === undefined) {
       this.setCurrentTime(0);
     }
   }
@@ -959,6 +954,7 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   // the playlist
   if (this.duration() !== Infinity && mediaIndex + 1 === playlist.segments.length) {
     this.mediaSource.endOfStream();
+    this.lastSeekedTime_ = undefined;
   }
 };
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -318,9 +318,14 @@ videojs.Hls.prototype.setupMetadataCueTranslation_ = function() {
  */
 videojs.Hls.prototype.play = function() {
   if (this.ended()) {
-    if (this.currentTime() === 0 || this.currentTime() === undefined || this.currentTime() === this.duration()) {
+    // When the video ends and the 'ended' event fires, current time is set to 0. If the video is in this state, or the
+    // current time is equal to the duration (ie, play head is at the end position), reset the video to the beginning on
+    // a play event.
+    if (this.currentTime() === 0 || this.currentTime() === this.duration()) {
       this.mediaIndex = 0;
       this.setCurrentTime(0);
+    // Otherwise, if the user has seeked to another point in the video after the 'ended' event, it is likely the case
+    // that they wish to restart playback from that point, so play from the play head's position.
     } else {
       this.mediaIndex = videojs.Hls.getMediaIndexByTime(this.playlists.media(), this.currentTime());
       this.setCurrentTime(this.currentTime());

--- a/test/functional/protractor.config.js
+++ b/test/functional/protractor.config.js
@@ -23,7 +23,7 @@ if (process.env.SAUCE_USERNAME) {
   config.maxDuration = 300;
 }
 
-config.baseUrl = 'http://localhost:9999/example.html';
+config.baseUrl = 'http://127.0.0.1:9999/example.html';
 config.specs = ['spec.js'];
 
 config.framework = 'jasmine2';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -133,7 +133,7 @@ module.exports = function(config) {
 
     // global config for SauceLabs
     sauceLabs: {
-      startConnect: true,
+      startConnect: false,
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
       build: process.env.TRAVIS_BUILD_NUMBER,
       testName: process.env.TRAVIS_BUILD_NUMBER + process.env.TRAVIS_BRANCH,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,8 +10,7 @@ module.exports = function(config) {
       singleRun: true,
       base: 'SauceLabs',
       browserName: 'chrome',
-      platform: 'Windows 7',
-      version: '34'
+      platform: 'Windows 7'
     },
 
     firefox_sl: {

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -2723,4 +2723,25 @@ test('does not download segments if preload option set to none', function() {
   strictEqual(loadedSegments, 0, 'did not download any segments');
 });
 
+test('mediaIndex is not set to 0 when seeking after playback end', function() {
+  player.src({
+    src: 'master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  openMediaSource(player);
+  standardXHRResponse(requests.shift()); // master
+  standardXHRResponse(requests.shift()); // media
+
+  player.ended = function() {
+    return true;
+  };
+
+  player.currentTime(30);
+
+  player.play();
+
+  strictEqual(player.hls.mediaIndex, 3, 'media index is non-zero');
+});
+
 })(window, window.videojs);

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -2749,7 +2749,7 @@ test('mediaIndex is not set to 0 when seeking after playback end', function() {
 
   player.play();
 
-  strictEqual(player.hls.mediaIndex, 3, 'media index is non-zero');
+  strictEqual(player.hls.mediaIndex, 2, 'media index is non-zero');
 });
 
 })(window, window.videojs);

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -2247,6 +2247,12 @@ test('calling play() at the end of a video resets the media index', function() {
                            '#EXT-X-ENDLIST\n');
   standardXHRResponse(requests.shift());
 
+  player.el().querySelector('.vjs-tech').vjs_getProperty = function(property) {
+    if (property === 'currentTime') {
+      return player.hls.mediaIndex * 10;
+    }
+  };
+
   strictEqual(player.hls.mediaIndex, 1, 'index is 1 after the first segment');
   player.hls.ended = function() {
     return true;
@@ -2254,6 +2260,8 @@ test('calling play() at the end of a video resets the media index', function() {
 
   player.play();
   strictEqual(player.hls.mediaIndex, 0, 'index is 1 after the first segment');
+
+  player.el().querySelector('.vjs-tech').vjs_getProperty = function() {};
 });
 
 test('drainBuffer will not proceed with empty source buffer', function() {


### PR DESCRIPTION
Seeking after ‘ended’ event would cause the player to begin playback at
the beginning, but count up from the seek point timestamp. Now it will
play from the seek point.