### PR TITLE
Properly parse CR+LF on Windows when generating manifests file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -299,7 +299,7 @@ module.exports = function(grunt) {
         // translate this manifest
         jsManifests += '  \'' + basename(filename, '.m3u8') + '\': ' +
           grunt.file.read(abspath)
-            .split('\n')
+            .split(/\r\n|\n/)
 
             // quote and concatenate
             .map(function(line) {


### PR DESCRIPTION
I had problems with running grunt karma tests on Windows as manifests file was not generated properly, The reason is that grunt seems to read files with Windows CR+LF line endings. This PR updates split function to also split on them.