### PR TITLE
maat cleanup

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -331,7 +331,6 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     let media = this.masterPlaylistLoader_.media();
     let master = this.masterPlaylistLoader_.master;
 
-    // we have been called to early
     if (!media || !master) {
       videojs.log.warn('useAudio() was called before playlist was loaded');
       return;
@@ -369,7 +368,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       }
     }
 
-    // all audio tracks are disabled somehow
+    // all audio tracks are disabled somehow, safari keeps playing
+    // so should we
     if (!label) {
       return;
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -331,13 +331,23 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     let media = this.masterPlaylistLoader_.media();
     let master = this.masterPlaylistLoader_.master;
 
-    if (!media || !media.attributes || !media.attributes.AUDIO ||
+    // we have been called to early
+    if (!media || !master) {
+      videojs.log.warn('useAudio() was called before playlist was loaded');
+      return;
+    }
+
+    // we have been called but there is no audio track data
+    // so we only have the main one (that we know about)
+    if (!media.attributes || !media.attributes.AUDIO ||
         !master.mediaGroups || !master.mediaGroups.AUDIO) {
       return;
     }
     let mediaGroupName = media.attributes.AUDIO;
 
     if (!master.mediaGroups.AUDIO[mediaGroupName]) {
+      videojs.log.warn('useAudio() was called with a mediaGroup ' + mediaGroupName +
+                       ' that does not exist in the master');
       return;
     }
     let audioEntries = master.mediaGroups.AUDIO[mediaGroupName];
@@ -358,6 +368,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         break;
       }
     }
+
+    // all audio tracks are disabled somehow
     if (!label) {
       return;
     }

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -114,8 +114,8 @@ const findSoleUncommonTimeRangesEnd = function(original, update) {
 };
 
 export default {
-  findRange_: findRange,
-  findNextRange_: findNextRange,
-  findSoleUncommonTimeRangesEnd_: findSoleUncommonTimeRangesEnd,
+  findRange,
+  findNextRange,
+  findSoleUncommonTimeRangesEnd,
   TIME_FUDGE_FACTOR
 };

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -16,7 +16,7 @@ import videojs from 'video.js';
  * @param mimeType {string} the desired MIME type of the underlying
  * SourceBuffer
  */
