### PR TITLE
(development branch) fix calling abort on a sourceBuffer whose mediaSource.readyState != open

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -574,7 +574,7 @@ videojs.HlsHandler.prototype.resetSrc_ = function() {
   this.cancelSegmentXhr();
   this.cancelKeyXhr();
 
-  if (this.sourceBuffer) {
+  if (this.sourceBuffer && this.mediaSource.readyState === 'open') {
     this.sourceBuffer.abort();
   }
 };


### PR DESCRIPTION
This is PR #464 by @jvquarck but against the development branch. 90afb6f seems to be the only applicable commit, bb12d03 cannot be applied due to conflicts (it doesn't exist).