### PR TITLE
Revert "Trigger loadstart"

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -107,16 +107,6 @@ videojs.Hls.prototype.src = function(src) {
     this.playlists.dispose();
   }
 
-  // We need to trigger this asynchronously to give others the chance
-  // to bind to the event when a source is set at player creation
-  setTimeout(function() {
-    // Be careful since the player could have been disposed immediately after
-    // setting the src
-    if (player && player.el()) {
-      player.trigger('loadstart');
-    }
-  }, 1);
-
   // The index of the next segment to be downloaded in the current
   // media playlist. When the current media playlist is live with
   // expiring segments, it may be a different value from the media


### PR DESCRIPTION
This reverts commit 099f282bdd43441c27a0f106db9cf2e620cc17b3.

The 4.x version of video-js-swf was reverted to previous behavior for video.js 4.x so videojs-contrib-hls should no longer be emitting the loadstart event itself. These changes will be included in 5.x.