### PR TITLE
Add github-releaser config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ _(none)_
 --------------------
 
 ## 0.17.2 (2015-06-15)
-
 * @dmlap fix seeking in live streams ([view](https://github.com/videojs/videojs-contrib-hls/pull/308))
 
 ## 0.17.1 (2015-06-08)

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,11 +3,12 @@
 var basename = require('path').basename;
 
 module.exports = function(grunt) {
+  var pkg = grunt.file.readJSON('package.json');
 
   // Project configuration.
   grunt.initConfig({
     // Metadata.
-    pkg: grunt.file.readJSON('package.json'),
+    pkg: pkg,
     banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
       '<%= grunt.template.today("yyyy-mm-dd") %>\n' +
       '* Copyright (c) <%= grunt.template.today("yyyy") %> Brightcove;' +
@@ -116,6 +117,23 @@ module.exports = function(grunt) {
     version: {
       project: {
         src: ['package.json']
+      }
+    },
+    'github-release': {
+      options: {
+        repository: 'videojs/videojs-contrib-hls',
+        auth: {
+          user: process.env.VJS_GITHUB_USER,
+          password: process.env.VJS_GITHUB_TOKEN
+        },
+        release: {
+          'tag_name': 'v' + pkg.version,
+          name: pkg.version,
+          body: require('chg').find(pkg.version).changesRaw
+        }
+      },
+      files: {
+        'dist': ['videojs.hls.min.js']
       }
     },
     karma: {


### PR DESCRIPTION
Setup grunt-github-releaser for subsequent releases. Remove a leading newline that caused chg to mis-parse the changelog for 0.17.2.