### PR TITLE
Use VideoJS 5.x component registration

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -1596,10 +1596,10 @@ if (window.Uint8Array) {
   videojs.getComponent('Flash').registerSourceHandler(HlsSourceHandler('flash'));
 }
 
-videojs.HlsHandler = HlsHandler;
-videojs.HlsSourceHandler = HlsSourceHandler;
-videojs.Hls = Hls;
-videojs.m3u8 = m3u8;
+videojs.registerComponent('HlsHandler', HlsHandler);
+videojs.registerComponent('HlsSourceHandler', HlsSourceHandler);
+videojs.registerComponent('Hls', Hls);
+videojs.registerComponent('m3u8', m3u8);
 
 export default {
   Hls,


### PR DESCRIPTION
### What does this do?

This updates the library to use VideoJS's 5.x component registration. Adding components directly to the VideoJS object is deprecated.

Addresses https://github.com/videojs/videojs-contrib-hls/issues/617