### PR TITLE
Blacklist

### DIFF
--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -110,7 +110,7 @@
     var match, event;
 
     //strip whitespace
-    line = line.replace(/^\s+|\s+$/g, '');
+    line = line.replace(/^[\u0000\s]+|[\u0000\s]+$/g, '');
     if (line.length === 0) {
       // ignore empty lines
       return;


### PR DESCRIPTION
First shot at temporarily blacklisting problematic playlists. Will flag a playlist as bad and then select the next appropriate playlist. If no playlists remain, it will signal the error that caused the problem to begin with.