### PR TITLE
Fix buffer trimming so that it doesn't use seekable.start if it has a…

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -1052,7 +1052,8 @@ videojs.HlsHandler.prototype.loadSegment = function(segmentInfo) {
     self = this,
     segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex],
     removeToTime = 0,
-    seekable = this.seekable();
+    seekable = this.seekable(),
+    currentTime = this.tech_.currentTime();
 
   // Chrome has a hard limit of 150mb of buffer and a very conservative "garbage collector"
   // We manually clear out the old buffer to ensure we don't trigger the QuotaExceeded error
@@ -1060,10 +1061,10 @@ videojs.HlsHandler.prototype.loadSegment = function(segmentInfo) {
   if (this.sourceBuffer && !this.sourceBuffer.updating) {
     // If we have a seekable range use that as the limit for what can be removed safely
     // otherwise remove anything older than 1 minute before the current play head
-    if (seekable.length && seekable.start(0) > 0) {
+    if (seekable.length && seekable.start(0) > 0 && seekable.start(0) < currentTime) {
       removeToTime = seekable.start(0);
     } else {
-      removeToTime = this.tech_.currentTime() - 60;
+      removeToTime = currentTime - 60;
     }
 
     if (removeToTime > 0) {


### PR DESCRIPTION
… value greater than the currentTime

We had a bug previously where if the seekable range was [10, 20] but currentTime was, say, 8 seconds we would remove up to seekable.start (in this case 10) and remove buffer we haven't even played yet. This would stall playback.