### PR TITLE
Point back to grunt-protractor-runner

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -223,7 +223,7 @@ module.exports = function(grunt) {
     protractor: {
       options: {
         configFile: 'test/functional/protractor.config.js',
-        webdriverManagerUpdate: process.env.TRAVIS ? false : true
+        webdriverManagerUpdate: !(process.env.TRAVIS && true)
       },
 
       chrome: {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-github-releaser": "^0.1.17",
     "grunt-karma": "~0.6.2",
     "grunt-open": "0.2.3",
-    "grunt-protractor-runner": "git+https://github.com/forbesjo/grunt-protractor-runner.git#webdriverManagerUpdate",
+    "grunt-protractor-runner": "^2.1.0",
     "grunt-shell": "0.6.1",
     "grunt-version": "^1.0.0",
     "karma": "~0.10.0",


### PR DESCRIPTION
The option to automatically update the selenium drivers got merged into grunt-protractor-runner so I'm pointing back to the original repo.