### PR TITLE
Don’t process update end until buffered value has been set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ env:
   - secure: AnduYGXka5ft1x7V3SuVYqvlKLvJGhUaRNFdy4UDJr3ZVuwpQjE4TMDG8REmJIJvXfHbh4qY4N1cFSGnXkZ4bH21Xk0v9DLhsxbarKz+X2BvPgXs+Af9EQ6vLEy/5S1vMLxfT5+y+Ec5bVNGOsdUZby8Y21CRzSg6ADN9kwPGlE=
 addons:
   sauce_connect: true
+  firefox: latest

--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1229,12 +1229,19 @@ videojs.HlsHandler.prototype.updateEndHandler_ = function () {
     seekable,
     timelineUpdate;
 
-  this.pendingSegment_ = null;
-
   // stop here if the update errored or was aborted
   if (!segmentInfo) {
     return;
   }
+
+  // In Firefox, the updateend event is triggered for both removing from the buffer and
+  // adding to the buffer. To prevent this code from executing on removals, we wait for
+  // segmentInfo to have a filled in buffered value before we continue processing.
+  if (!segmentInfo.buffered) {
+    return;
+  }
+
+  this.pendingSegment_ = null;
 
   playlist = this.playlists.media();
   segments = playlist.segments;


### PR DESCRIPTION
In Firefox, the updateend event is triggered for both removing from the buffer and adding to the buffer. To prevent our update end handler from executing on removals, we wait for segmentInfo to have a filled in buffered value before we continue processing.

Note that another way of checking this would be to see that the bytes are cleared out of segmentInfo (pendingSegment_), however, I was not sure if this was the same behavior in all browsers, and checking for the buffered value seemed the safest approach. Although appendBuffer is also executed asynchronously, and in theory, it is possible that updateend may come from the removal when we expect an updateend from the append, from my testing, I have not seen it required to check this value (the timing seems to work out such that the updateend from the removal is run before we start appending).