### PR TITLE
Moved `loadstart` to the flash side of contrib media-sources

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -137,12 +137,6 @@ videojs.Hls.prototype.src = function(src) {
   // load the MediaSource into the player
   this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen.bind(this));
 
-  // We need to trigger this asynchronously to give others the chance
-  // to bind to the event when a source is set at player creation
-  this.setTimeout(function() {
-    this.tech_.trigger('loadstart');
-  }.bind(this), 1);
-
   // The index of the next segment to be downloaded in the current
   // media playlist. When the current media playlist is live with
   // expiring segments, it may be a different value from the media


### PR DESCRIPTION
As a sourcehandler, we should no longer trigger loadstart in HLS and instead trigger it only if flash is being used.

Related to https://github.com/videojs/videojs-contrib-media-sources/pull/44