### PR TITLE
Pass codecs along into source buffer creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
+sudo: false
 node_js:
-- '0.10'
+  - "stable"
 install:
 - npm install -g grunt-cli && npm install
 notifications:
@@ -11,6 +12,9 @@ notifications:
     channels:
       - "chat.freenode.net#videojs"
     use_notice: true
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 env:
   global:
   - secure: dM7svnHPPu5IiUMeFWW5zg+iuWNpwt6SSDi3MmVvhSclNMRLesQoRB+7Qq5J/LiKhmjpv1/GlNVV0CTsHMRhZNwQ3fo38eEuTXv99aAflEITXwSEh/VntKViHbGFubn06EnVkJoH6MX3zJ6kbiwc2QdSQbywKzS6l6quUEpWpd0=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -357,7 +357,7 @@ module.exports = function(grunt) {
         grunt.task.run(['karma:saucelabs']);
         grunt.task.run(['connect:test', 'protractor:saucelabs']);
       } else {
-        grunt.task.run(['karma:phantomjs']);
+        grunt.task.run(['karma:firefox']);
       }
     } else {
       if (tasks.length === 0) {

--- a/example.html
+++ b/example.html
@@ -11,8 +11,6 @@
 
   <!-- transmuxing -->
   <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/lib/stream.js"></script>
-  <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/lib/mp4-generator.js"></script>
-  <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/lib/transmuxer.js"></script>
   <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/legacy/flv-tag.js"></script>
   <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/legacy/exp-golomb.js"></script>
   <script src="node_modules/videojs-contrib-media-sources/node_modules/mux.js/legacy/h264-extradata.js"></script>
@@ -23,6 +21,9 @@
 
   <!-- Media Sources plugin -->
   <script src="node_modules/videojs-contrib-media-sources/src/videojs-media-sources.js"></script>
+  <script>
+    videojs.MediaSource.webWorkerURI = 'node_modules/videojs-contrib-media-sources/src/transmuxer_worker.js';
+  </script>
 
   <!-- HLS plugin -->
   <script src="src/videojs-hls.js"></script>
@@ -38,12 +39,6 @@
   <script src="src/decrypter.js"></script>
 
   <script src="src/bin-utils.js"></script>
-
-  <!-- example MPEG2-TS segments -->
-  <!-- bipbop -->
-  <!-- <script src="test/tsSegment.js"></script> -->
-  <!-- bunnies -->
-  <!--<script src="test/tsSegment-bc.js"></script>-->
 
   <style>
     body {

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -10,10 +10,10 @@ var
   // a fudge factor to apply to advertised playlist bitrates to account for
   // temporary flucations in client bandwidth
   bandwidthVariance = 1.1,
+  Component = videojs.getComponent('Component'),
 
   // the amount of time to wait between checking the state of the buffer
   bufferCheckInterval = 500,
-  Component = videojs.getComponent('Component'),
 
   keyXhr,
   keyFailed,
@@ -133,7 +133,7 @@ videojs.Hls.prototype.src = function(src) {
 
   // We need to trigger this asynchronously to give others the chance
   // to bind to the event when a source is set at player creation
-  setTimeout(function() {
+  this.setTimeout(function() {
     this.tech_.trigger('loadstart');
   }.bind(this), 1);
 
@@ -597,6 +597,7 @@ videojs.Hls.prototype.dispose = function() {
   }
 
   this.resetSrc_();
+  Component.prototype.dispose.call(this);
 };
 
 /**

--- a/test/m3u8_test.js
+++ b/test/m3u8_test.js
@@ -207,7 +207,7 @@
           'the title is parsed');
   });
   test('parses #EXTINF tags with carriage returns', function() {
-    var 
+    var
       manifest = '#EXTINF:13,Does anyone really use the title attribute?\r\n',
       element;
     parseStream.on('data', function(elem) {
@@ -480,6 +480,16 @@
     strictEqual(element.tagType, 'stream-inf', 'the tag type is stream-inf');
     strictEqual(element.attributes.RESOLUTION.width, 396, 'width is parsed');
     strictEqual(element.attributes.RESOLUTION.height, 224, 'heigth is parsed');
+
+    manifest = '#EXT-X-STREAM-INF:CODECS="avc1.4d400d, mp4a.40.2"\n';
+    lineStream.push(manifest);
+
+    ok(element, 'an event was triggered');
+    strictEqual(element.type, 'tag', 'the line type is tag');
+    strictEqual(element.tagType, 'stream-inf', 'the tag type is stream-inf');
+    strictEqual(element.attributes.CODECS,
+                'avc1.4d400d, mp4a.40.2',
+                'codecs are parsed');
   });
   test('parses #EXT-X-STREAM-INF with arbitrary attributes', function() {
     var


### PR DESCRIPTION
If a codecs attribute is present on a variant stream, use it when adding a source buffer. Wait to create the source buffer until the variant playlist is downloaded and the media source is open.