### PR TITLE
Firefox live

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -360,6 +360,10 @@
       return;
     }
 
+    if (update.uri !== outdated.uri) {
+      return;
+    }
+
     // try using precise timing from first segment of the updated
     // playlist
     if (update.segments.length) {

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -926,15 +926,11 @@ videojs.HlsHandler.prototype.fillBuffer = function(mediaIndex) {
       segmentInfo.playlist.mediaSequence + mediaIndex) + this.playlists.expired_;
   }
 
-  // If we have seeked into a non-buffered time-range, remove all buffered
-  // time-ranges because they could have been incorrectly placed originally
   if (this.tech_.seeking() && outsideBufferedRanges) {
     // If there are discontinuities in the playlist, we can't be sure of anything
     // related to time so we reset the timestamp offset and start appending data
     // anew on every seek
     if (segmentInfo.playlist.discontinuityStarts.length) {
-      // Now that the forward buffer is clear, we have to set timestamp offset to
-      // the start of the buffered region
       segmentInfo.timestampOffset = segmentTimestampOffset;
     }
   } else if (segment.discontinuity && currentBuffered.length) {

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -165,6 +165,8 @@ videojs.HlsHandler.prototype.src = function(src) {
   }
   this.playlists = new videojs.Hls.PlaylistLoader(this.source_.src, this.options_.withCredentials);
 
+  this.tech_.on('canplay', this.setupFirstPlay.bind(this));
+
   this.playlists.on('loadedmetadata', function() {
     oldMediaPlaylist = this.playlists.media();
 
@@ -422,7 +424,11 @@ videojs.HlsHandler.prototype.setupFirstPlay = function() {
       this.sourceBuffer &&
 
       // 4) the active media playlist is available
-      media) {
+      media &&
+
+      // 5) the video element or flash player is in a readyState of
+      // at least HAVE_FUTURE_DATA
+      this.tech_.readyState >= 3) {
 
     // seek to the latest media position for live videos
     seekable = this.seekable();
@@ -1138,7 +1144,6 @@ videojs.HlsHandler.prototype.drainBuffer = function() {
   segment = playlist.segments[mediaIndex];
 
   if (segment.key && !bytes) {
-
     // this is an encrypted segment
     // if the key download failed, we want to skip this segment
     // but if the key hasn't downloaded yet, we want to try again later

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -335,6 +335,8 @@ test('autoplay seeks to the live point after playlist load', function() {
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(player);
+  player.tech_.readyState = 3;
+  player.tech_.trigger('play');
   standardXHRResponse(requests.shift());
   clock.tick(1);
 
@@ -355,6 +357,8 @@ test('autoplay seeks to the live point after media source open', function() {
   clock.tick(1);
   standardXHRResponse(requests.shift());
   openMediaSource(player);
+  player.tech_.readyState = 3;
+  player.tech_.trigger('play');
   clock.tick(1);
 
   notEqual(currentTime, 0, 'seeked on autoplay');
@@ -406,6 +410,7 @@ test('calls `remove` on sourceBuffer to when loading a live segment', function()
   player.tech_.hls.playlists.trigger('loadedmetadata');
   player.tech_.trigger('canplay');
   player.tech_.paused = function() { return false; };
+  player.tech_.readyState = 3;
   player.tech_.trigger('play');
 
   clock.tick(1);
@@ -1683,6 +1688,7 @@ test('live playlist starts three target durations before live', function() {
   equal(requests.length, 0, 'no outstanding segment request');
 
   player.tech_.paused = function() { return false; };
+  player.tech_.readyState = 3;
   player.tech_.trigger('play');
   clock.tick(1);
   mediaPlaylist = player.tech_.hls.playlists.media();
@@ -1703,6 +1709,7 @@ test('live playlist starts with correct currentTime value', function() {
   player.tech_.hls.playlists.trigger('loadedmetadata');
 
   player.tech_.paused = function() { return false; };
+  player.tech_.readyState = 3;
   player.tech_.trigger('play');
   clock.tick(1);
 


### PR DESCRIPTION
A few enhancements and a big fix:
* Check that the playlist is still the same uri when we try to update expired_ in playlist loader. If we switch playlists, changes in the media-sequence value may no longer be a valid way of determining the time that has expire. 
* Move the timestampOffset calculation from `drainBuffer` to `fillBuffer`. The state of the player can change between those two functions so we should calculate where to place a segment when we decided which segment to fetch.
* Correct seek-to-live behavior in firefox. Firefox doesn't allow you to seek until `canplay` is fired and doesn't fire `canplay` until after playback has begun. As a result, seeking to the right point in a live stream requires setupFirstPlay to wait for `canplay` and checking that the `readyState` signifies that we can *finally* seek.