### PR TITLE
Properly calculate PTS difference between segments

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -141,10 +141,8 @@
     // add in the PTS interval in seconds between them
     if (right >= left) {
       result += 0.001 *
-        (optionalMax(playlist.segments[right].maxVideoPts,
-                  playlist.segments[right].maxAudioPts) -
-         optionalMin(playlist.segments[left].minVideoPts,
-                  playlist.segments[left].minAudioPts));
+        optionalMax(playlist.segments[right].maxVideoPts - playlist.segments[left].minVideoPts,
+            playlist.segments[right].maxAudioPts - playlist.segments[left].minAudioPts);
     }
 
     return result;


### PR DESCRIPTION
Another seek related improvement. Our streams do not have audio and video aligned so PTS differ by around 1-1.5 s. Video is played OK, but segment duration is calculated incorrectly as once min was used and another time max. From the tests I read that you want the largest possible duration. I propose using maximum difference between video PTS difference and audio PTS difference. This fixes our problems (still have to thoroughly test for negative side effects).

Tests are currently broken as I'm not sure what was your case when writing them.