### PR TITLE
Fixed bug where currentTime is set beyond duration

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -497,6 +497,9 @@ videojs.Hls.prototype.updateDuration = function(playlist) {
   if (oldDuration !== newDuration) {
     player.trigger('durationchange');
   }
+  if (newDuration < this.currentTime()) {
+    this.setCurrentTime(newDuration);
+  }
 };
 
 /**


### PR DESCRIPTION
1. As `duration` changes, `currentTime` will be clamped to [0..duration] inclusive
1. A test or two proving this behavior is in place