### PR TITLE
Simplify stuff

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -450,7 +450,7 @@
           break;
         } else {
           knownStart = segment.end;
-          startIndex = i;
+          startIndex = i + 1;
         }
       }
     }
@@ -494,8 +494,13 @@
           return i;
         }
       }
-      // We haven't found a segment so load the first one
-      return 0;
+
+      // We haven't found a segment so load the first one if time is zero
+      if (time === 0) {
+        return 0;
+      } else {
+        return -1;
+      }
     } else {
       // We known nothing so walk from the front of the playlist,
       // subtracting durations until we find a segment that contains

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -422,7 +422,6 @@
       i,
       segment,
       originalTime = time,
-      targetDuration = this.media_.targetDuration || 10,
       numSegments = this.media_.segments.length,
       lastSegment = numSegments - 1,
       startIndex,
@@ -442,70 +441,36 @@
 
     // find segments with known timing information that bound the
     // target time
-
-    // Walk backward until we find the first segment with timeline
-    // information that is earlier than `time`
-    for (i = lastSegment; i >= 0; i--) {
-      segment = this.media_.segments[i];
-      if (segment.end !== undefined && segment.end <= time) {
-        startIndex = i + 1;
-        knownStart = segment.end;
-        if (startIndex >= numSegments) {
-          // The last segment claims to end *before* the time we are
-          // searching for so just return it
-          return numSegments;
-        }
-        break;
-      }
-      if (segment.start !== undefined && segment.start <= time) {
-        if (segment.end !== undefined && segment.end > time) {
-          // we've found the target segment exactly
-          return i;
-        }
-        startIndex = i;
-        knownStart = segment.start;
-        break;
-      }
-    }
-
-    // Walk forward until we find the first segment with timeline
-    // information that is greater than `time`
     for (i = 0; i < numSegments; i++) {
       segment = this.media_.segments[i];
-      if (segment.start !== undefined && segment.start > time) {
-        endIndex = i - 1;
-        knownEnd = segment.start;
-        if (endIndex < 0) {
-          // The first segment claims to start *after* the time we are
-          // searching for so the target segment must no longer be
-          // available
-          return -1;
+      if (segment.end) {
+        if (segment.end > time) {
+          knownEnd = segment.end;
+          endIndex = i;
+          break;
+        } else {
+          knownStart = segment.end;
+          startIndex = i;
         }
-        break;
-      }
-      if (segment.end !== undefined && segment.end > time) {
-        endIndex = i;
-        knownEnd = segment.end;
-        break;
       }
     }
 
     // use the bounds we just found and playlist information to
     // estimate the segment that contains the time we are looking for
-
     if (startIndex !== undefined) {
       // We have a known-start point that is before our desired time so
       // walk from that point forwards
       time = time - knownStart;
       for (i = startIndex; i < (endIndex || numSegments); i++) {
         segment = this.media_.segments[i];
-        time -= segment.duration || targetDuration;
+        time -= segment.duration;
+
         if (time < 0) {
           return i;
         }
       }
 
-      if (i === endIndex) {
+      if (i >= endIndex) {
         // We haven't found a segment but we did hit a known end point
         // so fallback to interpolating between the segment index
         // based on the known span of the timeline we are dealing with
@@ -523,7 +488,8 @@
       time = knownEnd - time;
       for (i = endIndex; i >= 0; i--) {
         segment = this.media_.segments[i];
-        time -= segment.duration || targetDuration;
+        time -= segment.duration;
+
         if (time < 0) {
           return i;
         }
@@ -535,12 +501,14 @@
       // subtracting durations until we find a segment that contains
       // time and return it
       time = time - this.expired_;
+
       if (time < 0) {
         return -1;
       }
+
       for (i = 0; i < numSegments; i++) {
         segment = this.media_.segments[i];
-        time -= segment.duration || targetDuration;
+        time -= segment.duration;
         if (time < 0) {
           return i;
         }

--- a/test/playlist-loader_test.js
+++ b/test/playlist-loader_test.js
@@ -811,7 +811,7 @@
                              '1001.ts\n' +
                              '#EXTINF:5,\n' +
                              '1002.ts\n');
-    loader.media().segments[0].start = 150;
+    loader.media().segments[0].end = 154;
 
     equal(loader.getMediaIndexForTime_(0), -1, 'the lowest returned value is  negative one');
     equal(loader.getMediaIndexForTime_(45), -1, 'expired content returns negative one');
@@ -819,6 +819,7 @@
     equal(loader.getMediaIndexForTime_(50 + 100), 0, 'calculates the earliest available position');
     equal(loader.getMediaIndexForTime_(50 + 100 + 2), 0, 'calculates within the first segment');
     equal(loader.getMediaIndexForTime_(50 + 100 + 2), 0, 'calculates within the first segment');
+    equal(loader.getMediaIndexForTime_(50 + 100 + 4), 1, 'calculates within the second segment');
     equal(loader.getMediaIndexForTime_(50 + 100 + 4.5), 1, 'calculates within the second segment');
     equal(loader.getMediaIndexForTime_(50 + 100 + 6), 1, 'calculates within the second segment');
   });
@@ -837,9 +838,9 @@
     loader.expired_ = 160;
     // annotate the first segment with a start time
     // this number would be coming from the Source Buffer in practice
-    loader.media().segments[0].start = 150;
+    loader.media().segments[0].end = 150;
 
-    equal(loader.getMediaIndexForTime_(151), 0, 'prefers the value on the first segment');
+    equal(loader.getMediaIndexForTime_(149), 0, 'prefers the value on the first segment');
 
     clock.tick(10 * 1000); // trigger a playlist refresh
     requests.shift().respond(200, null,


### PR DESCRIPTION
This fixes several bad behaviors we can fall into when seeking multiple times by simplifying things and taking a YAGNI approach to debugging.

Playlist-loader's `getmediaIndexForTime_` no longer uses segment start times and has been drastically simplified.

Hls's `bufferedAdditions_` has been changed completely and renamed `findSoleUncommonTimeRangesEnd_` - the only thing that wasn't simplified was the name! It now attempts to be sure 100% that it is returning a proper end-point for the segment or it returns nothing. Should fix many issues that were caused by bad information being saved to the playlist that was throwing off other calculations.

Aborted XHRs were still eventually triggering callbacks due to timeouts. The callback didn't check to make sure it was being executed for the current in-flight request before blowing away the state used to track requests.

Fixes #458