### PR TITLE
Audio/video track test page options

### DIFF
--- a/utils/stats/audio-track-selector.js
+++ b/utils/stats/audio-track-selector.js
@@ -1,0 +1,114 @@
+(function(videojs) {
+  var Component = videojs.getComponent('Component');
+
+  // -----------------
+  // AudioTrackMenuItem
+  // -----------------
+  //
+  var MenuItem = videojs.getComponent('MenuItem');
+
+  var AudioTrackMenuItem = videojs.extend(MenuItem, {
+    constructor: function(player, options) {
+      var track = options.track;
+      var tracks = player.audioTracks();
+
+      options.label = track.label || track.language || 'Unknown';
+      options.selected = track.enabled;
+
+      MenuItem.call(this, player, options);
+
+      this.track = track;
+
+      if (tracks) {
+        var changeHandler = videojs.bind(this, this.handleTracksChange);
+
+        tracks.addEventListener('change', changeHandler);
+        this.on('dispose', function() {
+          tracks.removeEventListener('change', changeHandler);
+        });
+      }
+    },
+
+    handleClick: function(event) {
+      var kind = this.track.kind;
+      var tracks = this.player_.audioTracks();
+
+      MenuItem.prototype.handleClick.call(this, event);
+
+      if (!tracks) return;
+
+      for (var i = 0; i < tracks.length; i++) {
+        var track = tracks[i];
+
+        if (track === this.track) {
+          track.enabled = true;
+        }
+      }
+    },
+
+    handleTracksChange: function(event) {
+      this.selected(this.track.enabled);
+    }
+  });
+
+  Component.registerComponent('AudioTrackMenuItem', AudioTrackMenuItem);
+
+  // -----------------
+  // AudioTrackButton
+  // -----------------
+  //
+  var MenuButton = videojs.getComponent('MenuButton');
+
+  var AudioTrackButton = videojs.extend(MenuButton, {
+    constructor: function(player, options) {
+      MenuButton.call(this, player, options);
+      this.el_.setAttribute('aria-label','Audio Menu');
+
+      var tracks = this.player_.audioTracks();
+
+      if (this.items.length <= 1) {
+        this.hide();
+      }
+
+      if (!tracks) {
+        return;
+      }
+
+      var updateHandler = videojs.bind(this, this.update);
+      tracks.addEventListener('removetrack', updateHandler);
+      tracks.addEventListener('addtrack', updateHandler);
+
+      this.player_.on('dispose', function() {
+        tracks.removeEventListener('removetrack', updateHandler);
+        tracks.removeEventListener('addtrack', updateHandler);
+      });
+    },
+
+    buildCSSClass() {
+      return 'vjs-subtitles-button ' + MenuButton.prototype.buildCSSClass.call(this);
+    },
+
+    createItems: function(items) {
+      items = items || [];
+
+      var tracks = this.player_.audioTracks();
+
+      if (!tracks) {
+        return items;
+      }
+
+      for (var i = 0; i < tracks.length; i++) {
+        var track = tracks[i];
+
+        items.push(new AudioTrackMenuItem(this.player_, {
+          'selectable': true,
+          'track': track
+        }));
+      }
+
+      return items;
+    }
+  });
+
+  Component.registerComponent('AudioTrackButton', AudioTrackButton);
+})(window.videojs);

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -51,7 +51,7 @@
   <form id="load-url">
     <label>
       URL to Load:
-      <input id="url-to-load" type="url" value="https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8">
+      <input id="url-to-load" type="url" value="http://solutions.brightcove.com/jwhisenant/hls/apple/bipbop/bipbopall.m3u8">
     </label>
     <br>
     <label>

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -28,13 +28,12 @@
       padding: 0 5px;
       margin: 20px 0;
     }
