### PR TITLE
Added a unit test to verify switching media groups during playback works

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   ],
   "dependencies": {
     "pkcs7": "^0.2.2",
-    "video.js": "5.9.0-1",
+    "video.js": "5.9.0-2",
     "videojs-contrib-media-sources": "^3.0.0",
     "videojs-swf": "^5.0.0"
   },

--- a/src/decrypter/decrypter.js
+++ b/src/decrypter/decrypter.js
@@ -20,7 +20,6 @@ const ntoh = function(word) {
     (word >>> 24);
 };
 
-/* eslint-disable max-len */
 /**
  * Decrypt bytes using AES-128 with CBC and PKCS#7 padding.
  * @param encrypted {Uint8Array} the encrypted bytes
@@ -33,7 +32,6 @@ const ntoh = function(word) {
  * @see http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
  * @see https://tools.ietf.org/html/rfc2315
  */
-/* eslint-enable max-len */
 export const decrypt = function(encrypted, key, initVector) {
   // word-level access to the encrypted bytes
   let encrypted32 = new Int32Array(encrypted.buffer,

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -1,5 +1,4 @@
 import document from 'global/document';
-/* eslint-disable max-len */
 /**
  * Constructs a new URI by interpreting a path relative to another
  * URI.
@@ -9,7 +8,6 @@ import document from 'global/document';
  * with `path`
  * @see http://stackoverflow.com/questions/470832/getting-an-absolute-url-from-a-relative-one-ie6-issue
  */
-/* eslint-enable max-len */
 const resolveUrl = function(basePath, path) {
   // use the base element to get the browser to handle URI resolution
   let oldBase = document.querySelector('base');

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -274,7 +274,9 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   getSegmentBufferedPercent_(playlist, mediaIndex, currentTime, buffered) {
     let segment = playlist.segments[mediaIndex];
-    let startOfSegment = duration(playlist, playlist.mediaSequence + mediaIndex) + this.expired_;
+    let startOfSegment = duration(playlist,
+                                  playlist.mediaSequence + mediaIndex) +
+                         this.expired_;
     let segmentRange = videojs.createTimeRanges([[
       Math.max(currentTime, startOfSegment),
       startOfSegment + segment.duration
@@ -299,7 +301,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // little after 0-time so add a fudge factor to try and fix those cases
     // or we end up fetching the same first segment over and over
     if (currentBuffered.length === 0 && currentTime === 0) {
-      currentBuffered = Ranges.findRange(buffered, currentTime + Ranges.TIME_FUDGE_FACTOR);
+      currentBuffered = Ranges.findRange(buffered,
+                                         currentTime + Ranges.TIME_FUDGE_FACTOR);
     }
 
     let bufferedTime;
@@ -314,7 +317,9 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (currentBuffered.length === 0) {
       // find the segment containing currentTime
-      mediaIndex = getMediaIndexForTime(playlist, currentTime, this.expired_ + this.timeCorrection_);
+      mediaIndex = getMediaIndexForTime(playlist,
+                                        currentTime,
+                                        this.expired_ + this.timeCorrection_);
     } else {
       // find the segment adjacent to the end of the current
       // buffered region
@@ -325,7 +330,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       if (bufferedTime >= GOAL_BUFFER_LENGTH) {
         return null;
       }
-      mediaIndex = getMediaIndexForTime(playlist, currentBufferedEnd, this.expired_ + this.timeCorrection_);
+      mediaIndex = getMediaIndexForTime(playlist,
+                                        currentBufferedEnd,
+                                        this.expired_ + this.timeCorrection_);
     }
 
     if (mediaIndex < 0 || mediaIndex === playlist.segments.length) {
@@ -336,13 +343,19 @@ export default class SegmentLoader extends videojs.EventTarget {
     // the percentage of the chosen segment that is buffered. If more than 90%
     // of the segment is buffered then fetching it will likely not help in any
     // way
-    let percentBuffered = this.getSegmentBufferedPercent_(playlist, mediaIndex, currentTime, buffered);
+    let percentBuffered = this.getSegmentBufferedPercent_(playlist,
+                                                          mediaIndex,
+                                                          currentTime,
+                                                          buffered);
 
     if (percentBuffered >= 90) {
       // Retry the buffered calculation with the next segment if there is another
       // segment after the currently selected segment
       if (mediaIndex + 1 < playlist.segments.length) {
-        percentBuffered = this.getSegmentBufferedPercent_(playlist, mediaIndex + 1, currentTime, buffered);
+        percentBuffered = this.getSegmentBufferedPercent_(playlist,
+                                                          mediaIndex + 1,
+                                                          currentTime,
+                                                          buffered);
       }
 
       // If both checks failed return and don't load anything

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -70,7 +70,7 @@ export default class HlsHandler extends Component {
     // backwards-compatibility
     if (tech.options_ && tech.options_.playerId) {
       _player = videojs(tech.options_.playerId);
-      if (!_player.hls) {
+      if (!_player.hasOwnProperty('hls')) {
         Object.defineProperty(_player, 'hls', {
           get: () => {
             videojs.log.warn('player.hls is deprecated. Use player.tech.hls instead.');

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -317,7 +317,8 @@ QUnit.test('adjusts the playlist offset if no buffering progress is made', funct
   QUnit.equal(this.requests[0].url, '1.ts', 'moved ahead a segment');
 });
 
-QUnit.test('never attempt to load a segment that is greater than 90% buffered', function() {
+QUnit.test('never attempt to load a segment that ' +
+           'is greater than 90% buffered', function() {
   let sourceBuffer;
   let playlist;
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -112,12 +112,21 @@ let fakeEnvironment = {
     this.clock.restore();
     videojs.xhr.XMLHttpRequest = window.XMLHttpRequest;
     this.xhr.restore();
+    ['warn', 'error'].forEach((level) => {
+      if (videojs.log && videojs.log[level] && videojs.log[level].restore) {
+        videojs.log[level].restore();
+      }
+    });
+
   }
 };
 
 export const useFakeEnvironment = function() {
   fakeEnvironment.clock = sinon.useFakeTimers();
-
+  ['warn', 'error'].forEach((level) => {
+    sinon.stub(videojs.log, level);
+  });
+  fakeEnvironment.log = videojs.log;
   fakeEnvironment.xhr = sinon.useFakeXMLHttpRequest();
   fakeEnvironment.requests.length = 0;
   fakeEnvironment.xhr.onCreate = function(xhr) {

--- a/utils/manifest/multipleAudioGroups.js
+++ b/utils/manifest/multipleAudioGroups.js
@@ -65,7 +65,7 @@
       AUDIO: "audio-lo"
     },
     timeline: 0,
-    uri: "hi/prog_index.m3u8"
+    uri: "lo2/prog_index.m3u8"
   }, {
     attributes: {
       "PROGRAM-ID": 1,
@@ -74,7 +74,7 @@
       AUDIO: "audio-hi"
     },
     timeline: 0,
-    uri: "lo/prog_index.m3u8"
+    uri: "hi/prog_index.m3u8"
   }, {
     attributes: {
       "PROGRAM-ID": 1,
@@ -83,6 +83,6 @@
       AUDIO: "audio-hi"
     },
     timeline: 0,
-    uri: "hi/prog_index.m3u8"
+    uri: "hi2/prog_index.m3u8"
   }]
 }

--- a/utils/manifest/multipleAudioGroups.m3u8
+++ b/utils/manifest/multipleAudioGroups.m3u8
@@ -10,8 +10,8 @@
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=195023,CODECS="mp4a.40.5", AUDIO="audio-lo"
 lo/prog_index.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=260000,CODECS="avc1.42e01e,mp4a.40.2", AUDIO="audio-lo"
-hi/prog_index.m3u8
+lo2/prog_index.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=591680,CODECS="mp4a.40.2, avc1.64001e", AUDIO="audio-hi"
-lo/prog_index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=650000,CODECS="avc1.42e01e,mp4a.40.2", AUDIO="audio-hi"
 hi/prog_index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=650000,CODECS="avc1.42e01e,mp4a.40.2", AUDIO="audio-hi"
+hi2/prog_index.m3u8


### PR DESCRIPTION
silenced videojs.log during tests
updated multipleAudioGroups files to be easier to understand
changed caret character to single quote where we were not using it as a template string
Pulls in changes from #642 