### PR TITLE
Fix the parsing of the ZEN-TOTAL-DURATION tag

### DIFF
--- a/src/m3u8/m3u8-parser.js
+++ b/src/m3u8/m3u8-parser.js
@@ -126,7 +126,7 @@
     }
 
     // Comments
-    if (line.indexOf('#EXT') !== 0) {
+    if (line.indexOf('#EXT') !== 0 && line.indexOf('#ZEN-TOTAL-DURATION:') !== 0) {
       this.trigger('data', {
         type: 'comment',
         text: line.slice(1)


### PR DESCRIPTION
The original implementation would always skip the `ZEN-TOTAL-DURATION` tag in [line 129](https://github.com/videojs/videojs-contrib-hls/compare/master...cllu:patch-1#diff-a523235bb2d98ee8619a642cbd1fd307L129).