-export default videojs.extend(null, {
+export default class SourceUpdater {
   constructor(mediaSource, mimeType) {
     let createSourceBuffer = () => {
       this.sourceBuffer_ = mediaSource.addSourceBuffer(mimeType);
@@ -47,7 +47,7 @@ export default videojs.extend(null, {
     } else {
       createSourceBuffer();
     }
-  },
+  }
 
   /**
    * Aborts the current segment and resets the segment parser.
@@ -57,7 +57,7 @@ export default videojs.extend(null, {
     this.queueCallback_(function abort() {
       this.sourceBuffer_.abort();
     }, done);
-  },
+  }
 
   /**
    * Queue an update to append an ArrayBuffer.
@@ -68,7 +68,7 @@ export default videojs.extend(null, {
     this.queueCallback_(function appendBuffer() {
       this.sourceBuffer_.appendBuffer(bytes);
     }, done);
-  },
+  }
 
   /**
    * Indicates what TimeRanges are buffered in the managed SourceBuffer.
@@ -79,17 +79,19 @@ export default videojs.extend(null, {
       return videojs.createTimeRanges();
     }
     return this.sourceBuffer_.buffered;
-  },
+  }
 
   /**
    * Queue an update to set the duration.
    * @see http://www.w3.org/TR/media-source/#widl-MediaSource-duration
    */
+  /* eslint-disable no-shadow */
   duration(duration) {
     this.queueCallback_(function duration() {
       this.sourceBuffer_.duration = duration;
     });
-  },
+  }
+  /* eslint-enable no-shadow */
 
   /**
    * Queue an update to remove a time range from the buffer.
@@ -100,7 +102,7 @@ export default videojs.extend(null, {
     this.queueCallback_(function remove() {
       this.sourceBuffer_.remove(start, end);
     });
-  },
+  }
 
   /**
    * Queue an update to remove a time range from the buffer.
@@ -109,7 +111,7 @@ export default videojs.extend(null, {
    */
   updating() {
     return this.sourceBuffer_.updating;
-  },
+  }
 
   timestampOffset(offset) {
     if (typeof offset !== 'undefined') {
@@ -119,12 +121,12 @@ export default videojs.extend(null, {
       this.timestampOffset_ = offset;
     }
     return this.timestampOffset_;
-  },
+  }
 
   queueCallback_(callback, done) {
     this.callbacks_.push([callback.bind(this), done]);
     this.runCallback_();
-  },
+  }
 
   runCallback_() {
     let callbacks;
@@ -137,4 +139,4 @@ export default videojs.extend(null, {
       callbacks[0]();
     }
   }
-});
+}

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -134,7 +134,7 @@ export default class HlsHandler extends Component {
     });
 
     this.masterPlaylistController_.on('loadedmetadata', () => {
-      let audioTracks = this.tech_.audioTracks();
+      let audioTrackList = this.tech_.audioTracks();
       let media = this.masterPlaylistController_.masterPlaylistLoader_.media();
       let mediaGroups =
         this.masterPlaylistController_.masterPlaylistLoader_.master.mediaGroups;
@@ -150,10 +150,10 @@ export default class HlsHandler extends Component {
       }
 
       // clear current audioTracks
-      while (audioTracks.length > 0) {
-        let last = audioTracks.length - 1;
+      while (audioTrackList.length > 0) {
+        let track = audioTrackList[(audioTrackList.length - 1)];
 
-        audioTracks.removeTrack(audioTracks[last]);
+        audioTrackList.removeTrack(track);
       }
 
       for (let label in attributes.audio) {
@@ -161,7 +161,7 @@ export default class HlsHandler extends Component {
 
         // disable eslint here so ie8 works
         /* eslint-disable dot-notation */
-        audioTracks.addTrack(new AudioTrack({
+        audioTrackList.addTrack(new AudioTrack({
           kind: hlstrack['default'] ? 'main' : 'alternative',
           language: hlstrack.language || '',
           enabled: hlstrack['default'] || false,

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -145,8 +145,8 @@ export default class HlsHandler extends Component {
       // only do alternative audio tracks in html5 mode, and if we have them
       if (this.mode_ === 'html5' &&
           media.attributes.AUDIO &&
-         mediaGroups[media.attributes.AUDIO]) {
-        attributes.audio = mediaGroups[media.attributes.AUDIO];
+         mediaGroups.AUDIO[media.attributes.AUDIO]) {
+        attributes.audio = mediaGroups.AUDIO[media.attributes.AUDIO];
       }
 
       // clear current audioTracks

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -13,6 +13,7 @@ import m3u8 from './m3u8';
 import videojs from 'video.js';
 import resolveUrl from './resolve-url';
 import MasterPlaylistController from './master-playlist-controller';
+import {AudioTrack} from 'video.js';
 
 const Hls = {
   PlaylistLoader,
@@ -104,12 +105,10 @@ export default class HlsHandler extends Component {
 
     this.on(this.tech_, 'play', this.play);
 
-    this.tech_.audioTracks().addEventListener('change', () => {
-      for (let i = 0; i < this.tech_.audioTracks().length; i++) {
-        if (this.tech_.audioTracks()[i].enabled) {
-          return this.masterPlaylistController_.useAudio(this.tech_.audioTracks()[i].label);
-        }
-      }
+    let audioTrackList = this.tech_.audioTracks();
+
+    audioTrackList.addEventListener('change', () => {
+      this.masterPlaylistController_.useAudio();
     });
   }
   src(src) {
@@ -132,6 +131,46 @@ export default class HlsHandler extends Component {
       mediaSourceMode: this.mode_,
       hlsHandler: this,
       externHls: Hls
+    });
+
+    this.masterPlaylistController_.on('loadedmetadata', () => {
+      let audioTracks = this.tech_.audioTracks();
+      let media = this.masterPlaylistController_.masterPlaylistLoader_.media();
+      let mediaGroups =
+        this.masterPlaylistController_.masterPlaylistLoader_.master.mediaGroups;
+      let attributes = {
+        audio: {main: {default: true}}
+      };
+
+      // only do alternative audio tracks in html5 mode, and if we have them
+      if (this.mode_ === 'html5' &&
+          media.attributes.AUDIO &&
+         mediaGroups[media.attributes.AUDIO]) {
+        attributes.audio = mediaGroups[media.attributes.AUDIO];
+      }
+
+      // clear current audioTracks
+      while (audioTracks.length > 0) {
+        let last = audioTracks.length - 1;
+
+        audioTracks.removeTrack(audioTracks[last]);
+      }
+
+      for (let label in attributes.audio) {
+        let hlstrack = attributes.audio[label];
+
+        // disable eslint here so ie8 works
+        /* eslint-disable dot-notation */
+        audioTracks.addTrack(new AudioTrack({
+          kind: hlstrack['default'] ? 'main' : 'alternative',
+          language: hlstrack.language || '',
+          enabled: hlstrack['default'] || false,
+          label
+        }));
+        /* eslint-enable dot-notation */
+      }
+      this.masterPlaylistController_.useAudio();
+      this.trigger('loadedmetadata');
     });
 
     // do nothing if the tech has been disposed already


### PR DESCRIPTION
use class syntax for SegmentLoader and SourceUpdater
this fixes playlist switching
move audioTrack addition back into hls
we now set this.audioPlaylistLoader_ to newPlaylistLoader right away
improved the code for adding an AudioTrack to video.js
ran the linter
removed loadaltaudio function
fixed seperate video/audio buffers