### PR TITLE
Account for expired segments when seeking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-hls",
-  "version": "0.17.1",
+  "version": "0.17.2-0",
   "engines": {
     "node": ">= 0.10.12"
   },

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -317,7 +317,6 @@ videojs.Hls.prototype.setupMetadataCueTranslation_ = function() {
  * ended.
  */
 videojs.Hls.prototype.play = function() {
-  var media;
   if (this.ended()) {
     this.mediaIndex = 0;
   }
@@ -327,9 +326,7 @@ videojs.Hls.prototype.play = function() {
   if (this.duration() === Infinity &&
       this.playlists.media() &&
       !this.player().hasClass('vjs-has-started')) {
-    media = this.playlists.media();
-    this.mediaIndex = videojs.Hls.getMediaIndexForLive_(media);
-    this.setCurrentTime(videojs.Hls.Playlist.seekable(media).end(0));
+    this.setCurrentTime(this.seekable().end(0));
   }
 
   // delegate back to the Flash implementation
@@ -645,7 +642,8 @@ videojs.Hls.prototype.fillBuffer = function(offset) {
   // being buffering so we don't preload data that will never be
   // played
   if (!this.playlists.media().endList &&
-      !this.player().hasClass('vjs-has-started')) {
+      !this.player().hasClass('vjs-has-started') &&
+      offset === undefined) {
     return;
   }
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -99,6 +99,10 @@ videojs.Hls.prototype.src = function(src) {
     this.playlists.dispose();
   }
 
+  // The index of the next segment to be downloaded in the current
+  // media playlist. When the current media playlist is live with
+  // expiring segments, it may be a different value from the media
+  // sequence number for a segment.
   this.mediaIndex = 0;
 
   this.playlists = new videojs.Hls.PlaylistLoader(this.src_, settings.withCredentials);
@@ -360,7 +364,7 @@ videojs.Hls.prototype.setCurrentTime = function(currentTime) {
   this.lastSeekedTime_ = currentTime;
 
   // determine the requested segment
-  this.mediaIndex = videojs.Hls.getMediaIndexByTime(this.playlists.media(), currentTime);
+  this.mediaIndex = this.playlists.getMediaIndexForTime_(currentTime);
 
   // abort any segments still being decoded
   this.sourceBuffer.abort();
@@ -1103,41 +1107,14 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
 };
 
 /**
- * Determine the media index in one playlist by a time in seconds. This
- * function iterates through the segments of a playlist and creates TimeRange
- * objects for each and then returns the most appropriate segment index by
- * checking the time value versus each range.
+ * Deprecated.
  *
- * @param playlist {object} The playlist of the segments being searched.
- * @param time {number} The time in seconds of what segment you want.
- * @returns {number} The media index, or -1 if none appropriate.
+ * @deprecated use player.hls.playlists.getMediaIndexForTime_() instead
  */
-videojs.Hls.getMediaIndexByTime = function(playlist, time) {
-  var index, counter, timeRanges, currentSegmentRange;
-
-  if (time === 0) {
-    return 0;
-  }
-
-  timeRanges = [];
-  for (index = 0; index < playlist.segments.length; index++) {
-    currentSegmentRange = {};
-    currentSegmentRange.start = (index === 0) ? 0 : timeRanges[index - 1].end;
-    currentSegmentRange.end = currentSegmentRange.start + playlist.segments[index].duration;
-    timeRanges.push(currentSegmentRange);
-  }
-
-  if (time >= timeRanges[timeRanges.length - 1].end) {
-    return (playlist.segments.length - 1);
-  }
-
-  for (counter = 0; counter < timeRanges.length; counter++) {
-    if (time >= timeRanges[counter].start && time < timeRanges[counter].end) {
-      return counter;
-    }
-  }
-
-  return -1;
+videojs.Hls.getMediaIndexByTime = function() {
+  videojs.log.warn('getMediaIndexByTime is deprecated. ' +
+                   'Use PlaylistLoader.getMediaIndexForTime_ instead.');
+  return 0;
 };
 
 /**

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1115,12 +1115,20 @@ videojs.Hls.translateMediaIndex = function(mediaIndex, original, update) {
 videojs.Hls.getMediaIndexByTime = function(playlist, time) {
   var index, counter, timeRanges, currentSegmentRange;
 
+  if (time === 0) {
+    return 0;
+  }
+
   timeRanges = [];
   for (index = 0; index < playlist.segments.length; index++) {
     currentSegmentRange = {};
     currentSegmentRange.start = (index === 0) ? 0 : timeRanges[index - 1].end;
     currentSegmentRange.end = currentSegmentRange.start + playlist.segments[index].duration;
     timeRanges.push(currentSegmentRange);
+  }
+
+  if (time >= timeRanges[timeRanges.length - 1].end) {
+    return (playlist.segments.length - 1);
   }
 
   for (counter = 0; counter < timeRanges.length; counter++) {

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1728,6 +1728,24 @@ test('mediaIndex is zero before the first segment loads', function() {
   strictEqual(player.hls.mediaIndex, 0, 'mediaIndex is zero');
 });
 
+test('mediaIndex returns correctly at playlist boundaries', function() {
+  player.src({
+    src: 'http://example.com/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  openMediaSource(player);
+  standardXHRResponse(requests.shift()); // master
+  standardXHRResponse(requests.shift()); // media
+
+  strictEqual(player.hls.mediaIndex, 0, 'mediaIndex is zero at first segment');
+
+  // seek to end
+  player.currentTime(40);
+
+  strictEqual(player.hls.mediaIndex, 3, 'mediaIndex is 3 at last segment');
+});
+
 test('reloads out-of-date live playlists when switching variants', function() {
   player.src({
     src: 'http://example.com/master.m3u8',

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1937,18 +1937,19 @@ test('continues playing after seek to discontinuity', function() {
     '#EXTINF:10,0\n' +
     '2.ts\n' +
     '#EXT-X-ENDLIST\n');
-  standardXHRResponse(requests.pop());
+  standardXHRResponse(requests.pop()); // 1.ts
 
   currentTime = 1;
   bufferEnd = 10;
   player.hls.checkBuffer_();
 
-  standardXHRResponse(requests.pop());
+  standardXHRResponse(requests.pop()); // 2.ts
 
   // seek to the discontinuity
   player.currentTime(10);
   tags.push({ pts: 0, bytes: new Uint8Array(1) });
-  standardXHRResponse(requests.pop());
+  tags.push({ pts: 11 * 1000, bytes: new Uint8Array(1) });
+  standardXHRResponse(requests.pop()); // 1.ts, again
   strictEqual(aborts, 1, 'aborted once for the seek');
 
   // the source buffer empties. is 2.ts still in the segment buffer?

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -1663,19 +1663,33 @@ test('updates the media index when a playlist reloads', function() {
 test('live playlist starts three target durations before live', function() {
   var mediaPlaylist;
   player.src({
-    src: 'http://example.com/manifest/liveStart30sBefore.m3u8',
+    src: 'live.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
-  standardXHRResponse(requests.shift());
+  requests.shift().respond(200, null,
+                           '#EXTM3U\n' +
+                           '#EXT-X-MEDIA-SEQUENCE:101\n' +
+                           '#EXTINF:10,\n' +
+                           '0.ts\n' +
+                           '#EXTINF:10,\n' +
+                           '1.ts\n' +
+                           '#EXTINF:10,\n' +
+                           '2.ts\n' +
+                           '#EXTINF:10,\n' +
+                           '3.ts\n' +
+                           '#EXTINF:10,\n' +
+                           '4.ts\n');
 
   equal(player.hls.mediaIndex, 0, 'waits for the first play to start buffering');
   equal(requests.length, 0, 'no outstanding segment request');
 
   player.play();
   mediaPlaylist = player.hls.playlists.media();
-  equal(player.hls.mediaIndex, 6, 'mediaIndex is updated at play');
-  equal(player.currentTime(), videojs.Hls.Playlist.seekable(mediaPlaylist).end(0));
+  equal(player.hls.mediaIndex, 1, 'mediaIndex is updated at play');
+  equal(player.currentTime(), player.seekable().end(0));
+
+  equal(requests.length, 1, 'begins buffering');
 });
 
 test('does not reset live currentTime if mediaIndex is one beyond the last available segment', function() {


### PR DESCRIPTION
Deprecate getMediaIndexByTime and replace it with a PlaylistLoader.getMediaIndexForTime_ that considers expired content in live playlists. Fix an issues that would allow the return value to be less than zero or greater than the index of the last available media segment. Currently, this code does not take into account rounding of segment durations in HLS v3.