### PR TITLE
Run non-PR karma tests in Sauce Labs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -351,11 +351,13 @@ module.exports = function(grunt) {
 
     grunt.task.run(['jshint', 'manifests-to-js']);
 
-    if (process.env.TRAVIS_PULL_REQUEST) {
-      grunt.task.run(['karma:phantomjs']);
-    } else if (process.env.TRAVIS) {
-      grunt.task.run(['karma:saucelabs']);
-      grunt.task.run(['connect:test', 'protractor:saucelabs']);
+    if (process.env.TRAVIS) {
+      if (process.env.TRAVIS_PULL_REQUEST === 'false') {
+        grunt.task.run(['karma:saucelabs']);
+        grunt.task.run(['connect:test', 'protractor:saucelabs']);
+      } else {
+        grunt.task.run(['karma:phantomjs']);
+      }
     } else {
       if (tasks.length === 0) {
         tasks.push('chrome');

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -61,7 +61,7 @@ module.exports = function(config) {
     customLaunchers: customLaunchers,
 
     // Start these browsers
-    browsers: ['chrome_sl', 'ipad_sl'], //Object.keys(customLaunchers),
+    browsers: ['chrome_sl', 'firefox_sl'], //Object.keys(customLaunchers),
 
     // List of files / patterns to load in the browser
     // Add any new src files to this list.


### PR DESCRIPTION
This fix is to get the karma tests in the main Travis builds to use Sauce Labs. Currently the karma tests are using phantomjs because `TRAVIS_PULL_REQUEST` is 'false'.