### PR TITLE
Re-introduce the concept of time correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   ],
   "dependencies": {
     "pkcs7": "^0.2.2",
-    "video.js": "^5.9.0-1",
+    "video.js": "5.9.0-1",
     "videojs-contrib-media-sources": "^3.0.0",
     "videojs-swf": "^5.0.0"
   },

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -140,6 +140,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.checkBufferTimeout_ = null;
     this.error_ = void 0;
     this.expired_ = 0;
+    this.timeCorrection_ = 0;
     this.currentTimeline_ = -1;
     this.xhr_ = null;
     this.pendingSegment_ = null;
@@ -272,6 +273,14 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   checkBuffer_(buffered, playlist, currentTime) {
     let currentBuffered = Ranges.findRange(buffered, currentTime);
+
+    // There are times when MSE reports the first segment as starting a
+    // little after 0-time so add a fudge factor to try and fix those cases
+    // or we end up fetching the same first segment over and over
+    if (currentBuffered.length === 0 && currentTime === 0) {
+      currentBuffered = findRange(buffered, currentTime + TIME_FUDGE_FACTOR);
+    }
+
     let bufferedTime;
     let currentBufferedEnd;
     let timestampOffset = this.sourceUpdater_.timestampOffset();
@@ -284,7 +293,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (currentBuffered.length === 0) {
       // find the segment containing currentTime
-      mediaIndex = getMediaIndexForTime(playlist, currentTime, this.expired_);
+      mediaIndex = getMediaIndexForTime(playlist, currentTime, this.expired_ + this.timeCorrection_);
     } else {
       // find the segment adjacent to the end of the current
       // buffered region
@@ -295,7 +304,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       if (bufferedTime >= GOAL_BUFFER_LENGTH) {
         return null;
       }
-      mediaIndex = getMediaIndexForTime(playlist, currentBufferedEnd, this.expired_);
+      mediaIndex = getMediaIndexForTime(playlist, currentBufferedEnd, this.expired_ + this.timeCorrection_);
     }
 
     if (mediaIndex < 0 || mediaIndex === playlist.segments.length) {
@@ -675,12 +684,14 @@ export default class SegmentLoader extends videojs.EventTarget {
                           timelineUpdate);
 
     // the last segment append must have been entirely in the
-    // already buffered time ranges. adjust the timestamp offset to
-    // fetch forward until we find a segment that adds to the
-    // buffered time ranges and improves subsequent media index
-    // calculations.
-//    if (!timelineUpdated) {
-//      this.expired_ -= segment.duration;
-//    }
+    // already buffered time ranges. adjust the timeCorrection
+    // offset to fetch forward until we find a segment that adds
+    // to the buffered time ranges and improves subsequent media
+    // index calculations.
+    if (!timelineUpdated) {
+      this.timeCorrection_ -= segment.duration;
+    } else {
+      this.timeCorrection_ = 0;
+    }
   }
 }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -278,7 +278,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // little after 0-time so add a fudge factor to try and fix those cases
     // or we end up fetching the same first segment over and over
     if (currentBuffered.length === 0 && currentTime === 0) {
-      currentBuffered = findRange(buffered, currentTime + TIME_FUDGE_FACTOR);
+      currentBuffered = Ranges.findRange(buffered, currentTime + Ranges.TIME_FUDGE_FACTOR);
     }
 
     let bufferedTime;
@@ -676,12 +676,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     timelineUpdate = Ranges.findSoleUncommonTimeRangesEnd(segmentInfo.buffered,
-                                                   this.sourceUpdater_.buffered());
+                                                          this.sourceUpdater_.buffered());
 
     // Update segment meta-data (duration and end-point) based on timeline
-    updateSegmentMetadata(playlist,
-                          currentMediaIndex,
-                          timelineUpdate);
+    let timelineUpdated = updateSegmentMetadata(playlist,
+                                                currentMediaIndex,
+                                                timelineUpdate);
 
     // the last segment append must have been entirely in the
     // already buffered time ranges. adjust the timeCorrection

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -106,8 +106,7 @@ QUnit.test('creates combined and audio only SegmentLoaders', function() {
               'created alternate audio track segment loader');
 });
 
-// TODO add back in once logic is returned in segment-loader
-QUnit.skip('if buffered, will request second segment byte range', function() {
+QUnit.test('if buffered, will request second segment byte range', function() {
   this.requests.length = 0;
   this.player.src({
     src: 'manifest/playlist.m3u8',


### PR DESCRIPTION
A few changes:
* When fetches aren't productive (the append didn't change the buffer), use a time-correction to "bump" the segment fetching logic forward until we find a segment that adds data to the buffer.
* When currentTime is 0, add a fudge factor to the currentTime to account for streams that start a little bit after 0. Because MSE specifies that the `buffered` property is the *intersection* of all source buffers, if the audio source buffer starts a little bit after the video, we end up with a combined `buffered` property that does not start at 0.