### PR TITLE
Fix grunt-protractor-runner dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -222,7 +222,8 @@ module.exports = function(grunt) {
     },
     protractor: {
       options: {
-        configFile: 'test/functional/protractor.config.js'
+        configFile: 'test/functional/protractor.config.js',
+        webdriverManagerUpdate: process.env.TRAVIS ? false : true
       },
 
       chrome: {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-github-releaser": "^0.1.17",
     "grunt-karma": "~0.6.2",
     "grunt-open": "0.2.3",
-    "grunt-protractor-runner": "git+https://github.com/forbesjo/grunt-protractor-runner.git#update-webdriver",
+    "grunt-protractor-runner": "git+https://github.com/forbesjo/grunt-protractor-runner.git#webdriverManagerUpdate",
     "grunt-shell": "0.6.1",
     "grunt-version": "^1.0.0",
     "karma": "~0.10.0",


### PR DESCRIPTION
I've added an option to grunt-protractor-runner to install the selenium drivers during the protractor task instead of always installing with grunt-protractor-runner. I added this option for situations where a user would not want to install the drivers in the CI environment.