### PR TITLE
There are cases when a mediasource is re-opened and we need to account for that

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -292,7 +292,12 @@ videojs.Hls.getMediaIndexForLive_ = function(selectedPlaylist) {
 };
 
 videojs.Hls.prototype.handleSourceOpen = function() {
-  this.setupSourceBuffer_();
+  // Only attempt to create the source buffer if none already exist.
+  // handleSourceOpen is also called when we are "re-opening" a source buffer
+  // after `endOfStream` has been called (in response to a seek for instance)
+  if (!this.sourceBuffer) {
+    this.setupSourceBuffer_();
+  }
 
   // if autoplay is enabled, begin playback. This is duplicative of
   // code in video.js but is required because play() must be invoked


### PR DESCRIPTION
The situation was:
* At the end of the playlist, we call `endOfStream` which sets the media source's `readyState` to `ended`
* On an out-of-buffer seek, we call `remove` to clear the buffer which re-opens the source buffer and sets `readyState` to `open` and that causes the the `sourceopen` event to fire
* On `sourceopen` we call `handleSourceOpen` which calls `setupSourceBuffer_` and that tries to make a new source buffer in the `mediaSource` object without taking into consideration whether a source buffer already exists.

Solution is to simply to not call `setupSourceBuffer_` if source buffers already exist in the media source.