### PR TITLE
Workaround for the firefox audio sample/channel change crash

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -189,6 +189,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.mediaSource = new videojs.MediaSource({ mode: this.mediaSourceMode });
     // load the media source into the player
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_.bind(this));
+    this.mediaSource.addEventListener('audioinfochanged', (e) => {
+      this.trigger(e);
+    });
 
     this.hlsHandler = hlsHandler;
     this.hlsHandler.mediaSource = this.mediaSource;
@@ -326,6 +329,30 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     if (this.audioPlaylistLoader_) {
       this.audioSegmentLoader_.load();
     }
+  }
+
+  getPlaylistAttributes_() {
+    let media = this.media();
+    let master = this.master();
+    let mediaGroups = master.mediaGroups;
+    let attributes = {
+      audio: {main: {default: true}}
+    };
+
+    if (!media.attributes) {
+      // source URL was playlist manifest, not master
+      // no audio tracks to add
+      return;
+    }
+
+    // only do alternative audio tracks in html5 mode, and if we have them
+    if (this.mediaSourceMode === 'html5' &&
+        media.attributes &&
+        media.attributes.AUDIO &&
+        mediaGroups.AUDIO[media.attributes.AUDIO]) {
+      attributes.audio = mediaGroups.AUDIO[media.attributes.AUDIO];
+    }
+    return attributes;
   }
 
   useAudio() {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -532,7 +532,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
    * making it unavailable for selection by the rendition selection algorithm
    * and then forces a new playlist (rendition) selection.
    */
-  blacklistCurrentPlaylist(error) {
+  blacklistCurrentPlaylist(error = {}) {
     let currentPlaylist;
     let nextPlaylist;
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -284,7 +284,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.masterPlaylistLoader_.on('error', () => {
-      this.blacklistCurrentPlaylist_(this.masterPlaylistLoader_.error);
+      this.blacklistCurrentPlaylist(this.masterPlaylistLoader_.error);
     });
 
     this.masterPlaylistLoader_.on('mediachanging', () => {
@@ -310,7 +310,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('error', () => {
-      this.blacklistCurrentPlaylist_(this.mainSegmentLoader_.error());
+      this.blacklistCurrentPlaylist(this.mainSegmentLoader_.error());
     });
 
     this.audioSegmentLoader_.on('error', () => {
@@ -331,7 +331,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     }
   }
 
-  getPlaylistAttributes_() {
+  getPlaylistAttributes() {
     let media = this.media();
     let master = this.master();
     let mediaGroups = master.mediaGroups;
@@ -532,7 +532,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
    * making it unavailable for selection by the rendition selection algorithm
    * and then forces a new playlist (rendition) selection.
    */
-  blacklistCurrentPlaylist_(error) {
+  blacklistCurrentPlaylist(error) {
     let currentPlaylist;
     let nextPlaylist;
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1678,8 +1678,9 @@ QUnit.test('adds audio tracks if we have parsed some from a playlist', function(
   QUnit.equal(at[2].kind, 'alternative', 'track 3 - kind = alternative if DEFAULT is NO');
 });
 
-QUnit.test('Removes current audio track and reverts to main when audioinfochanged triggered on Firefox', function() {
+QUnit.test('user changes audio track, revert to main and remove if audioinfochanged on Firefox', function() {
   let oldIsFirefox = videojs.browser.IS_FIREFOX;
+  let at = this.player.audioTracks();
 
   videojs.browser.IS_FIREFOX = true;
   this.player.src({
@@ -1687,102 +1688,113 @@ QUnit.test('Removes current audio track and reverts to main when audioinfochange
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.equal(this.player.audioTracks().length, 0, 'zero audio tracks at load time');
-
+  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
-  // master
   standardXHRResponse(this.requests.shift());
-  let at = this.player.audioTracks();
-
+  standardXHRResponse(this.requests.shift());
   QUnit.equal(at.length, 3, 'three audio tracks after load');
 
   // simulate audio track change
   let oldLabel = at[1].label;
+  let hls = this.player.tech_.hls;
+  let mpc = hls.masterPlaylistController_;
+  let revertCalls = 0;
+  let useAudioCalls = 0;
+  let blacklistCalls = 0;
 
+  mpc.blacklistCurrentPlaylist = () => blacklistCalls++;
+  mpc.useAudio = () => useAudioCalls++;
   at[1].enabled = true;
-  this.player.tech_.hls.masterPlaylistController_.trigger({
+  mpc.trigger({
     type: 'audioinfochanged',
-    new: {},
-    old: {}
+    revert: () => revertCalls++,
   });
 
   QUnit.equal(at.length, 2, 'two audio tracks after audioinfochanged');
   QUnit.notEqual(at[1].label, oldLabel, 'audio track at index 1 is not the same');
   QUnit.equal(at[0].enabled, true, 'main track at index 0 is enabled again');
-  QUnit.equal(this.env.log.warn.calls, 4, 'three useAudio() non-issue warns and one for firefox issue');
+  QUnit.equal(revertCalls, 1, 'revert was called once');
+  QUnit.equal(useAudioCalls, 3, 'useAudio was called three times, once for change, once for this, and once too early');
+  QUnit.equal(blacklistCalls, 0, 'blacklist was not called');
+  QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
   videojs.browser.IS_FIREFOX = oldIsFirefox;
 });
 
-QUnit.test('blacklists current playlist if we only have one audio track, and audioinfochange triggered on Firefox', function() {
+QUnit.test('audioinfochange triggered on Firefox with one audio track, blacklist', function() {
   let oldIsFirefox = videojs.browser.IS_FIREFOX;
+  let at = this.player.audioTracks();
 
   videojs.browser.IS_FIREFOX = true;
-
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.equal(this.player.audioTracks().length, 0, 'zero audio tracks at load time');
-
+  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
-
-  // master
   standardXHRResponse(this.requests.shift());
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(at.length, 1, 'one audio track after load');
 
-  let oldBlacklist = this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist;
+  let hls = this.player.tech_.hls;
+  let mpc = hls.masterPlaylistController_;
   let blacklistCalls = 0;
+  let revertCalls = 0;
+  let useAudioCalls = 0;
 
-  this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist = () => blacklistCalls++;
-
-  QUnit.equal(this.player.audioTracks().length, 1, 'one audio track after load');
-  this.player.tech_.hls.masterPlaylistController_.trigger({
+  mpc.blacklistCurrentPlaylist = () => blacklistCalls++;
+  mpc.useAudio = () => useAudioCalls++;
+  mpc.trigger({
     type: 'audioinfochanged',
-    new: {},
-    old: {}
+    revert: () => revertCalls++,
   });
 
-  QUnit.equal(this.player.audioTracks().length, 1, 'one audio track after audioinfochanged');
+  QUnit.equal(at.length, 1, 'one audio track after audioinfochanged');
   QUnit.equal(blacklistCalls, 1, 'blacklistCurrentPlaylist called once');
-
+  QUnit.equal(useAudioCalls, 1, 'useAudio called once');
+  QUnit.equal(revertCalls, 1, 'revert called once');
+  QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
   videojs.browser.IS_FIREFOX = oldIsFirefox;
-  this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist = oldBlacklist;
 });
 
-QUnit.test('blacklists current playlist if audioinfochange triggered, and the default track is enabled on Firefox', function() {
+QUnit.test('audioinfochange triggered on firefox with three audio track, default enabled, blacklist', function() {
   let oldIsFirefox = videojs.browser.IS_FIREFOX;
+  let at = this.player.audioTracks();
 
   videojs.browser.IS_FIREFOX = true;
-
   this.player.src({
     src: 'manifest/multipleAudioGroups.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.equal(this.player.audioTracks().length, 0, 'zero audio tracks at load time');
-
+  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
-  // master
   standardXHRResponse(this.requests.shift());
-  let at = this.player.audioTracks();
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(at.length, 3, 'one audio track after load');
+  QUnit.equal(at[0].enabled, true, 'main audio track enabled after load');
 
-  QUnit.equal(at.length, 3, 'three audio tracks after load');
 
-  let oldBlacklist = this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist;
+  let hls = this.player.tech_.hls;
+  let mpc = hls.masterPlaylistController_;
   let blacklistCalls = 0;
+  let revertCalls = 0;
+  let useAudioCalls = 0;
 
-  this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist = () => blacklistCalls++;
-  this.player.tech_.hls.masterPlaylistController_.trigger({
+  mpc.blacklistCurrentPlaylist = () => blacklistCalls++;
+  mpc.useAudio = () => useAudioCalls++;
+  mpc.trigger({
     type: 'audioinfochanged',
-    new: {},
-    old: {}
+    revert: () => revertCalls++,
   });
 
-  QUnit.equal(this.player.audioTracks().length, 3, 'three audio track after audioinfochanged');
+  QUnit.equal(at[0].enabled, true, 'main audio track still enabled');
+  QUnit.equal(at.length, 3, 'three audio track after audioinfochanged');
   QUnit.equal(blacklistCalls, 1, 'blacklistCurrentPlaylist called once');
-
+  QUnit.equal(useAudioCalls, 1, 'useAudio called once');
+  QUnit.equal(revertCalls, 1, 'revert called once');
+  QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
   videojs.browser.IS_FIREFOX = oldIsFirefox;
-  this.player.tech_.hls.masterPlaylistController_.blacklistCurrentPlaylist = oldBlacklist;
 });
 
 QUnit.test('cleans up the buffer when loading live segments', function() {
@@ -1957,7 +1969,7 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
   };
 
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist_({});
+  mpc.blacklistCurrentPlaylist({});
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }
@@ -1976,7 +1988,7 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
 
   oldMediaGroup = mpc.media().attributes.AUDIO;
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist_({});
+  mpc.blacklistCurrentPlaylist({});
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1707,7 +1707,7 @@ QUnit.test('user changes audio track, revert to main and remove if audioinfochan
   at[1].enabled = true;
   mpc.trigger({
     type: 'audioinfochanged',
-    revert: () => revertCalls++,
+    revert: () => revertCalls++
   });
 
   QUnit.equal(at.length, 2, 'two audio tracks after audioinfochanged');
@@ -1746,7 +1746,7 @@ QUnit.test('audioinfochange triggered on Firefox with one audio track, blacklist
   mpc.useAudio = () => useAudioCalls++;
   mpc.trigger({
     type: 'audioinfochanged',
-    revert: () => revertCalls++,
+    revert: () => revertCalls++
   });
 
   QUnit.equal(at.length, 1, 'one audio track after audioinfochanged');
@@ -1774,7 +1774,6 @@ QUnit.test('audioinfochange triggered on firefox with three audio track, default
   QUnit.equal(at.length, 3, 'one audio track after load');
   QUnit.equal(at[0].enabled, true, 'main audio track enabled after load');
 
-
   let hls = this.player.tech_.hls;
   let mpc = hls.masterPlaylistController_;
   let blacklistCalls = 0;
@@ -1785,7 +1784,7 @@ QUnit.test('audioinfochange triggered on firefox with three audio track, default
   mpc.useAudio = () => useAudioCalls++;
   mpc.trigger({
     type: 'audioinfochanged',
-    revert: () => revertCalls++,
+    revert: () => revertCalls++
   });
 
   QUnit.equal(at[0].enabled, true, 'main audio track still enabled');
@@ -1969,7 +1968,7 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
   };
 
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist({});
+  mpc.blacklistCurrentPlaylist();
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }
@@ -1988,7 +1987,7 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
 
   oldMediaGroup = mpc.media().attributes.AUDIO;
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist({});
+  mpc.blacklistCurrentPlaylist();
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }


### PR DESCRIPTION
MPC re-emits audiotrackchanged and HLS picks it up
unify the interface to get parsed playlist attributes in MPC