### PR TITLE
Duration and endOfStream fixes

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -506,11 +506,23 @@ videojs.HlsHandler.prototype.setCurrentTime = function(currentTime) {
 };
 
 videojs.HlsHandler.prototype.duration = function() {
-  var playlists = this.playlists;
+  var
+    playlists = this.playlists,
+    playlistDuration;
+
   if (playlists) {
-    return videojs.Hls.Playlist.duration(playlists.media());
+    playlistDuration = videojs.Hls.Playlist.duration(playlists.media());
+  } else {
+    return 0;
   }
-  return 0;
+
+  if (playlistDuration === Infinity) {
+    return playlistDuration;
+  } else if (this.mediaSource) {
+    return this.mediaSource.duration;
+  } else {
+    return playlistDuration;
+  }
 };
 
 videojs.HlsHandler.prototype.seekable = function() {


### PR DESCRIPTION
Fixes `duration` reporting issues and corrects a bug in`updateEndHandler_` where we weren't always calling `mediaSource.endOfStream` when we should have been.