-  </style>
-
-  <script>
-    if (window.location.search === '?flash') {
-      videojs.options.techOrder = ['flash'];
+    input {
+      margin-top: 15px;
+      min-width: 450px;
+      padding: 5px;
     }
-  </script>
+  </style>
 
 </head>
 <body>
@@ -42,18 +41,50 @@
     <p>The video below is an <a href="https://developer.apple.com/library/ios/documentation/networkinginternet/conceptual/streamingmediaguide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40008332-CH1-SW1">HTTP Live Stream</a>. On desktop browsers other than Safari, the HLS plugin will polyfill support for the format on top of the video.js Flash tech.</p>
     <p>Due to security restrictions in Flash, you will have to load this page over HTTP(S) to see the example in action.</p>
   </div>
-  <video id="video"
-         class="video-js vjs-default-skin"
-         height="300"
-         width="600"
-         controls>
-    <source
-       src="http://solutions.brightcove.com/jwhisenant/hls/apple/bipbop/bipbopall.m3u8"
-       type="application/x-mpegURL">
-    <source
-       src="http://s3.amazonaws.com/_bc_dml/example-content/bipbop-id3/index.m3u8"
-       type="application/x-mpegURL">
-  </video>
+
+  <div id="fixture">
+  </div>
+
+  <form id="load-url">
+    <label>
+      URL to Load:
+      <input id="url-to-load" type="url" value="http://solutions.brightcove.com/jwhisenant/hls/apple/bipbop/bipbopall.m3u8">
+    </label>
+    <br>
+    <label>
+      Player Options:
+      <input id="player-options" type="text" value='{}'>
+    </label>
+    <br>
+    <label>
+      URL Content Type:
+      <input id="url-content-type" type="text" value="application/x-mpegURL">
+    </label>
+    <br>
+    <label>
+      Default Caption Track Label (blank for none):
+      <input id="caption-track" type="text" value="">
+    </label>
+    <br>
+    <label>
+      Technology Mode:
+      <input type="radio" name="technology-mode" value="auto" checked> Auto
+      <input type="radio" name="technology-mode" value="html"> HTML
+      <input type="radio" name="technology-mode" value="flash"> Flash
+    </label>
+    <br>
+    <label>
+      Autoplay:
+      <input type="radio" name="autoplay" value="on"> On
+      <input type="radio" name="autoplay" value="off" checked> Off
+    </label>
+
+    <br>
+    <br>
+    <button type="submit">Load</button>
+  </form>
+  <br>
+
   <section class="stats">
     <div class="player-stats">
       <h2>Player Stats</h2>
@@ -94,9 +125,93 @@
 
   <script src="stats.js"></script>
   <script>
-    videojs.options.flash.swf = '../../node_modules/videojs-swf/dist/video-js.swf';
-    // initialize the player
-    var player = videojs('video').ready(function() {
+    function getCheckedValue(name) {
+      var radios = document.getElementsByName(name);
+      var value;
+      for (var i = 0, length = radios.length; i < length; i++) {
+        if (radios[i].checked) {
+          value = radios[i].value;
+          break;
+        }
+      }
+      return value;
+    }
+    function createPlayer() {
+      // dispose of existing player
+      if(window.player) {
+        window.player.dispose();
+      }
+      // create video element in the dom
+      var video = document.createElement('video');
+      video.id = 'videojs-contrib-hls-player';
+      video.className = 'video-js vjs-default-skin';
+      video.setAttribute('controls', true);
+      video.setAttribute('height', 300);
+      video.setAttribute('width', 600);
+      document.querySelector('#fixture').appendChild(video);
+      var techRadios = document.getElementsByName('technology-mode');
+      var techMode = getCheckedValue('technology-mode') || 'auto';
+      var autoplay = getCheckedValue('autoplay') || 'off';
+      var captionTrack = document.getElementById('caption-track').value || "";
+      var url = document.getElementById('url-to-load').value || "";
+      var options = {};
+      // try to parse options from the form
+      try {
+        options = JSON.parse(document.getElementById('player-options').value);
+      } catch(err) {
+        console.log("Reseting options to {}, JSON Parse Error:", err);
+      }
+      if(typeof options.techOrder === 'undefined') {
+        if (techMode === 'html') {
+          options.techOrder = ['html5'];
+        } else if (techMode === 'flash') {
+          options.techOrder = ['flash'];
+        }
+      }
+      if(typeof options.autoplay === 'undefined') {
+        if (autoplay === 'on') {
+          options.autoplay = true;
+        } else if (techMode === 'off') {
+          options.autoplay = false;
+        }
+      }
+      var type = document.getElementById('url-content-type').value;
+      // use the form data to add a src to the player
+      try {
+        window.player = videojs(video.id, options);
+        if(captionTrack) {
+          // hackey way to show captions
+          window.player.on('loadeddata', function(event) {
+            textTracks = this.textTracks().tracks_;
+            for(var i = 0; i < textTracks.length; i++) {
+              if(textTracks[i].label === captionTrack) {
+                console.log("Found matching track, going to show " + captionTrack);
+                textTracks[i].mode = "showing";
+                break;
+              }
+            }
+          });
+        }
+        window.player.src({
+          src: url,
+          type: type
+        });
+      } catch(err) {
+        console.log("caught an error trying to create and add src to player:", err);
+      }
+    }
+    (function(window, videojs) {
+      videojs.options.flash.swf = '../../node_modules/videojs-swf/dist/video-js.swf';
+      createPlayer();
+      // hook up the video switcher
+      document.getElementById('load-url').addEventListener('submit', function(event) {
+        event.preventDefault();
+        createPlayer();
+        return false;
+      });
+    }(window, window.videojs));
+
+    player.ready(function() {
 
       // ------------
       // Player Stats
@@ -169,22 +284,6 @@
       videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
       videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
     });
-
-    // -----------
-    // Tech Switch
-    // -----------
-
-    var techSwitch = document.createElement('a');
-    techSwitch.className = 'tech-switch';
-    if (player.el().querySelector('video')) {
-      techSwitch.href = window.location.origin + window.location.pathname + '?flash';
-      techSwitch.appendChild(document.createTextNode('Switch to the Flash tech'));
-    } else {
-      techSwitch.href = window.location.origin + window.location.pathname;
-      techSwitch.appendChild(document.createTextNode('Stop forcing Flash'));
-    }
-
-    document.body.insertBefore(techSwitch, document.querySelector('.stats'));
 
   </script>
 </body>

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -139,7 +139,8 @@
       }
       return value;
     }
-    function createPlayer() {
+
+    function createPlayer(cb) {
       // dispose of existing player
       if(window.player) {
         window.player.dispose();
@@ -199,101 +200,105 @@
           src: url,
           type: type
         });
+
+        cb(player);
       } catch(err) {
         console.log("caught an error trying to create and add src to player:", err);
       }
     }
