### PR TITLE
Duration should work when video or audio is missing

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -899,10 +899,14 @@ videojs.Hls.prototype.drainBuffer = function(event) {
   if (this.segmentParser_.tagsAvailable()) {
     // record PTS information for the segment so we can calculate
     // accurate durations and seek reliably
-    segment.minVideoPts = this.segmentParser_.stats.minVideoPts();
-    segment.maxVideoPts = this.segmentParser_.stats.maxVideoPts();
-    segment.minAudioPts = this.segmentParser_.stats.minAudioPts();
-    segment.maxAudioPts = this.segmentParser_.stats.maxAudioPts();
+    if (this.segmentParser_.stats.h264Tags()) {
+      segment.minVideoPts = this.segmentParser_.stats.minVideoPts();
+      segment.maxVideoPts = this.segmentParser_.stats.maxVideoPts();
+    }
+    if (this.segmentParser_.stats.aacTags()) {
+      segment.minAudioPts = this.segmentParser_.stats.minAudioPts();
+      segment.maxAudioPts = this.segmentParser_.stats.maxAudioPts();
+    }
   }
 
   while (this.segmentParser_.tagsAvailable()) {

--- a/test/playlist_test.js
+++ b/test/playlist_test.js
@@ -259,6 +259,30 @@
     equal(duration, 30.1, 'used the PTS-based interval');
   });
 
+  test('works for media without audio', function() {
+    equal(Playlist.duration({
+      mediaSequence: 0,
+      endList: true,
+      segments: [{
+        minVideoPts: 0,
+        maxVideoPts: 9 * 1000,
+        uri: 'no-audio.ts'
+      }]
+    }), 9, 'used video PTS values');
+  });
+
+  test('works for media without video', function() {
+    equal(Playlist.duration({
+      mediaSequence: 0,
+      endList: true,
+      segments: [{
+        minAudioPts: 0,
+        maxAudioPts: 9 * 1000,
+        uri: 'no-video.ts'
+      }]
+    }), 9, 'used video PTS values');
+  });
+
   test('uses the largest continuous available PTS ranges', function() {
     var playlist = {
       mediaSequence: 0,

--- a/test/segment-parser.js
+++ b/test/segment-parser.js
@@ -284,6 +284,17 @@
     equal(packets.length, 1, 'parsed non-payload metadata packet');
   });
 
+  test('returns undefined for PTS stats when a track is missing', function() {
+    parser.parseSegmentBinaryData(new Uint8Array(makePacket({
+      programs: {
+        0x01: [0x01]
+      }
+    })));
+
+    strictEqual(parser.stats.h264Tags(), 0, 'no video tags yet');
+    strictEqual(parser.stats.aacTags(), 0, 'no audio tags yet');
+  });
+
   test('parses the first bipbop segment', function() {
     parser.parseSegmentBinaryData(window.bcSegment);
 


### PR DESCRIPTION
If audio or video data is missing for an HLS stream, duration calculations should just use the info that is available. Fixes #341.