### PR TITLE
fix calling abort on a sourceBuffer whose mediaSource.readyState != open

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -434,7 +434,7 @@ videojs.Hls.prototype.setCurrentTime = function(currentTime) {
   this.mediaIndex = this.playlists.getMediaIndexForTime_(currentTime);
 
   // abort any segments still being decoded
-  if (this.sourceBuffer) {
+  if (this.sourceBuffer && this.mediaSource.readyState === 'open') {
     this.sourceBuffer.abort();
   }
 

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -508,7 +508,7 @@ videojs.Hls.prototype.resetSrc_ = function() {
   this.cancelSegmentXhr();
   this.cancelKeyXhr();
 
-  if (this.sourceBuffer) {
+  if (this.sourceBuffer && this.mediaSource.readyState === 'open') {
     this.sourceBuffer.abort();
   }
 };


### PR DESCRIPTION
#### Scenario
Loading hls source and changing source on end was firing an error for aborting a sourceBuffer whose parent mediaSource's readyState wasn't 'open'.

#### Reasoning
- Not sure if ffmpeg encoding related issue.
- Or browser-webkit related issue: https://w3c-test.org/media-source/SourceBuffer-abort-readyState.html
- Or maybe the fix is acceptable

#### Background
@lardawge claiming this in: https://github.com/videojs/videojs-contrib-hls/issues/382, among other mentions.

#### Conclussion
Not sure if fixing something or obscurifying another problem. Would appreciate some insight in this matter.