+
+    function setup(player) {
+      player.ready(function() {
+
+        // ------------
+        // Audio Track Switcher
+        // ------------
+
+        player.controlBar.addChild('AudioTrackButton', {}, 13);
+
+        // ------------
+        // Player Stats
+        // ------------
+
+        var currentTimeStat = document.querySelector('.current-time-stat');
+        var bufferedStat = document.querySelector('.buffered-stat');
+        var seekableStartStat = document.querySelector('.seekable-start-stat');
+        var seekableEndStat = document.querySelector('.seekable-end-stat');
+        var videoBitrateState = document.querySelector('.video-bitrate-stat');
+        var measuredBitrateStat = document.querySelector('.measured-bitrate-stat');
+
+        player.on('timeupdate', function() {
+          currentTimeStat.textContent = player.currentTime().toFixed(1);
+        });
+
+        window.setInterval(function() {
+          var bufferedText = '', oldStart, oldEnd, i;
+
+          // buffered
+          var buffered = player.buffered();
+          if (buffered.length) {
+            bufferedText += buffered.start(0) + ' - ' + buffered.end(0);
+          }
+          for (i = 1; i < buffered.length; i++) {
+            bufferedText += ', ' + buffered.start(i) + ' - ' + buffered.end(i);
+          }
+          bufferedStat.textContent = bufferedText;
+
+          // seekable
+          var seekable = player.seekable();
+          if (seekable && seekable.length) {
+
+            oldStart = seekableStartStat.textContent;
+            if (seekable.start(0).toFixed(1) !== oldStart) {
+              seekableStartStat.textContent = seekable.start(0).toFixed(1);
+            }
+            oldEnd = seekableEndStat.textContent;
+            if (seekable.end(0).toFixed(1) !== oldEnd) {
+              seekableEndStat.textContent = seekable.end(0).toFixed(1);
+            }
+          }
+
+          // bitrates
+          var playlist = player.tech_.hls.playlists.media();
+          if (playlist && playlist.attributes && playlist.attributes.BANDWIDTH) {
+            videoBitrateState.textContent = (playlist.attributes.BANDWIDTH / 1024).toLocaleString(undefined, {
+              maximumFractionDigits: 1
+            }) + ' kbps';
+          }
+          if (player.tech_.hls.bandwidth) {
+            measuredBitrateStat.textContent = (player.tech_.hls.bandwidth / 1024).toLocaleString(undefined, {
+              maximumFractionDigits: 1
+            }) + ' kbps';
+          }
+        }, 1000);
+
+        var trackEventCount = function(eventName, selector) {
+          var count = 0, element = document.querySelector(selector);
+          player.on(eventName, function() {
+            count++;
+            element.innerHTML = count;
+          });
+        };
+        trackEventCount('play', '.play-count');
+        trackEventCount('playing', '.playing-count');
+        trackEventCount('seeking', '.seeking-count');
+        trackEventCount('seeked', '.seeked-count');
+
+        videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
+        videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
+      });
+    }
+
     (function(window, videojs) {
       videojs.options.flash.swf = '../../node_modules/videojs-swf/dist/video-js.swf';
-      createPlayer();
+      createPlayer(setup);
       // hook up the video switcher
       document.getElementById('load-url').addEventListener('submit', function(event) {
         event.preventDefault();
-        createPlayer();
+        createPlayer(setup);
         return false;
       });
     }(window, window.videojs));
