### PR TITLE
Blacklist stuck manifests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videojs-contrib-hls",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "engines": {
     "node": ">= 0.10.12"
   },


### PR DESCRIPTION
Emit an error when a live playlist fails to update in a timely manner. This allows existing blacklisting code to run and attempt to recover by switching playlists.