### PR TITLE
[WIP] Master Playlist Controller + Support for Alternate Audio Track Loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   ],
   "dependencies": {
     "pkcs7": "^0.2.2",
-    "video.js": "^5.2.1",
+    "video.js": "^5.9.0-0",
     "videojs-contrib-media-sources": "^3.0.0",
     "videojs-swf": "^5.0.0"
   },

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1,4 +1,3 @@
-import Stream from './stream';
 import PlaylistLoader from './playlist-loader';
 import SegmentLoader from './segment-loader';
 import Ranges from './ranges';
@@ -155,7 +154,7 @@ const selectPlaylist = function() {
     sortedPlaylists[0];
 };
 
-export default class MasterPlaylistController extends Stream {
+export default class MasterPlaylistController extends videojs.EventTarget {
   constructor({url, withCredentials, currentTimeFunc, mediaSourceMode, hlsHandler,
     externHls}) {
     super();
@@ -221,8 +220,8 @@ export default class MasterPlaylistController extends Stream {
       this.updateDuration(this.masterPlaylistLoader_.media());
 
       // update seekable
-      seekable = this.hlsHandler.seekable();
-      if (this.hlsHandler.duration() === Infinity && seekable.length !== 0) {
+      seekable = this.seekable();
+      if (!updatedPlaylist.endList && seekable.length !== 0) {
         this.mediaSource.addSeekableRange_(seekable.start(0), seekable.end(0));
       }
     });
@@ -318,8 +317,8 @@ export default class MasterPlaylistController extends Stream {
 
     // check that everything is ready to begin buffering
 
-    // 1) the video is a live stream of unknown duration
-    if (this.hlsHandler.duration() === Infinity &&
+    // 1) the video is a live stream
+    if (!media.endList &&
 
         // 2) the player has not played before and is not paused
         this.hlsHandler.tech_.played().length === 0 &&
@@ -338,7 +337,7 @@ export default class MasterPlaylistController extends Stream {
         this.masterPlaylistLoader_.trigger('firstplay');
 
         // seek to the latest media position for live videos
-        seekable = this.hlsHandler.seekable();
+        seekable = this.seekable();
         if (seekable.length) {
           this.hlsHandler.tech_.setCurrentTime(seekable.end(0));
         }
@@ -396,7 +395,7 @@ export default class MasterPlaylistController extends Stream {
     return this.mediaSource.endOfStream('network');
   }
 
-  pause() {
+  pauseLoading() {
     this.mainSegmentLoader_.pause();
     if (this.audioPlaylistLoader_) {
       this.audioSegmentLoader_.pause();

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -211,12 +211,17 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       throw new Error('A non-empty playlist URL is required');
     }
 
-    this.masterPlaylistLoader_ = new PlaylistLoader(url, this.withCredentials);
+    this.masterPlaylistLoader_ = new PlaylistLoader({
+      srcUrl: url,
+      withCredentials: this.withCredentials,
+      startLoading: true
+    });
     this.hlsHandler.playlists = this.masterPlaylistLoader_;
 
     this.masterPlaylistLoader_.on('loadedmetadata', () => {
       let media = this.masterPlaylistLoader_.media();
       let master = this.masterPlaylistLoader_.master;
+      let alternateAudioUri;
 
       // if this isn't a live video and preload permits, start
       // downloading segments
@@ -227,14 +232,15 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         this.mainSegmentLoader_.load();
       }
 
-      this.audioPlaylistLoaders_ = [];
+      this.audioPlaylistLoaders_ = {};
       if (master.mediaGroups && master.mediaGroups.AUDIO) {
         for (let groupKey in master.mediaGroups.AUDIO) {
           for (let labelKey in master.mediaGroups.AUDIO[groupKey]) {
-            this.audioPlaylistLoaders_.push(new PlaylistLoader(
-              master.mediaGroups.AUDIO[groupKey][labelKey].uri,
-              this.withCredentials,
-              true));
+            alternateAudioUri = master.mediaGroups.AUDIO[groupKey][labelKey].uri;
+            this.audioPlaylistLoaders_[alternateAudioUri] = new PlaylistLoader({
+              srcUrl: alternateAudioUri,
+              withCredentials: this.withCredentials
+            });
           }
         }
       }
@@ -294,10 +300,14 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.audioSegmentLoader_.on('error', () => {
+      videojs.log.warn('Problem encountered with the current alternate audio track' +
+                       '. Switching back to default.');
       this.audioSegmentLoader_.abort();
       this.audioPlaylistLoader_ = null;
       this.useAudio('main');
     });
+
+    this.masterPlaylistLoader_.load();
   }
 
   load() {
@@ -325,16 +335,12 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     audioEntry =
       this.masterPlaylistLoader_.master.mediaGroups.AUDIO[mediaGroupName][label];
 
-    this.audioPlaylistLoaders_.forEach((audioPlaylistLoader) => {
-      if (audioPlaylistLoader.srcUrl === audioEntry.uri) {
-        newAudioPlaylistLoader = audioPlaylistLoader;
-      }
-    });
+    newAudioPlaylistLoader = this.audioPlaylistLoaders_[audioEntry.uri];
 
     if (!newAudioPlaylistLoader.started) {
       this.loadAlternateAudioPlaylistLoader_(newAudioPlaylistLoader);
     } else {
-      newAudioPlaylistLoader.resume();
+      newAudioPlaylistLoader.load();
       this.audioSegmentLoader_.load();
     }
   }
@@ -376,6 +382,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.audioPlaylistLoader_.on('error', () => {
+      videojs.log.warn('Problem encountered loading the alternate audio track' +
+                       '. Switching back to default.');
       this.audioSegmentLoader_.abort();
       this.audioPlaylistLoader_ = null;
       this.useAudio('main');

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -211,11 +211,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       throw new Error('A non-empty playlist URL is required');
     }
 
-    this.masterPlaylistLoader_ = new PlaylistLoader({
-      srcUrl: url,
-      withCredentials: this.withCredentials,
-      startLoading: true
-    });
+    this.masterPlaylistLoader_ = new PlaylistLoader(url, this.withCredentials);
     this.hlsHandler.playlists = this.masterPlaylistLoader_;
 
     this.masterPlaylistLoader_.on('loadedmetadata', () => {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1,0 +1,325 @@
+import Stream from './stream';
+import PlaylistLoader from './playlist-loader';
+import SegmentLoader from './segment-loader';
+import Ranges from './ranges';
+import videojs from 'video.js';
+
+// 5 minute blacklist
+const BLACKLIST_DURATION = 5 * 60 * 1000;
+
+// A fudge factor to apply to advertised playlist bitrates to account for
+// temporary flucations in client bandwidth
+const BANDWIDTH_VARIANCE = 1.2;
+
+let Hls;
+
+/**
+ * Returns the CSS value for the specified property on an element
+ * using `getComputedStyle`. Firefox has a long-standing issue where
+ * getComputedStyle() may return null when running in an iframe with
+ * `display: none`.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+ */
+const safeGetComputedStyle = function(el, property) {
+  let result;
+
+  if (!el) {
+    return '';
+  }
+
+  result = getComputedStyle(el);
+  if (!result) {
+    return '';
+  }
+
+  return result[property];
+};
+
+/**
+ * Chooses the appropriate media playlist based on the current
+ * bandwidth estimate and the player size.
+ * @return the highest bitrate playlist less than the currently detected
+ * bandwidth, accounting for some amount of bandwidth variance
+ */
+const selectPlaylist = function() {
+  let effectiveBitrate;
+  let sortedPlaylists = this.playlists.master.playlists.slice();
+  let bandwidthPlaylists = [];
+  let now = +new Date();
+  let i;
+  let variant;
+  let bandwidthBestVariant;
+  let resolutionPlusOne;
+  let resolutionPlusOneAttribute;
+  let resolutionBestVariant;
+  let width;
+  let height;
+
+  sortedPlaylists.sort(Hls.comparePlaylistBandwidth);
+
+  // filter out any playlists that have been excluded due to
+  // incompatible configurations or playback errors
+  sortedPlaylists = sortedPlaylists.filter((localVariant) => {
+    if (typeof localVariant.excludeUntil !== 'undefined') {
+      return now >= localVariant.excludeUntil;
+    }
+    return true;
+  });
+
+  // filter out any variant that has greater effective bitrate
+  // than the current estimated bandwidth
+  i = sortedPlaylists.length;
+  while (i--) {
+    variant = sortedPlaylists[i];
+
+    // ignore playlists without bandwidth information
+    if (!variant.attributes || !variant.attributes.BANDWIDTH) {
+      continue;
+    }
+
+    effectiveBitrate = variant.attributes.BANDWIDTH * BANDWIDTH_VARIANCE;
+
+    if (effectiveBitrate < this.bandwidth) {
+      bandwidthPlaylists.push(variant);
+
+      // since the playlists are sorted in ascending order by
+      // bandwidth, the first viable variant is the best
+      if (!bandwidthBestVariant) {
+        bandwidthBestVariant = variant;
+      }
+    }
+  }
+
+  i = bandwidthPlaylists.length;
+
+  // sort variants by resolution
+  bandwidthPlaylists.sort(Hls.comparePlaylistResolution);
+
+  // forget our old variant from above,
+  // or we might choose that in high-bandwidth scenarios
+  // (this could be the lowest bitrate rendition as  we go through all of them above)
+  variant = null;
+
+  width = parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10);
+  height = parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10);
+
+  // iterate through the bandwidth-filtered playlists and find
+  // best rendition by player dimension
+  while (i--) {
+    variant = bandwidthPlaylists[i];
+
+    // ignore playlists without resolution information
+    if (!variant.attributes ||
+        !variant.attributes.RESOLUTION ||
+        !variant.attributes.RESOLUTION.width ||
+        !variant.attributes.RESOLUTION.height) {
+      continue;
+    }
+
+    // since the playlists are sorted, the first variant that has
+    // dimensions less than or equal to the player size is the best
+
+    let variantResolution = variant.attributes.RESOLUTION;
+
+    if (variantResolution.width === width &&
+        variantResolution.height === height) {
+      // if we have the exact resolution as the player use it
+      resolutionPlusOne = null;
+      resolutionBestVariant = variant;
+      break;
+    } else if (variantResolution.width < width &&
+               variantResolution.height < height) {
+      // if both dimensions are less than the player use the
+      // previous (next-largest) variant
+      break;
+    } else if (!resolutionPlusOne ||
+               (variantResolution.width < resolutionPlusOneAttribute.width &&
+                variantResolution.height < resolutionPlusOneAttribute.height)) {
+      // If we still haven't found a good match keep a
+      // reference to the previous variant for the next loop
+      // iteration
+
+      // By only saving variants if they are smaller than the
+      // previously saved variant, we ensure that we also pick
+      // the highest bandwidth variant that is just-larger-than
+      // the video player
+      resolutionPlusOne = variant;
+      resolutionPlusOneAttribute = resolutionPlusOne.attributes.RESOLUTION;
+    }
+  }
+
+  // fallback chain of variants
+  return resolutionPlusOne ||
+    resolutionBestVariant ||
+    bandwidthBestVariant ||
+    sortedPlaylists[0];
+};
+
+export default class MasterPlaylistController extends Stream {
+  constructor({url, withCredentials, currentTimeFunc, mediaSource, hlsHandler,
+    externHls}) {
+    super();
+
+    this.segmentLoader_ = new SegmentLoader({
+      mediaSource,
+      currentTime: currentTimeFunc,
+      withCredentials
+    });
+    this.hlsHandler = hlsHandler;
+
+    Hls = externHls;
+
+    this.hlsHandler.selectPlaylist = this.hlsHandler.selectPlaylist || selectPlaylist;
+
+    if (!url) {
+      throw new Error('A non-empty playlist URL is required');
+    }
+
+    this.masterPlaylistLoader_ = new PlaylistLoader(url, withCredentials);
+    this.hlsHandler.playlists = this.masterPlaylistLoader_;
+
+    this.masterPlaylistLoader_.on('loadedmetadata', () => {
+      // if this isn't a live video and preload permits, start
+      // downloading segments
+      if (this.masterPlaylistLoader_.media().endList &&
+          this.hlsHandler.tech_.preload() !== 'metadata' &&
+          this.hlsHandler.tech_.preload() !== 'none') {
+        this.segmentLoader_.playlist(this.masterPlaylistLoader_.media());
+        this.segmentLoader_.load();
+      }
+
+      this.hlsHandler.setupSourceBuffer_();
+      this.hlsHandler.setupFirstPlay();
+      this.hlsHandler.tech_.trigger('loadedmetadata');
+    });
+
+    this.masterPlaylistLoader_.on('loadedplaylist', () => {
+      let updatedPlaylist = this.masterPlaylistLoader_.media();
+      let seekable;
+
+      if (!updatedPlaylist) {
+        // select the initial variant
+        this.masterPlaylistLoader_.media(this.hlsHandler.selectPlaylist());
+        return;
+      }
+
+      this.segmentLoader_.playlist(updatedPlaylist);
+      this.hlsHandler.updateDuration(this.masterPlaylistLoader_.media());
+
+      // update seekable
+      seekable = this.hlsHandler.seekable();
+      if (this.hlsHandler.duration() === Infinity && seekable.length !== 0) {
+        this.hlsHandler.mediaSource.addSeekableRange_(seekable.start(0), seekable.end(0));
+      }
+    });
+
+    this.masterPlaylistLoader_.on('error', () => {
+      this.blacklistCurrentPlaylist_(this.masterPlaylistLoader_.error);
+    });
+
+    this.masterPlaylistLoader_.on('mediachanging', () => {
+      this.segmentLoader_.pause();
+    });
+
+    this.masterPlaylistLoader_.on('mediachange', () => {
+      this.segmentLoader_.abort();
+      this.segmentLoader_.load();
+      this.hlsHandler.tech_.trigger({
+        type: 'mediachange',
+        bubbles: true
+      });
+    });
+
+    this.segmentLoader_.on('progress', () => {
+      // figure out what stream the next segment should be downloaded from
+      // with the updated bandwidth information
+      this.hlsHandler.bandwidth = this.segmentLoader_.bandwidth;
+      this.masterPlaylistLoader_.media(this.hlsHandler.selectPlaylist());
+
+      this.tech_.trigger('progress');
+    });
+
+    this.segmentLoader_.on('error', () => {
+      this.blacklistCurrentPlaylist_(this.segmentLoader_.error());
+    });
+  }
+
+  /*
+   * Blacklists a playlist when an error occurs for a set amount of time
+   * making it unavailable for selection by the rendition selection algorithm
+   * and then forces a new playlist (rendition) selection.
+   */
+  blacklistCurrentPlaylist_(error) {
+    let currentPlaylist;
+    let nextPlaylist;
+
+    // If the `error` was generated by the playlist loader, it will contain
+    // the playlist we were trying to load (but failed) and that should be
+    // blacklisted instead of the currently selected playlist which is likely
+    // out-of-date in this scenario
+    currentPlaylist = error.playlist || this.masterPlaylistLoader_.media();
+
+    // If there is no current playlist, then an error occurred while we were
+    // trying to load the master OR while we were disposing of the tech
+    if (!currentPlaylist) {
+      this.hlsHandler.error = error;
+      return this.hlsHandler.mediaSource.endOfStream('network');
+    }
+
+    // Blacklist this playlist
+    currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
+
+    // Select a new playlist
+    nextPlaylist = this.hlsHandler.selectPlaylist();
+
+    if (nextPlaylist) {
+      videojs.log.warn('Problem encountered with the current ' +
+                       'HLS playlist. Switching to another playlist.');
+
+      return this.masterPlaylistLoader_.media(nextPlaylist);
+    }
+    videojs.log.warn('Problem encountered with the current ' +
+                     'HLS playlist. No suitable alternatives found.');
+    // We have no more playlists we can select so we must fail
+    this.hlsHandler.error = error;
+    return this.hlsHandler.mediaSource.endOfStream('network');
+  }
+
+  pause() {
+    this.segmentLoader_.pause();
+  }
+
+  setCurrentTime(currentTime) {
+    let buffered = Ranges.findRange_(this.hlsHandler.tech_.buffered(), currentTime);
+
+    if (!(this.masterPlaylistLoader_ && this.masterPlaylistLoader_.media())) {
+      // return immediately if the metadata is not ready yet
+      return 0;
+    }
+
+    // it's clearly an edge-case but don't thrown an error if asked to
+    // seek within an empty playlist
+    if (!this.masterPlaylistLoader_.media().segments) {
+      return 0;
+    }
+
+    // if the seek location is already buffered, continue buffering as
+    // usual
+    if (buffered && buffered.length) {
+      return currentTime;
+    }
+
+    // cancel outstanding requests so we begin buffering at the new
+    // location
+    this.segmentLoader_.abort();
+
+    if (!this.hlsHandler.tech_.paused()) {
+      this.segmentLoader_.load();
+    }
+  }
+
+  dispose() {
+    this.masterPlaylistLoader_.dispose();
+    this.segmentLoader_.dispose();
+  }
+}

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -244,6 +244,10 @@ export default class MasterPlaylistController extends Stream {
     });
   }
 
+  load() {
+    this.mainSegmentLoader_.load();
+  }
+
   /*
    * Blacklists a playlist when an error occurs for a set amount of time
    * making it unavailable for selection by the rendition selection algorithm

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -200,13 +200,17 @@ const PlaylistLoader = function(srcUrl, withCredentials) {
     * Abort any outstanding work and clean up.
     */
   loader.dispose = function() {
+    loader.stopRequest();
+    window.clearTimeout(mediaUpdateTimeout);
+    dispose.call(this);
+  };
+
+  loader.stopRequest = () => {
     if (request) {
       request.onreadystatechange = null;
       request.abort();
       request = null;
     }
-    window.clearTimeout(mediaUpdateTimeout);
-    dispose.call(this);
   };
 
   /**
@@ -399,6 +403,11 @@ const PlaylistLoader = function(srcUrl, withCredentials) {
     haveMetadata(req, srcUrl);
     return loader.trigger('loadedmetadata');
   });
+
+  loader.pause = () => {
+    loader.stopRequest();
+    window.clearTimeout(mediaUpdateTimeout);
+  };
 };
 
 PlaylistLoader.prototype = new Stream();

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -102,7 +102,7 @@ const updateMaster = function(master, media) {
   return changed ? result : null;
 };
 
-const PlaylistLoader = function({srcUrl, withCredentials, startLoading}) {
+const PlaylistLoader = function(srcUrl, withCredentials) {
   /* eslint-disable consistent-this */
   let loader = this;
   /* eslint-enable consistent-this */
@@ -420,10 +420,6 @@ const PlaylistLoader = function({srcUrl, withCredentials, startLoading}) {
       return loader.trigger('loadedmetadata');
     });
   };
-
-  if (startLoading) {
-    loader.load();
-  }
 };
 
 PlaylistLoader.prototype = new Stream();

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -102,7 +102,7 @@ const updateMaster = function(master, media) {
   return changed ? result : null;
 };
 
-const PlaylistLoader = function(srcUrl, withCredentials) {
+const PlaylistLoader = function(srcUrl, withCredentials, startsPaused) {
   /* eslint-disable consistent-this */
   let loader = this;
   /* eslint-enable consistent-this */
@@ -184,6 +184,8 @@ const PlaylistLoader = function(srcUrl, withCredentials) {
 
     loader.trigger('loadedplaylist');
   };
+
+  loader.srcUrl = srcUrl;
 
   // initialize the loader state
   loader.state = 'HAVE_NOTHING';
@@ -338,76 +340,90 @@ const PlaylistLoader = function(srcUrl, withCredentials) {
     });
   });
 
-  // request the specified URL
-  request = XhrModule({
-    uri: srcUrl,
-    withCredentials
-  }, function(error, req) {
-    let parser;
-    let playlist;
-    let i;
-
-    // clear the loader's request reference
-    request = null;
-
-    if (error) {
-      loader.error = {
-        status: req.status,
-        message: 'HLS playlist request error at URL: ' + srcUrl,
-        responseText: req.responseText,
-        // MEDIA_ERR_NETWORK
-        code: 2
-      };
-      return loader.trigger('error');
-    }
-
-    parser = new m3u8.Parser();
-    parser.push(req.responseText);
-    parser.end();
-
-    loader.state = 'HAVE_MASTER';
-
-    parser.manifest.uri = srcUrl;
-
-    // loaded a master playlist
-    if (parser.manifest.playlists) {
-      loader.master = parser.manifest;
-
-      // setup by-URI lookups and resolve media playlist URIs
-      i = loader.master.playlists.length;
-      while (i--) {
-        playlist = loader.master.playlists[i];
-        loader.master.playlists[playlist.uri] = playlist;
-        playlist.resolvedUri = resolveUrl(loader.master.uri, playlist.uri);
-      }
-
-      loader.trigger('loadedplaylist');
-      if (!request) {
-        // no media playlist was specifically selected so start
-        // from the first listed one
-        loader.media(parser.manifest.playlists[0]);
-      }
-      return;
-    }
-
-    // loaded a media playlist
-    // infer a master playlist if none was previously requested
-    loader.master = {
-      uri: window.location.href,
-      playlists: [{
-        uri: srcUrl
-      }]
-    };
-    loader.master.playlists[srcUrl] = loader.master.playlists[0];
-    loader.master.playlists[0].resolvedUri = srcUrl;
-    haveMetadata(req, srcUrl);
-    return loader.trigger('loadedmetadata');
-  });
-
   loader.pause = () => {
     loader.stopRequest();
     window.clearTimeout(mediaUpdateTimeout);
   };
+
+  loader.resume = () => {
+    loader.trigger('mediaupdatetimeout');
+  };
+
+  loader.start = () => {
+    loader.started = true;
+
+    // request the specified URL
+    request = XhrModule({
+      uri: srcUrl,
+      withCredentials
+    }, function(error, req) {
+      let parser;
+      let playlist;
+      let i;
+
+      // clear the loader's request reference
+      request = null;
+
+      if (error) {
+        loader.error = {
+          status: req.status,
+          message: 'HLS playlist request error at URL: ' + srcUrl,
+          responseText: req.responseText,
+          // MEDIA_ERR_NETWORK
+          code: 2
+        };
+        return loader.trigger('error');
+      }
+
+      parser = new m3u8.Parser();
+      parser.push(req.responseText);
+      parser.end();
+
+      loader.state = 'HAVE_MASTER';
+
+      parser.manifest.uri = srcUrl;
+
+      // loaded a master playlist
+      if (parser.manifest.playlists) {
+        loader.master = parser.manifest;
+
+        // setup by-URI lookups and resolve media playlist URIs
+        i = loader.master.playlists.length;
+        while (i--) {
+          playlist = loader.master.playlists[i];
+          loader.master.playlists[playlist.uri] = playlist;
+          playlist.resolvedUri = resolveUrl(loader.master.uri, playlist.uri);
+        }
+
+        loader.trigger('loadedplaylist');
+        if (!request) {
+          // no media playlist was specifically selected so start
+          // from the first listed one
+          loader.media(parser.manifest.playlists[0]);
+        }
+        return;
+      }
+
+      // loaded a media playlist
+      // infer a master playlist if none was previously requested
+      loader.master = {
+        uri: window.location.href,
+        playlists: [{
+          uri: srcUrl
+        }]
+      };
+      loader.master.playlists[srcUrl] = loader.master.playlists[0];
+      loader.master.playlists[0].resolvedUri = srcUrl;
+      haveMetadata(req, srcUrl);
+      return loader.trigger('loadedmetadata');
+    });
+  };
+
+  if (startsPaused) {
+    return;
+  }
+
+  loader.start();
 };
 
 PlaylistLoader.prototype = new Stream();

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -102,7 +102,7 @@ const updateMaster = function(master, media) {
   return changed ? result : null;
 };
 
-const PlaylistLoader = function(srcUrl, withCredentials, startsPaused) {
+const PlaylistLoader = function({srcUrl, withCredentials, startLoading}) {
   /* eslint-disable consistent-this */
   let loader = this;
   /* eslint-enable consistent-this */
@@ -184,8 +184,6 @@ const PlaylistLoader = function(srcUrl, withCredentials, startsPaused) {
 
     loader.trigger('loadedplaylist');
   };
-
-  loader.srcUrl = srcUrl;
 
   // initialize the loader state
   loader.state = 'HAVE_NOTHING';
@@ -345,8 +343,12 @@ const PlaylistLoader = function(srcUrl, withCredentials, startsPaused) {
     window.clearTimeout(mediaUpdateTimeout);
   };
 
-  loader.resume = () => {
-    loader.trigger('mediaupdatetimeout');
+  loader.load = () => {
+    if (loader.started) {
+      loader.trigger('mediaupdatetimeout');
+    } else {
+      loader.start();
+    }
   };
 
   loader.start = () => {
@@ -419,11 +421,9 @@ const PlaylistLoader = function(srcUrl, withCredentials, startsPaused) {
     });
   };
 
-  if (startsPaused) {
-    return;
+  if (startLoading) {
+    loader.load();
   }
-
-  loader.start();
 };
 
 PlaylistLoader.prototype = new Stream();

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -114,17 +114,6 @@ export default class HlsHandler extends Component {
     this.bandwidth = options.bandwidth || 4194304;
     this.bytesReceived = 0;
 
-    // loadingState_ tracks how far along the buffering process we
-    // have been given permission to proceed. There are three possible
-    // values:
-    // - none: do not load playlists or segments
-    // - meta: load playlists but not segments
-    // - segments: load everything
-    this.loadingState_ = 'none';
-    if (this.tech_.preload() !== 'none') {
-      this.loadingState_ = 'meta';
-    }
-
     this.on(this.tech_, 'seeking', function() {
       this.setCurrentTime(this.tech_.currentTime());
     });
@@ -295,7 +284,7 @@ export default class HlsHandler extends Component {
         // 4) the active media playlist is available
         media) {
 
-      this.segments.load();
+      this.masterPlaylistController_.load();
 
       // 5) the video element or flash player is in a readyState of
       // at least HAVE_FUTURE_DATA
@@ -317,8 +306,6 @@ export default class HlsHandler extends Component {
    * Begin playing the video.
    */
   play() {
-    this.loadingState_ = 'segments';
-
     if (this.tech_.ended()) {
       this.tech_.setCurrentTime(0);
     }

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -103,6 +103,15 @@ export default class HlsHandler extends Component {
     });
 
     this.on(this.tech_, 'play', this.play);
+
+    this.tech_.audioTracks().on('change', () => {
+      for (let i = 0; i < this.tech_.audioTracks().length; i++) {
+        if (this.tech_.audioTracks()[i].enabled) {
+          return this.masterPlaylistController_.updateAudio(
+            this.tech_.audioTracks()[i].label);
+        }
+      }
+    });
   }
   src(src) {
     // do nothing if the src is falsey

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -62,27 +62,6 @@ Hls.isSupported = function() {
 
 const Component = videojs.getComponent('Component');
 
-const parseCodecs = function(codecs) {
-  let result = {
-    codecCount: 0,
-    videoCodec: null,
-    audioProfile: null
-  };
-
-  result.codecCount = codecs.split(',').length;
-  result.codecCount = result.codecCount || 2;
-
-  // parse the video codec but ignore the version
-  result.videoCodec = (/(^|\s|,)+(avc1)[^ ,]*/i).exec(codecs);
-  result.videoCodec = result.videoCodec && result.videoCodec[2];
-
-  // parse the last field of the audio codec
-  result.audioProfile = (/(^|\s|,)+mp4a.\d+\.(\d+)/i).exec(codecs);
-  result.audioProfile = result.audioProfile && result.audioProfile[2];
-
-  return result;
-};
-
 export default class HlsHandler extends Component {
   constructor(tech, options) {
     super(tech);
@@ -157,64 +136,6 @@ export default class HlsHandler extends Component {
       this.masterPlaylistController_.mediaSource));
   }
 
-  // TODO - unused, used to be used with sourceBuffer creation
-  /**
-   * Blacklist playlists that are known to be codec or
-   * stream-incompatible with the SourceBuffer configuration. For
-   * instance, Media Source Extensions would cause the video element to
-   * stall waiting for video data if you switched from a variant with
-   * video and audio to an audio-only one.
-   *
-   * @param media {object} a media playlist compatible with the current
-   * set of SourceBuffers. Variants in the current master playlist that
-   * do not appear to have compatible codec or stream configurations
-   * will be excluded from the default playlist selection algorithm
-   * indefinitely.
-   */
-  excludeIncompatibleVariants_(media) {
-    let master = this.playlists.master;
-    let codecCount = 2;
-    let videoCodec = null;
-    let audioProfile = null;
-    let codecs;
-
-    if (media.attributes && media.attributes.CODECS) {
-      codecs = parseCodecs(media.attributes.CODECS);
-      videoCodec = codecs.videoCodec;
-      audioProfile = codecs.audioProfile;
-      codecCount = codecs.codecCount;
-    }
-    master.playlists.forEach(function(variant) {
-      let variantCodecs = {
-        codecCount: 2,
-        videoCodec: null,
-        audioProfile: null
-      };
-
-      if (variant.attributes && variant.attributes.CODECS) {
-        variantCodecs = parseCodecs(variant.attributes.CODECS);
-      }
-
-      // if the streams differ in the presence or absence of audio or
-      // video, they are incompatible
-      if (variantCodecs.codecCount !== codecCount) {
-        variant.excludeUntil = Infinity;
-      }
-
-      // if h.264 is specified on the current playlist, some flavor of
-      // it must be specified on all compatible variants
-      if (variantCodecs.videoCodec !== videoCodec) {
-        variant.excludeUntil = Infinity;
-      }
-      // HE-AAC ("mp4a.40.5") is incompatible with all other versions of
-      // AAC audio in Chrome 46. Don't mix the two.
-      if ((variantCodecs.audioProfile === '5' && audioProfile !== '5') ||
-          (audioProfile === '5' && variantCodecs.audioProfile !== '5')) {
-        variant.excludeUntil = Infinity;
-      }
-    });
-  }
-
   /**
    * Begin playing the video.
    */
@@ -259,7 +180,9 @@ export default class HlsHandler extends Component {
     super.dispose();
   }
 
+  /* eslint-disable */
   // TODO no longer used internally
+  /* eslint-enable */
   playlistUriToUrl(segmentRelativeUrl) {
     let playListUrl;
 
@@ -274,7 +197,9 @@ export default class HlsHandler extends Component {
     return playListUrl;
   }
 
+  /* eslint-disable */
   // TODO no longer used internally
+  // eslint-enable
   /*
    * Sets `bandwidth`, `segmentXhrTime`, and appends to the `bytesReceived.
    * Expects an object with:

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -119,7 +119,7 @@ export default class HlsHandler extends Component {
     });
     this.on(this.tech_, 'error', function() {
       if (this.masterPlaylistController_) {
-        this.masterPlaylistController_.pause();
+        this.masterPlaylistController_.pauseLoading();
       }
     });
 
@@ -146,9 +146,6 @@ export default class HlsHandler extends Component {
       hlsHandler: this,
       externHls: Hls
     });
-
-    this.tech_.one('canplay',
-      this.masterPlaylistController_.setupFirstPlay.bind(this.masterPlaylistController_));
 
     // do nothing if the tech has been disposed already
     // this can occur if someone sets the src in player.ready(), for instance

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -131,11 +131,6 @@ export default class HlsHandler extends Component {
       return;
     }
 
-    this.mediaSource = new videojs.MediaSource({ mode: this.mode_ });
-
-    // load the MediaSource into the player
-    this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen.bind(this));
-
     this.options_ = {};
     if (typeof this.source_.withCredentials !== 'undefined') {
       this.options_.withCredentials = this.source_.withCredentials;
@@ -147,12 +142,13 @@ export default class HlsHandler extends Component {
       url: this.source_.src,
       withCredentials: this.options_.withCredentials,
       currentTimeFunc: this.tech_.currentTime.bind(this.tech_),
-      mediaSource: this.mediaSource,
+      mediaSourceMode: this.mode_,
       hlsHandler: this,
       externHls: Hls
     });
 
-    this.tech_.one('canplay', this.setupFirstPlay.bind(this));
+    this.tech_.one('canplay',
+      this.masterPlaylistController_.setupFirstPlay.bind(this.masterPlaylistController_));
 
     // do nothing if the tech has been disposed already
     // this can occur if someone sets the src in player.ready(), for instance
@@ -160,27 +156,11 @@ export default class HlsHandler extends Component {
       return;
     }
 
-    this.tech_.src(videojs.URL.createObjectURL(this.mediaSource));
-  }
-  handleSourceOpen() {
-    // Only attempt to create the source buffer if none already exist.
-    // handleSourceOpen is also called when we are "re-opening" a source buffer
-    // after `endOfStream` has been called (in response to a seek for instance)
-    if (!this.sourceBuffer) {
-      this.setupSourceBuffer_();
-    }
-
-    // if autoplay is enabled, begin playback. This is duplicative of
-    // code in video.js but is required because play() must be invoked
-    // *after* the media source has opened.
-    // NOTE: moving this invocation of play() after
-    // sourceBuffer.appendBuffer() below caused live streams with
-    // autoplay to stall
-    if (this.tech_.autoplay()) {
-      this.play();
-    }
+    this.tech_.src(videojs.URL.createObjectURL(
+      this.masterPlaylistController_.mediaSource));
   }
 
+  // TODO - unused, used to be used with sourceBuffer creation
   /**
    * Blacklist playlists that are known to be codec or
    * stream-incompatible with the SourceBuffer configuration. For
@@ -238,70 +218,6 @@ export default class HlsHandler extends Component {
     });
   }
 
-  setupSourceBuffer_() {
-    let media = this.playlists.media();
-    let mimeType;
-
-    // wait until a media playlist is available and the Media Source is
-    // attached
-    if (!media || this.mediaSource.readyState !== 'open') {
-      return;
-    }
-
-    // if the codecs were explicitly specified, pass them along to the
-    // source buffer
-    mimeType = 'video/mp2t';
-    if (media.attributes && media.attributes.CODECS) {
-      mimeType += '; codecs="' + media.attributes.CODECS + '"';
-    }
-    this.sourceBuffer = this.mediaSource.addSourceBuffer(mimeType);
-
-    // exclude any incompatible variant streams from future playlist
-    // selection
-    this.excludeIncompatibleVariants_(media);
-  }
-
-  /**
-   * Seek to the latest media position if this is a live video and the
-   * player and video are loaded and initialized.
-   */
-  setupFirstPlay() {
-    let seekable;
-    let media = this.playlists.media();
-
-    // check that everything is ready to begin buffering
-
-    // 1) the video is a live stream of unknown duration
-    if (this.duration() === Infinity &&
-
-        // 2) the player has not played before and is not paused
-        this.tech_.played().length === 0 &&
-        !this.tech_.paused() &&
-
-        // 3) the Media Source and Source Buffers are ready
-        this.sourceBuffer &&
-
-        // 4) the active media playlist is available
-        media) {
-
-      this.masterPlaylistController_.load();
-
-      // 5) the video element or flash player is in a readyState of
-      // at least HAVE_FUTURE_DATA
-      if (this.tech_.readyState() >= 1) {
-
-        // trigger the playlist loader to start "expired time"-tracking
-        this.playlists.trigger('firstplay');
-
-        // seek to the latest media position for live videos
-        seekable = this.seekable();
-        if (seekable.length) {
-          this.tech_.setCurrentTime(seekable.end(0));
-        }
-      }
-    }
-  }
-
   /**
    * Begin playing the video.
    */
@@ -311,7 +227,7 @@ export default class HlsHandler extends Component {
     }
 
     if (this.tech_.played().length === 0) {
-      return this.setupFirstPlay();
+      return this.masterPlaylistController_.setupFirstPlay();
     }
 
     // if the viewer has paused and we fell out of the live window,
@@ -328,89 +244,11 @@ export default class HlsHandler extends Component {
   }
 
   duration() {
-    let playlists = this.playlists;
-
-    if (!playlists) {
-      return 0;
-    }
-
-    if (this.mediaSource) {
-      return this.mediaSource.duration;
-    }
-
-    return Hls.Playlist.duration(playlists.media());
+    return this.masterPlaylistController_.duration();
   }
 
   seekable() {
-    let media;
-    let seekable;
-
-    if (!this.playlists) {
-      return videojs.createTimeRanges();
-    }
-    media = this.playlists.media();
-    if (!media) {
-      return videojs.createTimeRanges();
-    }
-
-    seekable = Hls.Playlist.seekable(media);
-    if (seekable.length === 0) {
-      return seekable;
-    }
-
-    // if the seekable start is zero, it may be because the player has
-    // been paused for a long time and stopped buffering. in that case,
-    // fall back to the playlist loader's running estimate of expired
-    // time
-    if (seekable.start(0) === 0) {
-      return videojs.createTimeRanges([[this.playlists.expired_,
-                                        this.playlists.expired_ + seekable.end(0)]]);
-    }
-
-    // seekable has been calculated based on buffering video data so it
-    // can be returned directly
-    return seekable;
-  }
-
-  /**
-   * Update the player duration
-   */
-  updateDuration(playlist) {
-    let oldDuration = this.mediaSource.duration;
-    let newDuration = Hls.Playlist.duration(playlist);
-    let buffered = this.tech_.buffered();
-    let setDuration = () => {
-      this.mediaSource.duration = newDuration;
-      this.tech_.trigger('durationchange');
-
-      this.mediaSource.removeEventListener('sourceopen', setDuration);
-    };
-
-    if (buffered.length > 0) {
-      newDuration = Math.max(newDuration, buffered.end(buffered.length - 1));
-    }
-
-    // if the duration has changed, invalidate the cached value
-    if (oldDuration !== newDuration) {
-      // update the duration
-      if (this.mediaSource.readyState !== 'open') {
-        this.mediaSource.addEventListener('sourceopen', setDuration);
-      } else if (!this.sourceBuffer || !this.sourceBuffer.updating) {
-        this.mediaSource.duration = newDuration;
-        this.tech_.trigger('durationchange');
-      }
-    }
-  }
-
-  /**
-   * Clear all buffers and reset any state relevant to the current
-   * source. After this function is called, the tech should be in a
-   * state suitable for switching to a different video.
-   */
-  resetSrc_() {
-    if (this.sourceBuffer && this.mediaSource.readyState === 'open') {
-      this.sourceBuffer.abort();
-    }
+    return this.masterPlaylistController_.seekable();
   }
 
   /**
@@ -421,10 +259,10 @@ export default class HlsHandler extends Component {
       this.masterPlaylistController_.dispose();
     }
 
-    this.resetSrc_();
     super.dispose();
   }
 
+  // TODO no longer used internally
   playlistUriToUrl(segmentRelativeUrl) {
     let playListUrl;
 
@@ -439,6 +277,7 @@ export default class HlsHandler extends Component {
     return playListUrl;
   }
 
+  // TODO no longer used internally
   /*
    * Sets `bandwidth`, `segmentXhrTime`, and appends to the `bytesReceived.
    * Expects an object with:

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1,0 +1,388 @@
+import QUnit from 'qunit';
+import videojs from 'video.js';
+import {
+  useFakeEnvironment,
+  useFakeMediaSource,
+  createPlayer,
+  standardXHRResponse,
+  openMediaSource
+} from './plugin-helpers.js';
+import MasterPlaylistController from '../src/master-playlist-controller';
+/* eslint-disable no-unused-vars */
+// we need this so that it can register hls with videojs
+import { Hls } from '../src/videojs-contrib-hls';
+/* eslint-enable no-unused-vars */
+
+QUnit.module('MasterPlaylistController', {
+  beforeEach() {
+    this.env = useFakeEnvironment();
+    this.clock = this.env.clock;
+    this.requests = this.env.requests;
+    this.mse = useFakeMediaSource();
+
+    // force the HLS tech to run
+    this.origSupportsNativeHls = videojs.Hls.supportsNativeHls;
+    videojs.Hls.supportsNativeHls = false;
+
+    this.player = createPlayer();
+    this.player.src({
+      src: 'manifest/master.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+    this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+  },
+  afterEach() {
+    this.env.restore();
+    this.mse.restore();
+    videojs.Hls.supportsNativeHls = this.origSupportsNativeHls;
+  }
+});
+
+QUnit.test('throws error when given an empty URL', function() {
+  let options = {
+    url: 'test',
+    currentTimeFunc: () => {},
+    hlsHandler: this.masterPlaylistController.hlsHandler
+  };
+
+  QUnit.ok(new MasterPlaylistController(options), 'can create with options');
+
+  options.url = '';
+  QUnit.throws(() => {
+    new MasterPlaylistController(options); // eslint-disable-line no-new
+  }, /A non-empty playlist URL is required/, 'requires a non empty url');
+});
+
+QUnit.test('obeys preload option', function() {
+  this.player.preload('none');
+  // master
+  standardXHRResponse(this.requests.shift());
+  // playlist
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.equal(this.requests.length, 0, 'no segment requests when preload is none');
+
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+  this.player.preload('auto');
+  // master
+  standardXHRResponse(this.requests.shift());
+  // playlist
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.equal(this.requests.length, 1, 'segment request when preload is auto');
+});
+
+QUnit.test('tech fires loadedmetadata when playlist loader loads first playlist',
+function() {
+  let firedLoadedMetadata = false;
+
+  this.masterPlaylistController.hlsHandler.tech_.on('loadedmetadata', () => {
+    firedLoadedMetadata = true;
+  });
+
+  // master
+  standardXHRResponse(this.requests.shift());
+  QUnit.ok(!firedLoadedMetadata, 'did not fire loadedmetadata');
+  // playlist
+  standardXHRResponse(this.requests.shift());
+  QUnit.ok(firedLoadedMetadata, 'fired loadedmetadata');
+});
+
+QUnit.test('creates combined and audio only SegmentLoaders', function() {
+  QUnit.equal(this.masterPlaylistController.mainSegmentLoader_.state, 'INIT',
+              'created combined segment loader');
+  QUnit.equal(this.masterPlaylistController.audioSegmentLoader_.state, 'INIT',
+              'created alternate audio track segment loader');
+});
+
+QUnit.test('if buffered, will request second segment byte range', function() {
+  this.requests.length = 0;
+  this.player.src({
+    src: 'manifest/playlist.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+  this.player.tech_.triggerReady();
+  this.clock.tick(1);
+  this.player.tech_.trigger('play');
+  openMediaSource(this.player, this.clock);
+  this.masterPlaylistController.mainSegmentLoader_.sourceUpdater_.buffered = () => {
+    return videojs.createTimeRanges([[0, 20]]);
+  };
+  // playlist
+  standardXHRResponse(this.requests[0]);
+  // segment
+  standardXHRResponse(this.requests[1]);
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(10 * 1000);
+  QUnit.equal(this.requests[2].headers.Range, 'bytes=1823412-2299991');
+});
+
+QUnit.test('re-initializes the combined playlist loader when switching sources',
+function() {
+  openMediaSource(this.player, this.clock);
+  // master
+  standardXHRResponse(this.requests.shift());
+  // playlist
+  standardXHRResponse(this.requests.shift());
+  // segment
+  standardXHRResponse(this.requests.shift());
+  // change the source
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+  // maybe not needed if https://github.com/videojs/video.js/issues/2326 gets fixed
+  this.clock.tick(1);
+  QUnit.ok(!this.masterPlaylistController.masterPlaylistLoader_.media(),
+           'no media playlist');
+  QUnit.equal(this.masterPlaylistController.masterPlaylistLoader_.state,
+              'HAVE_NOTHING',
+              'reset the playlist loader state');
+  QUnit.equal(this.requests.length, 1, 'requested the new src');
+
+  // buffer check
+  this.clock.tick(10 * 1000);
+  QUnit.equal(this.requests.length, 1, 'did not request a stale segment');
+
+  // sourceopen
+  openMediaSource(this.player, this.clock);
+
+  QUnit.equal(this.requests.length, 1, 'made one request');
+  QUnit.ok(
+    this.requests[0].url.indexOf('master.m3u8') >= 0,
+      'requested only the new playlist'
+  );
+});
+
+QUnit.test('updates the combined segment loader on live playlist refreshes', function() {
+  let updates = [];
+
+  openMediaSource(this.player, this.clock);
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  this.masterPlaylistController.mainSegmentLoader_.playlist = function(update) {
+    updates.push(update);
+  };
+
+  this.masterPlaylistController.masterPlaylistLoader_.trigger('loadedplaylist');
+  QUnit.equal(updates.length, 1, 'updated the segment list');
+});
+
+QUnit.test(
+'fires a progress event after downloading a segment from combined segment loader',
+function() {
+  let progressCount = 0;
+
+  openMediaSource(this.player, this.clock);
+
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  this.player.tech_.on('progress', function() {
+    progressCount++;
+  });
+
+  // segment
+  standardXHRResponse(this.requests.shift());
+  this.masterPlaylistController.mainSegmentLoader_.trigger('progress');
+  QUnit.equal(progressCount, 1, 'fired a progress event');
+});
+
+QUnit.test('blacklists switching from video+audio playlists to audio only', function() {
+  let audioPlaylist;
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.hls.bandwidth = 1e10;
+
+  // master
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="mp4a.40.2"\n' +
+                                'media.m3u8\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=10,RESOLUTION=1x1\n' +
+                                'media1.m3u8\n');
+  // media1
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.equal(this.masterPlaylistController.masterPlaylistLoader_.media(),
+              this.masterPlaylistController.masterPlaylistLoader_.master.playlists[1],
+              'selected video+audio');
+  audioPlaylist = this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0];
+  QUnit.equal(audioPlaylist.excludeUntil, Infinity, 'excluded incompatible playlist');
+});
+
+QUnit.test('blacklists switching from audio-only playlists to video+audio', function() {
+  let videoAudioPlaylist;
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.hls.bandwidth = 1;
+  // master
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="mp4a.40.2"\n' +
+                                'media.m3u8\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=10,RESOLUTION=1x1\n' +
+                                'media1.m3u8\n');
+
+  // media1
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(this.masterPlaylistController.masterPlaylistLoader_.media(),
+              this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0],
+              'selected audio only');
+  videoAudioPlaylist =
+    this.masterPlaylistController.masterPlaylistLoader_.master.playlists[1];
+  QUnit.equal(videoAudioPlaylist.excludeUntil,
+              Infinity,
+              'excluded incompatible playlist');
+});
+
+QUnit.test('blacklists switching from video-only playlists to video+audio', function() {
+  let videoAudioPlaylist;
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.hls.bandwidth = 1;
+  // master
+  this.requests.shift()
+    .respond(200, null,
+             '#EXTM3U\n' +
+             '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d"\n' +
+             'media.m3u8\n' +
+             '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+             'media1.m3u8\n');
+
+  // media
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(this.masterPlaylistController.masterPlaylistLoader_.media(),
+              this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0],
+              'selected video only');
+  videoAudioPlaylist =
+    this.masterPlaylistController.masterPlaylistLoader_.master.playlists[1];
+  QUnit.equal(videoAudioPlaylist.excludeUntil,
+              Infinity,
+              'excluded incompatible playlist');
+});
+
+QUnit.test('blacklists switching between playlists with incompatible audio codecs',
+function() {
+  let alternatePlaylist;
+
+  openMediaSource(this.player, this.clock);
+
+  this.player.tech_.hls.bandwidth = 1;
+  // master
+  this.requests.shift()
+    .respond(200, null,
+             '#EXTM3U\n' +
+             '#EXT-X-STREAM-INF:BANDWIDTH=1,CODECS="avc1.4d400d,mp4a.40.5"\n' +
+             'media.m3u8\n' +
+             '#EXT-X-STREAM-INF:BANDWIDTH=10,CODECS="avc1.4d400d,mp4a.40.2"\n' +
+             'media1.m3u8\n');
+
+  // media
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(this.masterPlaylistController.masterPlaylistLoader_.media(),
+              this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0],
+              'selected HE-AAC stream');
+  alternatePlaylist =
+    this.masterPlaylistController.masterPlaylistLoader_.master.playlists[1];
+  QUnit.equal(alternatePlaylist.excludeUntil, Infinity, 'excluded incompatible playlist');
+});
+
+QUnit.test('updates the combined segment loader on media changes', function() {
+  let updates = [];
+
+  this.masterPlaylistController.mediaSource.trigger('sourceopen');
+
+  this.masterPlaylistController.hlsHandler.bandwidth = 1;
+
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  this.masterPlaylistController.mainSegmentLoader_.playlist = function(update) {
+    updates.push(update);
+  };
+
+  // downloading the new segment will update bandwidth and cause a
+  // playlist change
+  // segment 0
+  standardXHRResponse(this.requests.shift());
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  // media
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(updates.length, 1, 'updated the segment list');
+});
+
+QUnit.test('selects a playlist after main/combined segment downloads', function() {
+  let calls = 0;
+
+  this.masterPlaylistController.hlsHandler.selectPlaylist = () => {
+    calls++;
+    return this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0];
+  };
+  this.masterPlaylistController.mediaSource.trigger('sourceopen');
+
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  // "downloaded" a segment
+  this.masterPlaylistController.mainSegmentLoader_.trigger('progress');
+  QUnit.strictEqual(calls, 2, 'selects after the initial segment');
+
+  // and another
+  this.masterPlaylistController.mainSegmentLoader_.trigger('progress');
+  QUnit.strictEqual(calls, 3, 'selects after additional segments');
+});
+
+QUnit.test('updates the duration after switching playlists', function() {
+  let selectedPlaylist = false;
+
+  this.masterPlaylistController.mediaSource.trigger('sourceopen');
+
+  this.masterPlaylistController.hlsHandler.bandwidth = 1e20;
+
+  // master
+  standardXHRResponse(this.requests[0]);
+  // media
+  standardXHRResponse(this.requests[1]);
+
+  this.masterPlaylistController.hlsHandler.selectPlaylist = () => {
+    selectedPlaylist = true;
+
+    // this duration should be overwritten by the playlist change
+    this.masterPlaylistController.mediaSource = {
+      duration: 0,
+      readyState: 'open'
+    };
+
+    return this.masterPlaylistController.masterPlaylistLoader_.master.playlists[1];
+  };
+
+  // segment 0
+  standardXHRResponse(this.requests[2]);
+  this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
+  // media1
+  standardXHRResponse(this.requests[3]);
+  QUnit.ok(selectedPlaylist, 'selected playlist');
+  QUnit.ok(this.masterPlaylistController.mediaSource.duration !== 0,
+           'updates the duration');
+});

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -228,7 +228,8 @@ QUnit.test('recognizes absolute key URLs', function() {
               'http://example.com/keys/key.php', 'resolved absolute path for key URI');
 });
 
-QUnit.test('jumps to HAVE_METADATA when initialized with a live media playlist', function() {
+QUnit.test('jumps to HAVE_METADATA when initialized with a live media playlist',
+function() {
   let loader = new PlaylistLoader('media.m3u8');
 
   this.requests.pop().respond(200, null,

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -33,19 +33,17 @@ QUnit.test('throws if the playlist url is empty or undefined', function() {
 });
 
 QUnit.test('starts without any metadata', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   QUnit.strictEqual(loader.state, 'HAVE_NOTHING', 'no metadata has loaded yet');
 });
 
 QUnit.test('starts with no expired time', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -57,12 +55,9 @@ QUnit.test('starts with no expired time', function() {
 });
 
 QUnit.test('requests the initial playlist immediately', function() {
-  /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
-  /* eslint-enable no-unused-vars */
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   QUnit.strictEqual(this.requests.length, 1, 'made a request');
   QUnit.strictEqual(this.requests[0].url,
@@ -71,11 +66,10 @@ QUnit.test('requests the initial playlist immediately', function() {
 });
 
 QUnit.test('moves to HAVE_MASTER after loading a master playlist', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
   let state;
+
+  loader.load();
 
   loader.on('loadedplaylist', function() {
     state = loader.state;
@@ -90,10 +84,9 @@ QUnit.test('moves to HAVE_MASTER after loading a master playlist', function() {
 
 QUnit.test('jumps to HAVE_METADATA when initialized with a media playlist', function() {
   let loadedmetadatas = 0;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   loader.on('loadedmetadata', function() {
     loadedmetadatas++;
@@ -112,10 +105,9 @@ QUnit.test('jumps to HAVE_METADATA when initialized with a media playlist', func
 });
 
 QUnit.test('resolves relative media playlist URIs', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -126,10 +118,9 @@ QUnit.test('resolves relative media playlist URIs', function() {
 });
 
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'manifest/media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('manifest/media.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -148,10 +139,9 @@ QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
 });
 
 QUnit.test('recognizes domain-relative URLs', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'manifest/media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('manifest/media.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -174,10 +164,9 @@ QUnit.test('recognizes domain-relative URLs', function() {
 });
 
 QUnit.test('recognizes key URLs relative to master and playlist', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: '/video/media-encrypted.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('/video/media-encrypted.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -204,10 +193,9 @@ QUnit.test('recognizes key URLs relative to master and playlist', function() {
 
 QUnit.test('trigger an error event when a media playlist 404s', function() {
   let count = 0;
-  let loader = new PlaylistLoader({
-    srcUrl: 'manifest/master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('manifest/master.m3u8');
+
+  loader.load();
 
   loader.on('error', function() {
     count += 1;
@@ -232,10 +220,9 @@ QUnit.test('trigger an error event when a media playlist 404s', function() {
 });
 
 QUnit.test('recognizes absolute key URLs', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: '/video/media-encrypted.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('/video/media-encrypted.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -263,10 +250,9 @@ QUnit.test('recognizes absolute key URLs', function() {
 
 QUnit.test('jumps to HAVE_METADATA when initialized with a live media playlist',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -280,10 +266,9 @@ function() {
 QUnit.test('moves to HAVE_METADATA after loading a media playlist', function() {
   let loadedPlaylist = 0;
   let loadedMetadata = 0;
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   loader.on('loadedplaylist', function() {
     loadedPlaylist++;
@@ -316,10 +301,9 @@ QUnit.test('moves to HAVE_METADATA after loading a media playlist', function() {
 });
 
 QUnit.test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -335,10 +319,9 @@ QUnit.test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', functi
 });
 
 QUnit.test('returns to HAVE_METADATA after refreshing the playlist', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -355,10 +338,9 @@ QUnit.test('returns to HAVE_METADATA after refreshing the playlist', function() 
 
 QUnit.test('does not increment expired seconds before firstplay is triggered',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -388,10 +370,9 @@ function() {
 });
 
 QUnit.test('increments expired seconds after a segment is removed', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -422,10 +403,9 @@ QUnit.test('increments expired seconds after a segment is removed', function() {
 });
 
 QUnit.test('increments expired seconds after a discontinuity', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -473,10 +453,9 @@ QUnit.test('increments expired seconds after a discontinuity', function() {
 
 QUnit.test('tracks expired seconds properly when two discontinuities expire at once',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -504,10 +483,9 @@ function() {
 
 QUnit.test('estimates expired if an entire window elapses between live playlist updates',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -534,10 +512,9 @@ function() {
 
 QUnit.test('emits an error when an initial playlist request fails', function() {
   let errors = [];
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   loader.on('error', function() {
     errors.push(loader.error);
@@ -550,10 +527,9 @@ QUnit.test('emits an error when an initial playlist request fails', function() {
 
 QUnit.test('errors when an initial media playlist request fails', function() {
   let errors = [];
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   loader.on('error', function() {
     errors.push(loader.error);
@@ -574,12 +550,9 @@ QUnit.test('errors when an initial media playlist request fails', function() {
 // http://tools.ietf.org/html/draft-pantos-http-live-streaming-12#section-6.3.4
 QUnit.test('halves the refresh timeout if a playlist is unchanged since the last reload',
 function() {
-  /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
-  /* eslint-enable no-unused-vars */
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -603,11 +576,10 @@ function() {
 });
 
 QUnit.test('preserves segment metadata across playlist refreshes', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
   let segment;
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -638,11 +610,10 @@ QUnit.test('preserves segment metadata across playlist refreshes', function() {
 });
 
 QUnit.test('clears the update timeout when switching quality', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live-master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live-master.m3u8');
   let refreshes = 0;
+
+  loader.load();
 
   // track the number of playlist refreshes triggered
   loader.on('mediaupdatetimeout', function() {
@@ -675,12 +646,9 @@ QUnit.test('clears the update timeout when switching quality', function() {
 });
 
 QUnit.test('media-sequence updates are considered a playlist change', function() {
-  /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
-  /* eslint-enable no-unused-vars */
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -703,10 +671,9 @@ QUnit.test('media-sequence updates are considered a playlist change', function()
 QUnit.test('emits an error if a media refresh fails', function() {
   let errors = 0;
   let errorResponseText = 'custom error message';
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   loader.on('error', function() {
     errors++;
@@ -728,10 +695,9 @@ QUnit.test('emits an error if a media refresh fails', function() {
 });
 
 QUnit.test('switches media playlists when requested', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -760,10 +726,9 @@ QUnit.test('switches media playlists when requested', function() {
 });
 
 QUnit.test('can switch playlists immediately after the master is downloaded', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   loader.on('loadedplaylist', function() {
     loader.media('high.m3u8');
@@ -778,10 +743,9 @@ QUnit.test('can switch playlists immediately after the master is downloaded', fu
 });
 
 QUnit.test('can switch media playlists based on URI', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -810,10 +774,9 @@ QUnit.test('can switch media playlists based on URI', function() {
 });
 
 QUnit.test('aborts in-flight playlist refreshes when switching', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -835,10 +798,9 @@ QUnit.test('aborts in-flight playlist refreshes when switching', function() {
 });
 
 QUnit.test('switching to the active playlist is a no-op', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -858,10 +820,9 @@ QUnit.test('switching to the active playlist is a no-op', function() {
 });
 
 QUnit.test('switching to the active live playlist is a no-op', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -880,10 +841,9 @@ QUnit.test('switching to the active live playlist is a no-op', function() {
 });
 
 QUnit.test('switches back to loaded playlists without re-requesting them', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -912,10 +872,9 @@ QUnit.test('switches back to loaded playlists without re-requesting them', funct
 
 QUnit.test('aborts outstanding requests if switching back to an already loaded playlist',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -949,10 +908,9 @@ function() {
 
 QUnit.test('does not abort requests when the same playlist is re-requested',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -974,10 +932,9 @@ function() {
 });
 
 QUnit.test('throws an error if a media switch is initiated too early', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   QUnit.throws(function() {
     loader.media('high.m3u8');
@@ -993,10 +950,9 @@ QUnit.test('throws an error if a media switch is initiated too early', function(
 
 QUnit.test('throws an error if a switch to an unrecognized playlist is requested',
 function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -1009,10 +965,9 @@ function() {
 });
 
 QUnit.test('dispose cancels the refresh timeout', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -1027,10 +982,9 @@ QUnit.test('dispose cancels the refresh timeout', function() {
 });
 
 QUnit.test('dispose aborts pending refresh requests', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'live.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('live.m3u8');
+
+  loader.load();
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -1047,11 +1001,10 @@ QUnit.test('dispose aborts pending refresh requests', function() {
 });
 
 QUnit.test('errors if requests take longer than 45s', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
   let errors = 0;
+
+  loader.load();
 
   loader.on('error', function() {
     errors++;
@@ -1063,12 +1016,11 @@ QUnit.test('errors if requests take longer than 45s', function() {
 });
 
 QUnit.test('triggers an event when the active media changes', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'master.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('master.m3u8');
   let mediaChanges = 0;
   let mediaChangings = 0;
+
+  loader.load();
 
   loader.on('mediachange', function() {
     mediaChanges++;
@@ -1116,10 +1068,9 @@ QUnit.test('triggers an event when the active media changes', function() {
 });
 
 QUnit.test('does not misintrepret playlists missing newlines at the end', function() {
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   // no newline
   this.requests.shift().respond(200, null,

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -33,13 +33,19 @@ QUnit.test('throws if the playlist url is empty or undefined', function() {
 });
 
 QUnit.test('starts without any metadata', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   QUnit.strictEqual(loader.state, 'HAVE_NOTHING', 'no metadata has loaded yet');
 });
 
 QUnit.test('starts with no expired time', function() {
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -52,7 +58,10 @@ QUnit.test('starts with no expired time', function() {
 
 QUnit.test('requests the initial playlist immediately', function() {
   /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
   /* eslint-enable no-unused-vars */
 
   QUnit.strictEqual(this.requests.length, 1, 'made a request');
@@ -62,7 +71,10 @@ QUnit.test('requests the initial playlist immediately', function() {
 });
 
 QUnit.test('moves to HAVE_MASTER after loading a master playlist', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
   let state;
 
   loader.on('loadedplaylist', function() {
@@ -78,7 +90,10 @@ QUnit.test('moves to HAVE_MASTER after loading a master playlist', function() {
 
 QUnit.test('jumps to HAVE_METADATA when initialized with a media playlist', function() {
   let loadedmetadatas = 0;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   loader.on('loadedmetadata', function() {
     loadedmetadatas++;
@@ -97,7 +112,10 @@ QUnit.test('jumps to HAVE_METADATA when initialized with a media playlist', func
 });
 
 QUnit.test('resolves relative media playlist URIs', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -108,7 +126,10 @@ QUnit.test('resolves relative media playlist URIs', function() {
 });
 
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
-  let loader = new PlaylistLoader('manifest/media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'manifest/media.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -127,7 +148,10 @@ QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
 });
 
 QUnit.test('recognizes domain-relative URLs', function() {
-  let loader = new PlaylistLoader('manifest/media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'manifest/media.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -150,7 +174,10 @@ QUnit.test('recognizes domain-relative URLs', function() {
 });
 
 QUnit.test('recognizes key URLs relative to master and playlist', function() {
-  let loader = new PlaylistLoader('/video/media-encrypted.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: '/video/media-encrypted.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -177,7 +204,10 @@ QUnit.test('recognizes key URLs relative to master and playlist', function() {
 
 QUnit.test('trigger an error event when a media playlist 404s', function() {
   let count = 0;
-  let loader = new PlaylistLoader('manifest/master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'manifest/master.m3u8',
+    startLoading: true
+  });
 
   loader.on('error', function() {
     count += 1;
@@ -202,7 +232,10 @@ QUnit.test('trigger an error event when a media playlist 404s', function() {
 });
 
 QUnit.test('recognizes absolute key URLs', function() {
-  let loader = new PlaylistLoader('/video/media-encrypted.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: '/video/media-encrypted.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
@@ -230,7 +263,10 @@ QUnit.test('recognizes absolute key URLs', function() {
 
 QUnit.test('jumps to HAVE_METADATA when initialized with a live media playlist',
 function() {
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -244,7 +280,10 @@ function() {
 QUnit.test('moves to HAVE_METADATA after loading a media playlist', function() {
   let loadedPlaylist = 0;
   let loadedMetadata = 0;
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   loader.on('loadedplaylist', function() {
     loadedPlaylist++;
@@ -277,7 +316,10 @@ QUnit.test('moves to HAVE_METADATA after loading a media playlist', function() {
 });
 
 QUnit.test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -293,7 +335,10 @@ QUnit.test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', functi
 });
 
 QUnit.test('returns to HAVE_METADATA after refreshing the playlist', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -310,7 +355,10 @@ QUnit.test('returns to HAVE_METADATA after refreshing the playlist', function() 
 
 QUnit.test('does not increment expired seconds before firstplay is triggered',
 function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -340,7 +388,10 @@ function() {
 });
 
 QUnit.test('increments expired seconds after a segment is removed', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -371,7 +422,10 @@ QUnit.test('increments expired seconds after a segment is removed', function() {
 });
 
 QUnit.test('increments expired seconds after a discontinuity', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -419,7 +473,10 @@ QUnit.test('increments expired seconds after a discontinuity', function() {
 
 QUnit.test('tracks expired seconds properly when two discontinuities expire at once',
 function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -447,7 +504,10 @@ function() {
 
 QUnit.test('estimates expired if an entire window elapses between live playlist updates',
 function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   loader.trigger('firstplay');
   this.requests.pop().respond(200, null,
@@ -474,7 +534,10 @@ function() {
 
 QUnit.test('emits an error when an initial playlist request fails', function() {
   let errors = [];
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   loader.on('error', function() {
     errors.push(loader.error);
@@ -487,7 +550,10 @@ QUnit.test('emits an error when an initial playlist request fails', function() {
 
 QUnit.test('errors when an initial media playlist request fails', function() {
   let errors = [];
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   loader.on('error', function() {
     errors.push(loader.error);
@@ -509,7 +575,10 @@ QUnit.test('errors when an initial media playlist request fails', function() {
 QUnit.test('halves the refresh timeout if a playlist is unchanged since the last reload',
 function() {
   /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
   /* eslint-enable no-unused-vars */
 
   this.requests.pop().respond(200, null,
@@ -534,7 +603,10 @@ function() {
 });
 
 QUnit.test('preserves segment metadata across playlist refreshes', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
   let segment;
 
   this.requests.pop().respond(200, null,
@@ -566,7 +638,10 @@ QUnit.test('preserves segment metadata across playlist refreshes', function() {
 });
 
 QUnit.test('clears the update timeout when switching quality', function() {
-  let loader = new PlaylistLoader('live-master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live-master.m3u8',
+    startLoading: true
+  });
   let refreshes = 0;
 
   // track the number of playlist refreshes triggered
@@ -601,7 +676,10 @@ QUnit.test('clears the update timeout when switching quality', function() {
 
 QUnit.test('media-sequence updates are considered a playlist change', function() {
   /* eslint-disable no-unused-vars */
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
   /* eslint-enable no-unused-vars */
 
   this.requests.pop().respond(200, null,
@@ -625,7 +703,10 @@ QUnit.test('media-sequence updates are considered a playlist change', function()
 QUnit.test('emits an error if a media refresh fails', function() {
   let errors = 0;
   let errorResponseText = 'custom error message';
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   loader.on('error', function() {
     errors++;
@@ -647,7 +728,10 @@ QUnit.test('emits an error if a media refresh fails', function() {
 });
 
 QUnit.test('switches media playlists when requested', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -676,7 +760,10 @@ QUnit.test('switches media playlists when requested', function() {
 });
 
 QUnit.test('can switch playlists immediately after the master is downloaded', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   loader.on('loadedplaylist', function() {
     loader.media('high.m3u8');
@@ -691,7 +778,10 @@ QUnit.test('can switch playlists immediately after the master is downloaded', fu
 });
 
 QUnit.test('can switch media playlists based on URI', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -720,7 +810,10 @@ QUnit.test('can switch media playlists based on URI', function() {
 });
 
 QUnit.test('aborts in-flight playlist refreshes when switching', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -742,7 +835,10 @@ QUnit.test('aborts in-flight playlist refreshes when switching', function() {
 });
 
 QUnit.test('switching to the active playlist is a no-op', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -762,7 +858,10 @@ QUnit.test('switching to the active playlist is a no-op', function() {
 });
 
 QUnit.test('switching to the active live playlist is a no-op', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -781,7 +880,10 @@ QUnit.test('switching to the active live playlist is a no-op', function() {
 });
 
 QUnit.test('switches back to loaded playlists without re-requesting them', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -810,7 +912,10 @@ QUnit.test('switches back to loaded playlists without re-requesting them', funct
 
 QUnit.test('aborts outstanding requests if switching back to an already loaded playlist',
 function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -844,7 +949,10 @@ function() {
 
 QUnit.test('does not abort requests when the same playlist is re-requested',
 function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -866,7 +974,10 @@ function() {
 });
 
 QUnit.test('throws an error if a media switch is initiated too early', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   QUnit.throws(function() {
     loader.media('high.m3u8');
@@ -882,7 +993,10 @@ QUnit.test('throws an error if a media switch is initiated too early', function(
 
 QUnit.test('throws an error if a switch to an unrecognized playlist is requested',
 function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -895,7 +1009,10 @@ function() {
 });
 
 QUnit.test('dispose cancels the refresh timeout', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -910,7 +1027,10 @@ QUnit.test('dispose cancels the refresh timeout', function() {
 });
 
 QUnit.test('dispose aborts pending refresh requests', function() {
-  let loader = new PlaylistLoader('live.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'live.m3u8',
+    startLoading: true
+  });
 
   this.requests.pop().respond(200, null,
                               '#EXTM3U\n' +
@@ -927,7 +1047,10 @@ QUnit.test('dispose aborts pending refresh requests', function() {
 });
 
 QUnit.test('errors if requests take longer than 45s', function() {
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
   let errors = 0;
 
   loader.on('error', function() {
@@ -940,7 +1063,10 @@ QUnit.test('errors if requests take longer than 45s', function() {
 });
 
 QUnit.test('triggers an event when the active media changes', function() {
-  let loader = new PlaylistLoader('master.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'master.m3u8',
+    startLoading: true
+  });
   let mediaChanges = 0;
   let mediaChangings = 0;
 
@@ -990,7 +1116,10 @@ QUnit.test('triggers an event when the active media changes', function() {
 });
 
 QUnit.test('does not misintrepret playlists missing newlines at the end', function() {
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   // no newline
   this.requests.shift().respond(200, null,

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -392,7 +392,10 @@ QUnit.module('Playlist Media Index For Time', {
 
 QUnit.test('can get media index by playback position for non-live videos', function() {
   let media;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -419,7 +422,10 @@ QUnit.test('can get media index by playback position for non-live videos', funct
 
 QUnit.test('returns the lower index when calculating for a segment boundary', function() {
   let media;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -442,7 +448,10 @@ QUnit.test(
 'accounts for non-zero starting segment time when calculating media index',
 function() {
   let media;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -517,7 +526,10 @@ function() {
 
 QUnit.test('prefers precise segment timing when tracking expired time', function() {
   let media;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
 
   loader.trigger('firstplay');
   this.requests.shift().respond(200, null,
@@ -563,7 +575,10 @@ QUnit.test('prefers precise segment timing when tracking expired time', function
 
 QUnit.test('accounts for expired time when calculating media index', function() {
   let media;
-  let loader = new PlaylistLoader('media.m3u8');
+  let loader = new PlaylistLoader({
+    srcUrl: 'media.m3u8',
+    startLoading: true
+  });
   let expired = 150;
 
   this.requests.shift().respond(200, null,

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -392,10 +392,9 @@ QUnit.module('Playlist Media Index For Time', {
 
 QUnit.test('can get media index by playback position for non-live videos', function() {
   let media;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -422,10 +421,9 @@ QUnit.test('can get media index by playback position for non-live videos', funct
 
 QUnit.test('returns the lower index when calculating for a segment boundary', function() {
   let media;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -448,10 +446,9 @@ QUnit.test(
 'accounts for non-zero starting segment time when calculating media index',
 function() {
   let media;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +
@@ -526,10 +523,9 @@ function() {
 
 QUnit.test('prefers precise segment timing when tracking expired time', function() {
   let media;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
+
+  loader.load();
 
   loader.trigger('firstplay');
   this.requests.shift().respond(200, null,
@@ -575,11 +571,10 @@ QUnit.test('prefers precise segment timing when tracking expired time', function
 
 QUnit.test('accounts for expired time when calculating media index', function() {
   let media;
-  let loader = new PlaylistLoader({
-    srcUrl: 'media.m3u8',
-    startLoading: true
-  });
+  let loader = new PlaylistLoader('media.m3u8');
   let expired = 150;
+
+  loader.load();
 
   this.requests.shift().respond(200, null,
     '#EXTM3U\n' +

--- a/test/plugin-helpers.js
+++ b/test/plugin-helpers.js
@@ -1,5 +1,11 @@
+import document from 'global/document';
 import sinon from 'sinon';
 import videojs from 'video.js';
+/* eslint-disable no-unused-vars */
+// needed so MediaSource can be registered with videojs
+import MediaSource from 'videojs-contrib-media-sources';
+/* eslint-enable */
+import testDataManifests from './test-manifests.js';
 
 // a SourceBuffer that tracks updates but otherwise is a noop
 class MockSourceBuffer extends videojs.EventTarget {
@@ -118,4 +124,146 @@ export const useFakeEnvironment = function() {
   videojs.xhr.XMLHttpRequest = fakeEnvironment.xhr;
 
   return fakeEnvironment;
+};
+
+// patch over some methods of the provided tech so it can be tested
+// synchronously with sinon's fake timers
+export const mockTech = function(tech) {
+  if (tech.isMocked_) {
+    // make this function idempotent because HTML and Flash based
+    // playback have very different lifecycles. For HTML, the tech
+    // is available on player creation. For Flash, the tech isn't
+    // ready until the source has been loaded and one tick has
+    // expired.
+    return;
+  }
+
+  tech.isMocked_ = true;
+  tech.src_ = null;
+  tech.time_ = null;
+
+  tech.paused_ = !tech.autoplay();
+  tech.paused = function() {
+    return tech.paused_;
+  };
+
+  if (!tech.currentTime_) {
+    tech.currentTime_ = tech.currentTime;
+  }
+  tech.currentTime = function() {
+    return tech.time_ === null ? tech.currentTime_() : tech.time_;
+  };
+
+  tech.setSrc = function(src) {
+    tech.src_ = src;
+  };
+  tech.src = function(src) {
+    if (src !== null) {
+      return tech.setSrc(src);
+    }
+    return tech.src_ === null ? tech.src : tech.src_;
+  };
+  tech.currentSrc_ = tech.currentSrc;
+  tech.currentSrc = function() {
+    return tech.src_ === null ? tech.currentSrc_() : tech.src_;
+  };
+
+  tech.play_ = tech.play;
+  tech.play = function() {
+    tech.play_();
+    tech.paused_ = false;
+    tech.trigger('play');
+  };
+  tech.pause_ = tech.pause_;
+  tech.pause = function() {
+    tech.pause_();
+    tech.paused_ = true;
+    tech.trigger('pause');
+  };
+
+  tech.setCurrentTime = function(time) {
+    tech.time_ = time;
+
+    setTimeout(function() {
+      tech.trigger('seeking');
+      setTimeout(function() {
+        tech.trigger('seeked');
+      }, 1);
+    }, 1);
+  };
+};
+
+export const createPlayer = function(options) {
+  let video;
+  let player;
+
+  video = document.createElement('video');
+  video.className = 'video-js';
+  document.querySelector('#qunit-fixture').appendChild(video);
+  player = videojs(video, options || {
+    flash: {
+      swf: ''
+    }
+  });
+
+  player.buffered = function() {
+    return videojs.createTimeRange(0, 0);
+  };
+  mockTech(player.tech_);
+
+  return player;
+};
+
+export const openMediaSource = function(player, clock) {
+  // ensure the Flash tech is ready
+  player.tech_.triggerReady();
+  clock.tick(1);
+  // mock the tech *after* it has finished loading so that we don't
+  // mock a tech that will be unloaded on the next tick
+  mockTech(player.tech_);
+
+  // simulate the sourceopen event
+  player.tech_.hls.mediaSource.readyState = 'open';
+  player.tech_.hls.mediaSource.dispatchEvent({
+    type: 'sourceopen',
+    swfId: player.tech_.el().id
+  });
+};
+
+export const standardXHRResponse = function(request) {
+  if (!request.url) {
+    return;
+  }
+
+  let contentType = 'application/json';
+  // contents off the global object
+  let manifestName = (/(?:.*\/)?(.*)\.m3u8/).exec(request.url);
+
+  if (manifestName) {
+    manifestName = manifestName[1];
+  } else {
+    manifestName = request.url;
+  }
+
+  if (/\.m3u8?/.test(request.url)) {
+    contentType = 'application/vnd.apple.mpegurl';
+  } else if (/\.ts/.test(request.url)) {
+    contentType = 'video/MP2T';
+  }
+
+  request.response = new Uint8Array(16).buffer;
+  request.respond(200, { 'Content-Type': contentType },
+                  testDataManifests[manifestName]);
+};
+
+// return an absolute version of a page-relative URL
+export const absoluteUrl = function(relativeUrl) {
+  return window.location.protocol + '//' +
+    window.location.host +
+    (window.location.pathname
+        .split('/')
+        .slice(0, -1)
+        .concat(relativeUrl)
+        .join('/')
+    );
 };

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1420,7 +1420,12 @@ QUnit.test('fires loadstart manually if Flash is used', function() {
       return 'auto';
     },
     src() {},
-    setTimeout: window.setTimeout
+    setTimeout: window.setTimeout,
+    audioTracks() {
+      return {
+        on: () => {}
+      };
+    }
   }))();
   let loadstarts = 0;
 


### PR DESCRIPTION
The first commit is the Master Playlist Controller (original PR: https://github.com/videojs/videojs-contrib-hls/pull/591 ).

The third commit includes changes to support alternate audio track loading.

CODE MOVES:
- A lot of moves were done from videojs-contrib-hls to master-playlist-controller to better confine the logic of the main plugin file (dealing with videojs interfaces), and the HLS specific logic.
- Some old unused code was removed (including sourceBuffer handling and creation within videojs-contrib-hls, as that is now the responsibility of each segment loader's source updater).

TODOs (included in code):
- loadAlternateAudioPlaylist is unused, and should be used when we start listening to change events on AudioTracksList
- within loadAlternateAudioPlaylists, on error events, there are TODOs to re-enable the main's audio
- Some methods within videojs-contrib-hls are unused within the project, and should either be removed or used where appropriate (TODOs are labeled above excludeIncompatibleVariants, playlistUriToUrl, and setBandwidth).

NOTES:
- We're not listening to audio segment loader progress events. This is because we do not need to switch renditions, and don't gain much by keeping an eye on the bandwidth (instead we rely on the bandwidth estimates from the combined video/audio stream).
- We're not pausing the alternate audio segment loading on media changes, as we might as well continue loading the same audio track.
- We're only tracking expired time for the main stream.

There are currently no tests, and old tests were not moved/fixed. These need to be added.