-
-    player.ready(function() {
-
-      // ------------
-      // Audio Track Switcher
-      // ------------
-
-      player.controlBar.addChild('AudioTrackButton', {}, 13);
-
-      // ------------
-      // Player Stats
-      // ------------
-
-      var currentTimeStat = document.querySelector('.current-time-stat');
-      var bufferedStat = document.querySelector('.buffered-stat');
-      var seekableStartStat = document.querySelector('.seekable-start-stat');
-      var seekableEndStat = document.querySelector('.seekable-end-stat');
-      var videoBitrateState = document.querySelector('.video-bitrate-stat');
-      var measuredBitrateStat = document.querySelector('.measured-bitrate-stat');
-
-      player.on('timeupdate', function() {
-        currentTimeStat.textContent = player.currentTime().toFixed(1);
-      });
-
-      window.setInterval(function() {
-        var bufferedText = '', oldStart, oldEnd, i;
-
-        // buffered
-        var buffered = player.buffered();
-        if (buffered.length) {
-          bufferedText += buffered.start(0) + ' - ' + buffered.end(0);
-        }
-        for (i = 1; i < buffered.length; i++) {
-          bufferedText += ', ' + buffered.start(i) + ' - ' + buffered.end(i);
-        }
-        bufferedStat.textContent = bufferedText;
-
-        // seekable
-        var seekable = player.seekable();
-        if (seekable && seekable.length) {
-
-          oldStart = seekableStartStat.textContent;
-          if (seekable.start(0).toFixed(1) !== oldStart) {
-            seekableStartStat.textContent = seekable.start(0).toFixed(1);
-          }
-          oldEnd = seekableEndStat.textContent;
-          if (seekable.end(0).toFixed(1) !== oldEnd) {
-            seekableEndStat.textContent = seekable.end(0).toFixed(1);
-          }
-        }
-
-        // bitrates
-        var playlist = player.tech_.hls.playlists.media();
-        if (playlist && playlist.attributes && playlist.attributes.BANDWIDTH) {
-          videoBitrateState.textContent = (playlist.attributes.BANDWIDTH / 1024).toLocaleString(undefined, {
-            maximumFractionDigits: 1
-          }) + ' kbps';
-        }
-        if (player.tech_.hls.bandwidth) {
-          measuredBitrateStat.textContent = (player.tech_.hls.bandwidth / 1024).toLocaleString(undefined, {
-            maximumFractionDigits: 1
-          }) + ' kbps';
-        }
-      }, 1000);
-
-      var trackEventCount = function(eventName, selector) {
-        var count = 0, element = document.querySelector(selector);
-        player.on(eventName, function() {
-          count++;
-          element.innerHTML = count;
-        });
-      };
-      trackEventCount('play', '.play-count');
-      trackEventCount('playing', '.playing-count');
-      trackEventCount('seeking', '.seeking-count');
-      trackEventCount('seeked', '.seeked-count');
-
-      videojs.Hls.displayStats(document.querySelector('.switching-stats'), player);
-      videojs.Hls.displayCues(document.querySelector('.segment-timeline'), player);
-    });
-
   </script>
 </body>
 </html>

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -12,6 +12,9 @@
   <!-- HLS plugin -->
   <script src="../../dist/videojs-contrib-hls.js"></script>
 
