### PR TITLE
Fix the IE11 bug without introducing a massive bandwidth leak into Flash playback

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -323,8 +323,8 @@ const filterBufferedRanges = function(predicate) {
     // report a fully empty buffer until SourceBuffers have been created
     // which is after a segment has been loaded and transmuxed.
     if (!this.mediaSource ||
-        !this.mediaSource.mediaSource_ ||
-        !this.mediaSource.mediaSource_.sourceBuffers.length) {
+        (this.mediaSource.mediaSource_ &&
+        !this.mediaSource.mediaSource_.sourceBuffers.length)) {
       return videojs.createTimeRanges([]);
     }
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -752,7 +752,7 @@ QUnit.test('starts downloading a segment on loadedmetadata', function() {
                     'the first segment is requested');
 });
 
-QUnit.test('always returns an empty buffered region when there are no SourceBuffers', function() {
+QUnit.test('return an empty buffered region when there are no SourceBuffers but a real MediaSource exists', function() {
   this.player.src({
     src: 'manifest/media.m3u8',
     type: 'application/vnd.apple.mpegurl'
@@ -778,11 +778,11 @@ QUnit.test('always returns an empty buffered region when there are no SourceBuff
               0,
               'empty TimeRanges returned');
 
-   // Simulate the condition with no media source
+   // Simulate the condition with no media source (ie. Flash)
   delete this.player.hls.mediaSource.mediaSource_;
 
-  QUnit.equal(this.player.tech_.hls.findBufferedRange_().length,
-              0,
+  QUnit.equal(this.player.tech_.hls.findBufferedRange_().end(0),
+              10,
               'empty TimeRanges returned');
 });
 


### PR DESCRIPTION
The last release had a bug that meant that if the virtual MediaSource did not contain a *real* MediaSource, HLS would always consider the buffer empty. In a Flash fallback scenario (such as IE11 on Windows 7) we would download segments as quickly as possible repeated while playing back. Not only was this wasting massive amounts of bandwidth but it meant that the transmuxer we processing segments as quickly as possible and negatively affecting playback performance.

Now the condition reads: The *real* MediaSource **must** exist AND the sourceBuffers array **must** be empty in order to return an empty buffer as a work around the IE11 bug. Otherwise, continue processing as normal.