### PR TITLE
Don't prepublish in Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt"
+    "prepublish": "if [ -z \"$TRAVIS\" ]; then grunt; fi"
   },
   "keywords": [
     "videojs",


### PR DESCRIPTION
The Travis's Sauce Connect doesn't get to start between npm install and prepublish. Only prepublish locally.