### PR TITLE
Added an extra null check for mediaSource

### DIFF
--- a/src/videojs-hls.js
+++ b/src/videojs-hls.js
@@ -892,6 +892,7 @@ var filterBufferedRanges = function(predicate) {
     // report a fully empty buffer until SourceBuffers have been created
     // which is after a segment has been loaded and transmuxed.
     if (!this.mediaSource ||
+        !this.mediaSource.mediaSource_ ||
         !this.mediaSource.mediaSource_.sourceBuffers.length) {
       return videojs.createTimeRanges([]);
     }

--- a/test/videojs-hls_test.js
+++ b/test/videojs-hls_test.js
@@ -739,6 +739,13 @@ test('always returns an empty buffered region when there are no SourceBuffers', 
   equal(player.tech_.hls.findBufferedRange_().length,
         0,
         'empty TimeRanges returned');
+
+  // Simulate the condition with no media source
+  player.hls.mediaSource.mediaSource_ = undefined;
+
+  equal(player.tech_.hls.findBufferedRange_().length,
+        0,
+        'empty TimeRanges returned');
 });
 
 test('finds the correct buffered region based on currentTime', function() {


### PR DESCRIPTION
Added an extra null check for mediaSource, it looks like `this.mediaSource.mediaSource_` doesn't exist on an MSE-less browser causing the script to error out.