### PR TITLE
Support EXT-X-KEY:IV prefixed with 0X

### DIFF
--- a/src/m3u8/parse-stream.js
+++ b/src/m3u8/parse-stream.js
@@ -280,7 +280,7 @@ export default class ParseStream extends Stream {
         event.attributes = parseAttributes(match[1]);
         // parse the IV string into a Uint32Array
         if (event.attributes.IV) {
-          if (event.attributes.IV.substring(0, 2) === '0x') {
+          if (event.attributes.IV.substring(0, 2).toLowerCase() === '0x') {
             event.attributes.IV = event.attributes.IV.substring(2);
           }
 

--- a/test/m3u8.test.js
+++ b/test/m3u8.test.js
@@ -608,6 +608,35 @@ QUnit.test('parses lightly-broken #EXT-X-KEY tags', function() {
                     'trims and removes quotes around the URI');
 });
 
+QUnit.test('parses prefixed with 0x or 0X #EXT-X-KEY:IV tags', function() {
+  let manifest;
+  let element;
+
+  this.parseStream.on('data', function(elem) {
+    element = elem;
+  });
+
+  manifest = '#EXT-X-KEY:IV=0x1234567890abcdef1234567890abcdef\n';
+  this.lineStream.push(manifest);
+  QUnit.ok(element.attributes.IV, 'detected an IV attribute');
+  QUnit.deepEqual(element.attributes.IV, new Uint32Array([
+    0x12345678,
+    0x90abcdef,
+    0x12345678,
+    0x90abcdef
+  ]), 'parsed an IV value with 0x');
+
+  manifest = '#EXT-X-KEY:IV=0X1234567890abcdef1234567890abcdef\n';
+  this.lineStream.push(manifest);
+  QUnit.ok(element.attributes.IV, 'detected an IV attribute');
+  QUnit.deepEqual(element.attributes.IV, new Uint32Array([
+    0x12345678,
+    0x90abcdef,
+    0x12345678,
+    0x90abcdef
+  ]), 'parsed an IV value with 0X');
+});
+
 QUnit.test('ignores empty lines', function() {
   let manifest = '\n';
   let event = false;


### PR DESCRIPTION
I use the Adobe Media Server 5. It publish a manifest contains ``IV=0X1234567890abcdef1234567890abcdef``

I found brew specification.
https://tools.ietf.org/html/draft-pantos-http-live-streaming-18#ref-AES_128
> hexadecimal-sequence: an unquoted string of characters from the
set [0..9] and [A..F] that is prefixed with 0x or 0X