+  <!-- Track Selector plugin -->
+  <script src="audio-track-selector.js"></script>
+
   <!-- player stats visualization -->
   <link href="stats.css" rel="stylesheet">
   <script src="../switcher/js/vendor/d3.min.js"></script>
@@ -48,7 +51,7 @@
   <form id="load-url">
     <label>
       URL to Load:
-      <input id="url-to-load" type="url" value="http://solutions.brightcove.com/jwhisenant/hls/apple/bipbop/bipbopall.m3u8">
+      <input id="url-to-load" type="url" value="https://devimages.apple.com.edgekey.net/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8">
     </label>
     <br>
     <label>
@@ -84,21 +87,6 @@
     <button type="submit">Load</button>
   </form>
   <br>
-
-  <div class="audio-tracks">
-    <label>Select Audio Track:
-      <select></select>
-    </label>
-    <div class="track-info"></div>
-  </div>
-  <br>
-
-  <div class="video-tracks">
-    <label>Select Video Track:
-      <select></select>
-    </label>
-    <div class="track-info"></div>
-  </div>
 
   <section class="stats">
     <div class="player-stats">
@@ -229,58 +217,10 @@
     player.ready(function() {
 
       // ------------
-      // Audio/Video Track Switcher
+      // Audio Track Switcher
       // ------------
 
-      //TODO: mock, remove this
-      player.audioTracks = function() {
-        return [{label:'English',enabled:false},{label:'Spanish',enabled:false}];
-      };
-      player.videoTracks = function() {
-        return [{label:'English',enabled:false},{label:'Spanish',enabled:false}];
-      };
-      //TODO: mock, remove this
-
-      player.on('loadstart', function() {
-        var
-          audioTracks = player.audioTracks(),
-          videoTracks = player.audioTracks(),
-          select;
-
-        if (audioTracks.length) {
-          select = document.querySelector('.audio-tracks select');
-          select.innerHTML = '';
-          audioTracks.map(function(track, i) {
-            var option = document.createElement('option');
-            option.label = track.label || i;
-            option.value = i;
-            select.appendChild(option);
-          });
-
-          select.onchange = function() {
-            player.audioTracks()[this.value].enabled = true;
-
-            document.querySelector('.audio-tracks .track-info').innerText = JSON.stringify(player.audioTracks());
-          };
-        }
-
-        if (videoTracks.length) {
-          select = document.querySelector('.video-tracks select');
-          select.innerHTML = '';
-          videoTracks.map(function(track, i) {
-            var option = document.createElement('option');
-            option.label = track.label || i;
-            option.value = i;
-            select.appendChild(option);
-          });
-
-          select.onchange = function() {
-            player.videoTracks()[this.value].enabled = true;
-
-            document.querySelector('.video-tracks .track-info').innerText = JSON.stringify(player.videoTracks());
-          };
-        }
-      });
+      player.controlBar.addChild('AudioTrackButton', {}, 13);
 
       // ------------
       // Player Stats

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -85,6 +85,21 @@
   </form>
   <br>
 
+  <div class="audio-tracks">
+    <label>Select Audio Track:
+      <select></select>
+    </label>
+    <div class="track-info"></div>
+  </div>
+  <br>
+
+  <div class="video-tracks">
+    <label>Select Video Track:
+      <select></select>
+    </label>
+    <div class="track-info"></div>
+  </div>
+
   <section class="stats">
     <div class="player-stats">
       <h2>Player Stats</h2>
@@ -212,6 +227,60 @@
     }(window, window.videojs));
 
     player.ready(function() {
+
+      // ------------
+      // Audio/Video Track Switcher
+      // ------------
+
+      //TODO: mock, remove this
+      player.audioTracks = function() {
+        return [{label:'English',enabled:false},{label:'Spanish',enabled:false}];
+      };
+      player.videoTracks = function() {
+        return [{label:'English',enabled:false},{label:'Spanish',enabled:false}];
+      };
+      //TODO: mock, remove this
+
+      player.on('loadstart', function() {
+        var
+          audioTracks = player.audioTracks(),
+          videoTracks = player.audioTracks(),
+          select;
+
+        if (audioTracks.length) {
+          select = document.querySelector('.audio-tracks select');
+          select.innerHTML = '';
+          audioTracks.map(function(track, i) {
+            var option = document.createElement('option');
+            option.label = track.label || i;
+            option.value = i;
+            select.appendChild(option);
+          });
+
+          select.onchange = function() {
+            player.audioTracks()[this.value].enabled = true;
+
+            document.querySelector('.audio-tracks .track-info').innerText = JSON.stringify(player.audioTracks());
+          };
+        }
+
+        if (videoTracks.length) {
+          select = document.querySelector('.video-tracks select');
+          select.innerHTML = '';
+          videoTracks.map(function(track, i) {
+            var option = document.createElement('option');
+            option.label = track.label || i;
+            option.value = i;
+            select.appendChild(option);
+          });
+
+          select.onchange = function() {
+            player.videoTracks()[this.value].enabled = true;
+
+            document.querySelector('.video-tracks .track-info').innerText = JSON.stringify(player.videoTracks());
+          };
+        }
+      });
 
       // ------------
       // Player Stats

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -9,28 +9,13 @@
   <!-- video.js -->
   <script src="../../node_modules/video.js/dist/video.js"></script>
 
-  <!-- Media Sources plugin -->
-  <script src="../../node_modules/videojs-contrib-media-sources/dist/videojs-media-sources.js"></script>
-
   <!-- HLS plugin -->
-  <script src="../../src/videojs-hls.js"></script>
-
-  <!-- m3u8 handling -->
-  <script src="../../src/xhr.js"></script>
-  <script src="../../src/stream.js"></script>
-  <script src="../../src/m3u8/m3u8-parser.js"></script>
-  <script src="../../src/playlist.js"></script>
-  <script src="../../src/playlist-loader.js"></script>
-
-  <script src="../../node_modules/pkcs7/dist/pkcs7.unpad.js"></script>
-  <script src="../../src/decrypter.js"></script>
+  <script src="../../dist/videojs-contrib-hls.js"></script>
 
   <!-- player stats visualization -->
   <link href="stats.css" rel="stylesheet">
   <script src="../switcher/js/vendor/d3.min.js"></script>
 
-  <!-- debugging -->
-  <script src="../../src/bin-utils.js"></script>
   <style>
     body {
       font-family: Arial, sans-serif;


### PR DESCRIPTION
This PR adds dropdowns to select video and audio tracks. This also includes changes from #560 

Todo: 
- [x] remove fake `audioTracks()` / `videoTracks()`