### PR TITLE
Ensure Flash mode fires "loadstart"

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -102,6 +102,13 @@ videojs.HlsSourceHandler = function(mode) {
       return mpegurlRE.test(srcObj.type);
     },
     handleSource: function(source, tech) {
+      if (mode === 'flash') {
+        // We need to trigger this asynchronously to give others the chance
+        // to bind to the event when a source is set at player creation
+        tech.setTimeout(function() {
+          tech.trigger('loadstart');
+        }, 1);
+      }
       tech.hls = new videojs.Hls(tech, {
         source: source,
         mode: mode
@@ -138,12 +145,6 @@ videojs.Hls.prototype.src = function(src) {
 
   // load the MediaSource into the player
   this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen.bind(this));
-
-  // We need to trigger this asynchronously to give others the chance
-  // to bind to the event when a source is set at player creation
-  this.setTimeout(function() {
-    this.tech_.trigger('loadstart');
-  }.bind(this), 1);
 
   // The index of the next segment to be downloaded in the current
   // media playlist. When the current media playlist is live with

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -2594,6 +2594,38 @@ test('the source handler supports HLS mime types', function() {
   });
 });
 
+test('fires loadstart manually if Flash is used', function() {
+  var
+    tech = new (videojs.extend(videojs.EventTarget, {
+      buffered: function() {
+        return videojs.createTimeRange();
+      },
+      currentTime: function() {
+        return 0;
+      },
+      el: function() {
+        return {};
+      },
+      preload: function() {
+        return 'auto';
+      },
+      src: function() {},
+      setTimeout: window.setTimeout
+    }))(),
+    loadstarts = 0;
+  tech.on('loadstart', function() {
+    loadstarts++;
+  });
+  videojs.HlsSourceHandler('flash').handleSource({
+    src: 'movie.m3u8',
+    type: 'application/x-mpegURL'
+  }, tech);
+
+  equal(loadstarts, 0, 'loadstart is not synchronous');
+  clock.tick(1);
+  equal(loadstarts, 1, 'fired loadstart');
+});
+
 test('has no effect if native HLS is available', function() {
   var player;
   videojs.Hls.supportsNativeHls = true;


### PR DESCRIPTION
For #400. Flash doesn't currently fire "loadstart" in data generation mode. Triggering that event should probably happen in video.js itself but fire it once the source handler is selected to make things behave somewhat sanely for now.