### PR TITLE
fixed bug where initial playlist was blacklisted

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1007,7 +1007,7 @@ videojs.HlsHandler.prototype.blacklistCurrentPlaylist_ = function(error) {
 
   if (nextPlaylist) {
     videojs.log.warn('Problem encountered with the current HLS playlist. Switching to another playlist.');
-
+    this.player.trigger('loadedmetadata');
     return this.playlists.media(nextPlaylist);
   } else {
     videojs.log.warn('Problem encountered with the current HLS playlist. No suitable alternatives found.');


### PR DESCRIPTION
Made sure loadedmetadata was triggered when the second (non-failing playlist) is eventually loaded and parsed.