### PR TITLE
Long term seekable start

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1206,7 +1206,7 @@ videojs.HlsHandler.prototype.updateEndHandler_ = function () {
       var next = this.findNextBufferedRange_();
       if (next.length) {
         videojs.log('tried seeking to', this.tech_.currentTime(), 'but that was too early, retrying at', next.start(0));
-        this.tech_.setCurrentTime(next.start(0));
+        this.tech_.setCurrentTime(next.start(0) + TIME_FUDGE_FACTOR);
       }
     }
   }

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -187,7 +187,7 @@ videojs.HlsHandler.prototype.src = function(src) {
   }.bind(this));
 
   this.playlists.on('loadedplaylist', function() {
-    var updatedPlaylist = this.playlists.media();
+    var updatedPlaylist = this.playlists.media(), seekable;
 
     if (!updatedPlaylist) {
       // select the initial variant
@@ -196,6 +196,14 @@ videojs.HlsHandler.prototype.src = function(src) {
     }
 
     this.updateDuration(this.playlists.media());
+
+    // update seekable
+    seekable = this.seekable();
+    if (this.duration() === Infinity &&
+        seekable.length !== 0) {
+      this.mediaSource.addSeekableRange_(seekable.start(0), seekable.end(0));
+    }
+
     oldMediaPlaylist = updatedPlaylist;
   }.bind(this));
 
@@ -291,7 +299,6 @@ videojs.Hls.bufferedAdditions_ = function(original, update) {
   return result;
 };
 
-
 var parseCodecs = function(codecs) {
   var result = {
     codecCount: 0,
@@ -312,6 +319,7 @@ var parseCodecs = function(codecs) {
 
   return result;
 };
+
 /**
  * Blacklist playlists that are known to be codec or
  * stream-incompatible with the SourceBuffer configuration. For
@@ -445,15 +453,15 @@ videojs.HlsHandler.prototype.play = function() {
   // if the viewer has paused and we fell out of the live window,
   // seek forward to the earliest available position
   if (this.duration() === Infinity) {
-    if (this.tech_.currentTime() < this.tech_.seekable().start(0)) {
-      this.tech_.setCurrentTime(this.tech_.seekable().start(0));
+    if (this.tech_.currentTime() < this.seekable().start(0)) {
+      this.tech_.setCurrentTime(this.seekable().start(0));
     }
   }
 };
 
 videojs.HlsHandler.prototype.setCurrentTime = function(currentTime) {
   var
-    buffered = this.findCurrentBuffered_();
+    buffered = this.findBufferedRange_();
 
   if (!(this.playlists && this.playlists.media())) {
     // return immediately if the metadata is not ready yet
@@ -501,7 +509,7 @@ videojs.HlsHandler.prototype.duration = function() {
 };
 
 videojs.HlsHandler.prototype.seekable = function() {
-  var media;
+  var media, seekable;
 
   if (!this.playlists) {
     return videojs.createTimeRanges();
@@ -511,7 +519,25 @@ videojs.HlsHandler.prototype.seekable = function() {
     return videojs.createTimeRanges();
   }
 
-  return videojs.Hls.Playlist.seekable(media);
+  seekable = videojs.Hls.Playlist.seekable(media);
+  if (seekable.length === 0) {
+    return seekable;
+  }
+
+  // if the seekable start is zero, it may be because the player has
+  // been paused for a long time and stopped buffering. in that case,
+  // fall back to the playlist loader's running estimate of expired
+  // time
+  if (seekable.start(0) === 0) {
+   return videojs.createTimeRanges([[
+      this.playlists.expired_,
+      this.playlists.expired_ + seekable.end(0)
+    ]]);
+  }
+
+  // seekable has been calculated based on buffering video data so it
+  // can be returned directly
+  return seekable;
 };
 
 /**
@@ -522,15 +548,10 @@ videojs.HlsHandler.prototype.updateDuration = function(playlist) {
       newDuration = videojs.Hls.Playlist.duration(playlist),
       setDuration = function() {
         this.mediaSource.duration = newDuration;
-        // update seekable
-        if (seekable.length !== 0 && newDuration === Infinity) {
-          this.mediaSource.addSeekableRange_(seekable.start(0), seekable.end(0));
-        }
         this.tech_.trigger('durationchange');
 
         this.mediaSource.removeEventListener('sourceopen', setDuration);
-      }.bind(this),
-      seekable = this.seekable();
+      }.bind(this);
 
   // if the duration has changed, invalidate the cached value
   if (oldDuration !== newDuration) {
@@ -539,10 +560,6 @@ videojs.HlsHandler.prototype.updateDuration = function(playlist) {
       this.mediaSource.addEventListener('sourceopen', setDuration);
     } else if (!this.sourceBuffer || !this.sourceBuffer.updating) {
       this.mediaSource.duration = newDuration;
-      // update seekable
-      if (seekable.length !== 0 && newDuration === Infinity) {
-        this.mediaSource.addSeekableRange_(seekable.start(0), seekable.end(0));
-      }
       this.tech_.trigger('durationchange');
     }
   }
@@ -745,41 +762,61 @@ videojs.HlsHandler.prototype.stopCheckingBuffer_ = function() {
   this.tech_.off('waiting', this.drainBuffer);
 };
 
-/**
- * Attempts to find the buffered TimeRange where playback is currently
- * happening. Returns a new TimeRange with one or zero ranges.
- */
-videojs.HlsHandler.prototype.findCurrentBuffered_ = function() {
-  var
-    ranges,
-    i,
-    tech = this.tech_,
-    // !!The order of the next two lines is important!!
-    // `currentTime` must be equal-to or greater-than the start of the
-    // buffered range. Flash executes out-of-process so, every value can
-    // change behind the scenes from line-to-line. By reading `currentTime`
-    // after `buffered`, we ensure that it is always a current or later
-    // value during playback.
-    buffered = tech.buffered(),
-    currentTime = tech.currentTime();
+var filterBufferedRanges = function(predicate) {
+  return function(time) {
+    var
+      i,
+      ranges = [],
+      tech = this.tech_,
+      // !!The order of the next two assignments is important!!
+      // `currentTime` must be equal-to or greater-than the start of the
+      // buffered range. Flash executes out-of-process so, every value can
+      // change behind the scenes from line-to-line. By reading `currentTime`
+      // after `buffered`, we ensure that it is always a current or later
+      // value during playback.
+      buffered = tech.buffered();
 
-  if (buffered && buffered.length) {
-    // Search for a range containing the play-head
-    for (i = 0; i < buffered.length; i++) {
-      if (buffered.start(i) - TIME_FUDGE_FACTOR <= currentTime &&
-          buffered.end(i) + TIME_FUDGE_FACTOR >= currentTime) {
-        ranges = videojs.createTimeRanges(buffered.start(i), buffered.end(i));
-        ranges.indexOf = i;
-        return ranges;
+
+    if (time === undefined) {
+      time = tech.currentTime();
+    }
+
+    if (buffered && buffered.length) {
+      // Search for a range containing the play-head
+      for (i = 0; i < buffered.length; i++) {
+        if (predicate(buffered.start(i), buffered.end(i), time)) {
+          ranges.push([buffered.start(i), buffered.end(i)]);
+        }
       }
     }
-  }
 
-  // Return an empty range if no ranges exist
-  ranges = videojs.createTimeRanges();
-  ranges.indexOf = -1;
-  return ranges;
+    return videojs.createTimeRanges(ranges);
+  };
 };
+
+/**
+ * Attempts to find the buffered TimeRange that contains the specified
+ * time, or where playback is currently happening if no specific time
+ * is specified.
+ * @param time (optional) {number} the time to filter on. Defaults to
+ * currentTime.
+ * @return a new TimeRanges object.
+ */
+videojs.HlsHandler.prototype.findBufferedRange_ = filterBufferedRanges(function(start, end, time) {
+  return start - TIME_FUDGE_FACTOR <= time &&
+    end + TIME_FUDGE_FACTOR >= time;
+});
+
+/**
+ * Returns the TimeRanges that begin at or later than the specified
+ * time.
+ * @param time (optional) {number} the time to filter on. Defaults to
+ * currentTime.
+ * @return a new TimeRanges object.
+ */
+videojs.HlsHandler.prototype.findNextBufferedRange_ = filterBufferedRanges(function(start, end, time) {
+  return start - TIME_FUDGE_FACTOR >= time;
+});
 
 /**
  * Determines whether there is enough video data currently in the buffer
@@ -791,7 +828,7 @@ videojs.HlsHandler.prototype.fillBuffer = function(mediaIndex) {
   var
     tech = this.tech_,
     currentTime = tech.currentTime(),
-    currentBuffered = this.findCurrentBuffered_(),
+    currentBuffered = this.findBufferedRange_(),
     currentBufferedEnd = 0,
     bufferedTime = 0,
     segment,
@@ -1025,7 +1062,7 @@ videojs.HlsHandler.prototype.drainBuffer = function(event) {
     segIv,
     segmentTimestampOffset = 0,
     hasBufferedContent = (this.tech_.buffered().length !== 0),
-    currentBuffered = this.findCurrentBuffered_(),
+    currentBuffered = this.findBufferedRange_(),
     outsideBufferedRanges = !(currentBuffered && currentBuffered.length);
 
   // if the buffer is empty or the source buffer hasn't been created
@@ -1132,6 +1169,7 @@ videojs.HlsHandler.prototype.updateEndHandler_ = function () {
     playlist,
     currentMediaIndex,
     currentBuffered,
+    seekable,
     timelineUpdates;
 
   this.pendingSegment_ = null;
@@ -1144,7 +1182,7 @@ videojs.HlsHandler.prototype.updateEndHandler_ = function () {
   playlist = this.playlists.media();
   segments = playlist.segments;
   currentMediaIndex = segmentInfo.mediaIndex + (segmentInfo.mediaSequence - playlist.mediaSequence);
-  currentBuffered = this.findCurrentBuffered_();
+  currentBuffered = this.findBufferedRange_();
 
   // if we switched renditions don't try to add segment timeline
   // information to the playlist
@@ -1156,9 +1194,25 @@ videojs.HlsHandler.prototype.updateEndHandler_ = function () {
   // added by the media processing
   segment = playlist.segments[currentMediaIndex];
 
+  // when seeking to the beginning of the seekable range, it's
+  // possible that imprecise timing information may cause the seek to
+  // end up earlier than the start of the range
+  // in that case, seek again
+  seekable = this.seekable();
+  if (this.tech_.seeking() &&
+      currentBuffered.length === 0) {
+    if (seekable.length &&
+        this.tech_.currentTime() < seekable.start(0)) {
+      var next = this.findNextBufferedRange_();
+      if (next.length) {
+        videojs.log('tried seeking to', this.tech_.currentTime(), 'but that was too early, retrying at', next.start(0));
+        this.tech_.setCurrentTime(next.start(0));
+      }
+    }
+  }
+
   timelineUpdates = videojs.Hls.bufferedAdditions_(segmentInfo.buffered,
                                                    this.tech_.buffered());
-
   timelineUpdates.forEach(function (update) {
     if (segment) {
       if (update.end !== undefined) {

--- a/test/stats/index.html
+++ b/test/stats/index.html
@@ -45,6 +45,12 @@
     }
   </style>
 
+  <script>
+    if (window.location.search === '?flash') {
+      videojs.options.techOrder = ['flash'];
+    }
+  </script>
+
 </head>
 <body>
   <div class="info">
@@ -64,20 +70,35 @@
        type="application/x-mpegURL">
   </video>
   <section class="stats">
-    <h2>Player Stats</h2>
-    <dl>
-      <dt>Current Time:</dt>
-      <dd class="current-time-stat">0</dd>
-      <dt>Buffered:</dt>
-      <dd class="buffered-stat">-</dd>
-      <dt>Seekable:</dt>
-      <dd><span class="seekable-start-stat">-</span> - <span class="seekable-end-stat">-</span></dd>
-      <dt>Video Bitrate:</dt>
-      <dd class="video-bitrate-stat">0 kbps</dd>
-      <dt>Measured Bitrate:</dt>
-      <dd class="measured-bitrate-stat">0 kbps</dd>
-    </dl>
-    <h3>Bitrate Switching</h3>
+    <div class="player-stats">
+      <h2>Player Stats</h2>
+      <dl>
+        <dt>Current Time:</dt>
+        <dd class="current-time-stat">0</dd>
+        <dt>Buffered:</dt>
+        <dd class="buffered-stat">-</dd>
+        <dt>Seekable:</dt>
+        <dd><span class="seekable-start-stat">-</span> - <span class="seekable-end-stat">-</span></dd>
+        <dt>Video Bitrate:</dt>
+        <dd class="video-bitrate-stat">0 kbps</dd>
+        <dt>Measured Bitrate:</dt>
+        <dd class="measured-bitrate-stat">0 kbps</dd>
+      </dl>
+    </div>
+    <div class="event-counts">
+      <h2>Event Counts</h2>
+      <dl>
+        <dt>Play:</dt>
+        <dd class="play-count">0</dd>
+        <dt>Playing:</dt>
+        <dd class="playing-count">0</dd>
+        <dt>Seeking:</dt>
+        <dd class="seeking-count">0</dd>
+        <dt>Seeked:</dt>
+        <dd class="seeked-count">0</dd>
+      </dl>
+    </div>
+    <h3 class="bitrate-switching">Bitrate Switching</h3>
     <div class="switching-stats">
       Once the player begins loading, you'll see information about the
       operation of the adaptive quality switching here.
@@ -90,66 +111,96 @@
   <script>
     videojs.options.flash.swf = '../../node_modules/videojs-swf/dist/video-js.swf';
     // initialize the player
-    var player = videojs('video');
+    var player = videojs('video').ready(function() {
 
-    // ------------
-    // Player Stats
-    // ------------
+      // ------------
+      // Player Stats
+      // ------------
 
-    var currentTimeStat = document.querySelector('.current-time-stat');
-    var bufferedStat = document.querySelector('.buffered-stat');
-    var seekableStartStat = document.querySelector('.seekable-start-stat');
-    var seekableEndStat = document.querySelector('.seekable-end-stat');
-    var videoBitrateState = document.querySelector('.video-bitrate-stat');
-    var measuredBitrateStat = document.querySelector('.measured-bitrate-stat');
+      var currentTimeStat = document.querySelector('.current-time-stat');
+      var bufferedStat = document.querySelector('.buffered-stat');
+      var seekableStartStat = document.querySelector('.seekable-start-stat');
+      var seekableEndStat = document.querySelector('.seekable-end-stat');
+      var videoBitrateState = document.querySelector('.video-bitrate-stat');
+      var measuredBitrateStat = document.querySelector('.measured-bitrate-stat');
 
-    player.on('timeupdate', function() {
-      currentTimeStat.textContent = player.currentTime().toFixed(1);
+      player.on('timeupdate', function() {
+        currentTimeStat.textContent = player.currentTime().toFixed(1);
+      });
+
+      window.setInterval(function() {
+        var bufferedText = '', oldStart, oldEnd, i;
+
+        // buffered
+        var buffered = player.buffered();
+        if (buffered.length) {
+          bufferedText += buffered.start(0) + ' - ' + buffered.end(0);
+        }
+        for (i = 1; i < buffered.length; i++) {
+          bufferedText += ', ' + buffered.start(i) + ' - ' + buffered.end(i);
+        }
+        bufferedStat.textContent = bufferedText;
+
+        // seekable
+        var seekable = player.seekable();
+        if (seekable && seekable.length) {
+
+          oldStart = seekableStartStat.textContent;
+          if (seekable.start(0).toFixed(1) !== oldStart) {
+            seekableStartStat.textContent = seekable.start(0).toFixed(1);
+          }
+          oldEnd = seekableEndStat.textContent;
+          if (seekable.end(0).toFixed(1) !== oldEnd) {
+            seekableEndStat.textContent = seekable.end(0).toFixed(1);
+          }
+        }
+
+        // bitrates
+        var playlist = player.tech_.hls.playlists.media();
+        if (playlist && playlist.attributes && playlist.attributes.BANDWIDTH) {
+          videoBitrateState.textContent = (playlist.attributes.BANDWIDTH / 1024).toLocaleString(undefined, {
+            maximumFractionDigits: 1
+          }) + ' kbps';
+        }
+        if (player.tech_.hls.bandwidth) {
+          measuredBitrateStat.textContent = (player.tech_.hls.bandwidth / 1024).toLocaleString(undefined, {
+            maximumFractionDigits: 1
+          }) + ' kbps';
+        }
+      }, 1000);
+
+      var trackEventCount = function(eventName, selector) {
+        var count = 0, element = document.querySelector(selector);
+        player.on(eventName, function() {
+          count++;
+          element.innerHTML = count;
+        });
+      };
+      trackEventCount('play', '.play-count');
+      trackEventCount('playing', '.playing-count');
+      trackEventCount('seeking', '.seeking-count');
+      trackEventCount('seeked', '.seeked-count');
+
+      videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
+      videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
     });
 
-    player.on('progress', function() {
-      var bufferedText = '', oldStart, oldEnd, i;
+    // -----------
+    // Tech Switch
+    // -----------
 
-      // buffered
-      var buffered = player.buffered();
-      if (buffered.length) {
-        bufferedText += buffered.start(0) + ' - ' + buffered.end(0);
-      }
-      for (i = 1; i < buffered.length; i++) {
-        bufferedText += ', ' + buffered.start(i) + ' - ' + buffered.end(i);
-      }
-      bufferedStat.textContent = bufferedText;
+    var techSwitch = document.createElement('a');
+    techSwitch.className = 'tech-switch';
+    if (player.el().querySelector('video')) {
+      techSwitch.href = window.location.origin + window.location.pathname + '?flash';
+      techSwitch.appendChild(document.createTextNode('Switch to the Flash tech'));
+    } else {
+      techSwitch.href = window.location.origin + window.location.pathname;
+      techSwitch.appendChild(document.createTextNode('Stop forcing Flash'));
+    }
 
-      // seekable
-      var seekable = player.seekable();
-      if (seekable && seekable.length) {
+    document.body.insertBefore(techSwitch, document.querySelector('.stats'));
 
-        oldStart = seekableStartStat.textContent;
-        if (seekable.start(0).toFixed(1) !== oldStart) {
-          seekableStartStat.textContent = seekable.start(0).toFixed(1);
-        }
-        oldEnd = seekableEndStat.textContent;
-        if (seekable.end(0).toFixed(1) !== oldEnd) {
-          seekableEndStat.textContent = seekable.end(0).toFixed(1);
-        }
-      }
-
-      // bitrates
-      var playlist = player.tech_.hls.playlists.media();
-      if (playlist && playlist.attributes && playlist.attributes.BANDWIDTH) {
-        videoBitrateState.textContent = (playlist.attributes.BANDWIDTH / 1024).toLocaleString(undefined, {
-          maximumFractionDigits: 1
-        }) + ' kbps';
-      }
-      if (player.tech_.hls.bandwidth) {
-        measuredBitrateStat.textContent = (player.tech_.hls.bandwidth / 1024).toLocaleString(undefined, {
-          maximumFractionDigits: 1
-        }) + ' kbps';
-      }
-    });
-
-    videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
-    videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
   </script>
 </body>
 </html>

--- a/test/stats/stats.css
+++ b/test/stats/stats.css
@@ -1,3 +1,19 @@
+.tech-switch {
+  padding: 8px 0 0;
+  display: block;
+}
+
+.player-stats, .event-counts {
+  box-sizing: border-box;
+  padding: 8px;
+  float: left;
+  width: 50%;
+}
+
+h3.bitrate-switching {
+  clear: both;
+}
+
 .axis text,
 .cue text {
   font: 12px sans-serif;


### PR DESCRIPTION
When we switch playlists in a live video, we have to find the right place in the new playlist to continue buffering. This is complicated because we can't guarantee the two variants are segmented at the same time positions or that the windows of time they represent are exactly in sync. Most of the time, they're pretty close to one another and we can use that fact to make better guesses at which segment to download when switching.

This PR adds back tracking of expired content in the playlist loader, which can then be used to estimate the seekable window for live playlists even before we've buffered any segments from them. This also allows seekable to be accurate even when the player has paused for a long time and all the segment timing information we gathered has gone out of date. To make rejoining or seeking in a live stream even more robust, we detect when a seek "misses" the live window and seek again to a safe position.