### PR TITLE
	Use information from buffering to calculate seekable

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -389,7 +389,10 @@
       return 0;
     }
 
-    // 1) Walk backward until we find the first segment with timeline
+    // find segments with known timing information that bound the
+    // target time
+
+    // Walk backward until we find the first segment with timeline
     // information that is earlier than `time`
     for (i = lastSegment; i >= 0; i--) {
       segment = this.media_.segments[i];
@@ -414,7 +417,7 @@
       }
     }
 
-    // 2) Walk forward until we find the first segment with timeline
+    // Walk forward until we find the first segment with timeline
     // information that is greater than `time`
     for (i = 0; i < numSegments; i++) {
       segment = this.media_.segments[i];
@@ -423,7 +426,8 @@
         knownEnd = segment.start;
         if (endIndex < 0) {
           // The first segment claims to start *after* the time we are
-          // searching for so just return it
+          // searching for so the target segment must no longer be
+          // available
           return -1;
         }
         break;
@@ -434,6 +438,9 @@
         break;
       }
     }
+
+    // use the bounds we just found and playlist information to
+    // estimate the segment that contains the time we are looking for
 
     if (startIndex !== undefined) {
       // We have a known-start point that is before our desired time so

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -51,6 +51,9 @@ videojs.HlsHandler = videojs.extend(Component, {
     // being downloaded or processed
     this.pendingSegment_ = null;
 
+    // start playlist selection at a reasonable bandwidth for
+    // broadband internet
+    this.bandwidth = options.bandwidth || 4194304; // 0.5 Mbps
     this.bytesReceived = 0;
 
     // loadingState_ tracks how far along the buffering process we

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -738,8 +738,8 @@ test('buffer checks are noops when only the master is ready', function() {
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
-  standardXHRResponse(requests.shift());
-  standardXHRResponse(requests.shift());
+  standardXHRResponse(requests.shift()); // master
+  standardXHRResponse(requests.shift()); // media
   // ignore any outstanding segment requests
   requests.length = 0;
 
@@ -752,7 +752,8 @@ test('buffer checks are noops when only the master is ready', function() {
   openMediaSource(player);
 
   // respond with the master playlist but don't send the media playlist yet
-  standardXHRResponse(requests.shift());
+  player.tech_.hls.bandwidth = 1; // force media1 to be requested
+  standardXHRResponse(requests.shift()); // master
   // trigger fillBuffer()
   player.tech_.hls.checkBuffer_();
 
@@ -1377,8 +1378,8 @@ test('waits to download new segments until the media playlist is stable', functi
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
-  standardXHRResponse(requests.shift()); // master
   player.tech_.hls.bandwidth = 1; // make sure we stay on the lowest variant
+  standardXHRResponse(requests.shift()); // master
   standardXHRResponse(requests.shift()); // media1
 
   // force a playlist switch


### PR DESCRIPTION
Look forward and backward through the playlist to find an anchor to base seekable calculations on. This is helpful for live playlists in particular, where the only way to determine the correct starting position for the seekable range is to look at where future segments have ended up in the buffer. Without this change, the start of seekable was always zero, even if the live sliding window had moved forward.