### PR TITLE
Minor fixes to fetcher

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -141,8 +141,7 @@
     // https://tools.ietf.org/html/draft-pantos-http-live-streaming-16#section-6.3.3
     start = intervalDuration(playlist, playlist.mediaSequence);
     end = intervalDuration(playlist,
-                           playlist.mediaSequence + playlist.segments.length);
-    end -= (playlist.targetDuration || DEFAULT_TARGET_DURATION) * 3;
+                           playlist.mediaSequence + Math.max(0, playlist.segments.length - 3));
     end = Math.max(0, end);
     return videojs.createTimeRange(start, end);
   };

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -142,7 +142,6 @@
     start = intervalDuration(playlist, playlist.mediaSequence);
     end = intervalDuration(playlist,
                            playlist.mediaSequence + Math.max(0, playlist.segments.length - 3));
-    end = Math.max(0, end);
     return videojs.createTimeRange(start, end);
   };
 

--- a/test/playlist_test.js
+++ b/test/playlist_test.js
@@ -381,8 +381,8 @@
     });
     equal(seekable.start(0), 0, 'starts at the earliest available segment');
     equal(seekable.end(0),
-          9 - (2 * 3),
-          'allows seeking no further than three target durations from the end');
+          9 - (2 + 2 + 1),
+          'allows seeking no further than three segments from the end');
   });
 
 })(window, window.videojs);


### PR DESCRIPTION
* Increased the `bandwidthVariance` based on similar constraints in other projects
* Added a fudge factor of half a frame to account for TimeRanges rounding
* Don't try to cancel a fetch in the middle of an append operation

* Live point is now 3 segments from the end instead of 3 target durations