### PR TITLE
Feature/byterange support

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -42,6 +42,13 @@
     if (options.withCredentials) {
       request.withCredentials = true;
     }
+    if (options.headers) {
+      for (var header in options.headers) {
+        if (options.headers.hasOwnProperty(header)) {
+          request.setRequestHeader(header, options.headers[header]);
+        }
+      }
+    }
     if (options.timeout) {
       abortTimeout = window.setTimeout(function() {
         if (request.readyState !== 4) {


### PR DESCRIPTION
* This pull request adds support for the #EXT-X-BYTERANGE tag to support HLS playlists with byteranges, like the one in Listing 15 of Apple's [Example Playlist Files](https://developer.apple.com/library/ios/technotes/tn2288/_index.html#//apple_ref/doc/uid/DTS40012238-CH1-BYTE_RANGE_SUPPORT_FOR_SEGMENTS). It does not break compatibility with old-style playlists, like the one in Listing 14. This would fix [#342](https://github.com/videojs/videojs-contrib-hls/issues/342).

* The byterange is added to the request for each segment as an HTTP Range header. Servers serving videos for playlists with #EXT-X-BYTERANGE tags need to parse request headers like this one:

        Range:bytes=0-288955
   
    The server should respond with status code 206 (partial content) and the appropriate segment of the video. The response should also contain the `Content-Range` header, e.g:
    
        Content-Range:bytes 0-288955/2521832

* If the video is on a different domain from the player, the server must give the player explicit permission to use the `Range` header by including the `Access-Control-Allow-Headers` header in its response to the CORS preflight request:

        Access-Control-Allow-Headers:Range

    The preflight request uses the HTTP 'OPTIONS' verb and is sent automatically by the browser. A CORS error will be thrown if the server does not respond with the proper header.

* Tested in Chrome, Firefox, Safari, Edge 12, and IE 11 using a player based on the [example player](http://videojs.github.io/videojs-contrib-hls/). Does not work with IE 10, but neither did the existing videojs.hls.js.

* Tested against version 4.12.6 of video.js. Does not work with the latest version (5.2), but neither did the existing videojs.hls.js.

* No tests were added to the test suite. The fix depends on a change I made to `videojs.Hls.xhr` to support sending arbitrary headers, and it didn't look to me like `videojs.Hls.xhr` was tested anywhere. I would be happy to add test(s) if someone can point me in the right direction.

* Known issue: Chrome issues an OPTIONS request for every video segment if CORS is required. As far as I know, it should cache the OPTIONS response for a while, so this shouldn't be the case. Firefox does not have this problem - it only issues an OPTIONS request for the first segment.