### PR TITLE
More duration updates

### DIFF
--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -375,7 +375,8 @@
 
     // the manifest is empty until the parse stream begins delivering data
     this.manifest = {
-      allowCache: true
+      allowCache: true,
+      discontinuityStarts: []
     };
 
     // update the manifest with the m3u8 entry from the parse stream
@@ -513,6 +514,7 @@
             },
             'discontinuity': function() {
               currentUri.discontinuity = true;
+              this.manifest.discontinuityStarts.push(uris.length);
             },
             'targetduration': function() {
               if (!isFinite(entry.duration) || entry.duration < 0) {

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -431,11 +431,12 @@
     for (i = 0; i < this.media_.segments.length; i++) {
       time -= Playlist.duration(this.media_,
                                 this.media_.mediaSequence + i,
-                                this.media_.mediaSequence + i + 1);
+                                this.media_.mediaSequence + i + 1,
+                                true);
 
       // HLS version 3 and lower round segment durations to the
       // nearest decimal integer. When the correct media index is
-      // ambiguous, prefer the lower one.
+      // ambiguous, prefer the higher one.
       if (time <= 0) {
         return i;
       }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -432,7 +432,7 @@
       time -= Playlist.duration(this.media_,
                                 this.media_.mediaSequence + i,
                                 this.media_.mediaSequence + i + 1,
-                                true);
+                                false);
 
       // HLS version 3 and lower round segment durations to the
       // nearest decimal integer. When the correct media index is

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -31,15 +31,6 @@
     // allow in-band metadata to be observed
     self.metadataStream = new MetadataStream();
 
-    this.mediaTimelineOffset = null;
-
-    // The first timestamp value encountered during parsing. This
-    // value can be used to determine the relative timing between
-    // frames and the start of the current timestamp sequence. It
-    // should be reset to null before parsing a segment with
-    // discontinuous timestamp values from previous segments.
-    self.timestampOffset = null;
-
     // For information on the FLV format, see
     // http://download.macromedia.com/f4v/video_file_format_spec_v10_1.pdf.
     // Technically, this function returns the header and a metadata FLV tag
@@ -359,13 +350,6 @@
 
           // Skip past "optional" portion of PTS header
           offset += pesHeaderLength;
-
-          // keep track of the earliest encounted PTS value so
-          // external parties can align timestamps across
-          // discontinuities
-          if (self.timestampOffset === null) {
-            self.timestampOffset = pts;
-          }
 
           if (pid === self.stream.programMapTable[STREAM_TYPES.h264]) {
             h264Stream.setNextTimeStamp(pts,

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -890,13 +890,6 @@ videojs.Hls.prototype.drainBuffer = function(event) {
 
   event = event || {};
 
-  // if this segment starts is the start of a new discontinuity
-  // sequence, the segment parser's timestamp offset must be
-  // re-calculated
-  if (segment.discontinuity) {
-    this.segmentParser_.timestampOffset = null;
-  }
-
   // transmux the segment data from MP2T to FLV
   this.segmentParser_.parseSegmentBinaryData(bytes);
   this.segmentParser_.flushTags();

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1151,30 +1151,6 @@ videojs.Hls.getMediaIndexByTime = function() {
 };
 
 /**
- * Determine the current time in seconds in one playlist by a media index. This
- * function iterates through the segments of a playlist up to the specified index
- * and then returns the time up to that point.
- *
- * @param playlist {object} The playlist of the segments being searched.
- * @param mediaIndex {number} The index of the target segment in the playlist.
- * @returns {number} The current time to that point, or 0 if none appropriate.
- */
-videojs.Hls.prototype.getCurrentTimeByMediaIndex_ = function(playlist, mediaIndex) {
-  var index, time = 0, segment;
-
-  if (!playlist.segments || mediaIndex === 0) {
-    return 0;
-  }
-
-  for (index = 0; index < mediaIndex; index++) {
-    segment = playlist.segments[index];
-    time += segment.preciseDuration || segment.duration || playlist.targetDuration || 0;
-  }
-
-  return time;
-};
-
-/**
  * A comparator function to sort two playlist object by bandwidth.
  * @param left {object} a media playlist object
  * @param right {object} a media playlist object

--- a/test/manifest/absoluteUris.js
+++ b/test/manifest/absoluteUris.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/allowCache.js
+++ b/test/manifest/allowCache.js
@@ -142,5 +142,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/allowCacheInvalid.js
+++ b/test/manifest/allowCacheInvalid.js
@@ -14,5 +14,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/brightcove.js
+++ b/test/manifest/brightcove.js
@@ -41,5 +41,6 @@
       },
       "uri": "http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001"
     }
-  ]
+  ],
+  "discontinuityStarts": []
 }

--- a/test/manifest/byteRange.js
+++ b/test/manifest/byteRange.js
@@ -138,5 +138,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/disallowCache.js
+++ b/test/manifest/disallowCache.js
@@ -14,5 +14,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/disc-sequence.js
+++ b/test/manifest/disc-sequence.js
@@ -22,5 +22,6 @@
     }
   ],
   "targetDuration": 19,
-  "endList": true
+  "endList": true,
+  "discontinuityStarts": [2]
 }

--- a/test/manifest/discontinuity.js
+++ b/test/manifest/discontinuity.js
@@ -44,5 +44,6 @@
     }
   ],
   "targetDuration": 19,
-  "endList": true
+  "endList": true,
+  "discontinuityStarts": [2, 4, 7]
 }

--- a/test/manifest/domainUris.js
+++ b/test/manifest/domainUris.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/emptyAllowCache.js
+++ b/test/manifest/emptyAllowCache.js
@@ -14,5 +14,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/emptyMediaSequence.js
+++ b/test/manifest/emptyMediaSequence.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/emptyPlaylistType.js
+++ b/test/manifest/emptyPlaylistType.js
@@ -29,5 +29,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/emptyTargetDuration.js
+++ b/test/manifest/emptyTargetDuration.js
@@ -41,5 +41,6 @@
       },
       "uri": "http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001"
     }
-  ]
+  ],
+  "discontinuityStarts": []
 }

--- a/test/manifest/encrypted.js
+++ b/test/manifest/encrypted.js
@@ -2,6 +2,7 @@
   "allowCache": true,
   "mediaSequence": 7794,
   "discontinuitySequence": 0,
+  "discontinuityStarts": [],
   "segments": [
     {
       "duration": 2.833,

--- a/test/manifest/event.js
+++ b/test/manifest/event.js
@@ -30,5 +30,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/extXPlaylistTypeInvalidPlaylist.js
+++ b/test/manifest/extXPlaylistTypeInvalidPlaylist.js
@@ -9,5 +9,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/extinf.js
+++ b/test/manifest/extinf.js
@@ -142,5 +142,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/invalidAllowCache.js
+++ b/test/manifest/invalidAllowCache.js
@@ -14,5 +14,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/invalidMediaSequence.js
+++ b/test/manifest/invalidMediaSequence.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/invalidPlaylistType.js
+++ b/test/manifest/invalidPlaylistType.js
@@ -29,5 +29,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/invalidTargetDuration.js
+++ b/test/manifest/invalidTargetDuration.js
@@ -141,5 +141,6 @@
     }
   ],
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/liveMissingSegmentDuration.js
+++ b/test/manifest/liveMissingSegmentDuration.js
@@ -17,5 +17,6 @@
     }
   ],
   "targetDuration": 8,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/liveStart30sBefore.js
+++ b/test/manifest/liveStart30sBefore.js
@@ -40,5 +40,6 @@
     }
   ],
   "targetDuration": 10,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/manifestExtTTargetdurationNegative.js
+++ b/test/manifest/manifestExtTTargetdurationNegative.js
@@ -8,5 +8,6 @@
     }
   ],
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/manifestExtXEndlistEarly.js
+++ b/test/manifest/manifestExtXEndlistEarly.js
@@ -25,5 +25,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/manifestNoExtM3u.js
+++ b/test/manifest/manifestNoExtM3u.js
@@ -9,5 +9,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/master.js
+++ b/test/manifest/master.js
@@ -41,5 +41,6 @@
       },
       "uri": "media3.m3u8"
     }
-  ]
+  ],
+  "discontinuityStarts": []
 }

--- a/test/manifest/media.js
+++ b/test/manifest/media.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/mediaSequence.js
+++ b/test/manifest/mediaSequence.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/missingEndlist.js
+++ b/test/manifest/missingEndlist.js
@@ -12,5 +12,6 @@
     }
   ],
   "targetDuration": 10,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/missingExtinf.js
+++ b/test/manifest/missingExtinf.js
@@ -18,5 +18,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/missingMediaSequence.js
+++ b/test/manifest/missingMediaSequence.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/missingSegmentDuration.js
+++ b/test/manifest/missingSegmentDuration.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/multipleTargetDurations.js
+++ b/test/manifest/multipleTargetDurations.js
@@ -19,5 +19,6 @@
       "duration": 10
     }
   ],
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/negativeMediaSequence.js
+++ b/test/manifest/negativeMediaSequence.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/playlist.js
+++ b/test/manifest/playlist.js
@@ -142,5 +142,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/playlistMediaSequenceHigher.js
+++ b/test/manifest/playlistMediaSequenceHigher.js
@@ -10,5 +10,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/streamInfInvalid.js
+++ b/test/manifest/streamInfInvalid.js
@@ -10,5 +10,6 @@
     {
       "uri": "media1.m3u8"
     }
-  ]
+  ],
+  "discontinuityStarts": []
 }

--- a/test/manifest/twoMediaSequences.js
+++ b/test/manifest/twoMediaSequences.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 8,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/versionInvalid.js
+++ b/test/manifest/versionInvalid.js
@@ -10,5 +10,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/manifest/whiteSpace.js
+++ b/test/manifest/whiteSpace.js
@@ -22,5 +22,6 @@
   ],
   "targetDuration": 10,
   "endList": true,
-  "discontinuitySequence": 0
+  "discontinuitySequence": 0,
+  "discontinuityStarts": []
 }

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -2710,12 +2710,13 @@ test('treats invalid keys as a key request failure', function() {
   equal(bytes[0], 'flv', 'appended the flv header');
 
   tags.length = 0;
-  tags.push({ pts: 1, bytes: new Uint8Array([1]) });
+  tags.push({ pts: 2833, bytes: new Uint8Array([1]) },
+            { pts: 4833, bytes: new Uint8Array([2]) });
   // second segment request
   standardXHRResponse(requests.shift());
 
   equal(bytes.length, 2, 'appended bytes');
-  deepEqual(new Uint8Array([1]), bytes[1], 'skipped to the second segment');
+  deepEqual(bytes[1], new Uint8Array([1, 2]), 'skipped to the second segment');
 });
 
 test('live stream should not call endOfStream', function(){

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -104,8 +104,6 @@ var
         return 'flv';
       };
       this.parseSegmentBinaryData = function() {};
-      this.timestampOffset = 0;
-      this.mediaTimelineOffset = 0;
       this.flushTags = function() {};
       this.tagsAvailable = function() {
         return tags.length;
@@ -1344,9 +1342,6 @@ test('translates ID3 PTS values to cue media timeline positions', function() {
   openMediaSource(player);
 
   player.hls.segmentParser_.parseSegmentBinaryData = function() {
-    // setup the timestamp offset
-    this.timestampOffset = tags[0].pts;
-
     // trigger a metadata event
     player.hls.segmentParser_.metadataStream.trigger('data', {
       pts: 5 * 1000,
@@ -1375,9 +1370,6 @@ test('translates ID3 PTS values across discontinuities', function() {
   openMediaSource(player);
 
   player.hls.segmentParser_.parseSegmentBinaryData = function() {
-    if (this.timestampOffset === null) {
-      this.timestampOffset = tags[0].pts;
-    }
     // trigger a metadata event
     if (events.length) {
       player.hls.segmentParser_.metadataStream.trigger('data', events.shift());
@@ -1395,7 +1387,6 @@ test('translates ID3 PTS values across discontinuities', function() {
                            '1.ts\n');
 
   // segment 0 starts at PTS 14000 and has a cue point at 15000
-  player.hls.segmentParser_.timestampOffset = 14 * 1000;
   tags.push({ pts: 14 * 1000, bytes: new Uint8Array(1) },
             { pts: 24 * 1000, bytes: new Uint8Array(1) });
   events.push({


### PR DESCRIPTION
Pulled in #279 so that seeking "between segments" does not cause an error. Updated duration calculation so that PTS-based results are used for the largest span of segments possible. Previously, PTS values were only used to calculate duration when they formed a continuous interval. This is a lot more conservative than necessary because PTS values are directly comparable unless there is a discontinuity between their containing segments. This method should result in more accurate calculations and get rid of some unnecessary segment iteration.