### PR TITLE
Flush audio on seek to prevent wrong audio PTS

### DIFF
--- a/src/aac-stream.js
+++ b/src/aac-stream.js
@@ -29,6 +29,10 @@ window.videojs.Hls.AacStream = function() {
 
   this.tags = [];
 
+  this.flush = function() {
+    state = 0;
+  };
+
   // (pts:uint):void
   this.setTimeStampOffset = function(pts) {
 
@@ -45,7 +49,7 @@ window.videojs.Hls.AacStream = function() {
 
     // If data is aligned, flush all internal buffers
     if (dataAligned) {
-      state = 0;
+      this.flush();
     }
   };
 

--- a/src/segment-parser.js
+++ b/src/segment-parser.js
@@ -90,6 +90,10 @@
       h264Stream.finishFrame();
     };
 
+    self.flushAudio = function() {
+      aacStream.flush();
+    };
+
     /**
      * Returns whether a call to `getNextTag()` will be successful.
      * @return {boolean} whether there is at least one transmuxed FLV

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -433,6 +433,11 @@ videojs.Hls.prototype.setCurrentTime = function(currentTime) {
     this.sourceBuffer.abort();
   }
 
+  // flush audio on seek
+  if (this.segmentParser_) {
+    this.segmentParser_.flushAudio();
+  }
+
   // cancel outstanding requests and buffer appends
   this.cancelSegmentXhr();
 

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -114,6 +114,7 @@ var
       };
       this.parseSegmentBinaryData = function() {};
       this.flushTags = function() {};
+      this.flushAudio = function() {};
       this.tagsAvailable = function() {
         return tags.length;
       };


### PR DESCRIPTION
Flush audio on seek to prevent first audio tag in seeked segment having the same PTS as it was the last from previously processed segment. This fixes a lot of seek issues for us.