### PR TITLE
Allow dynamic source switching

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -337,7 +337,13 @@ export default class PlaylistLoader extends Stream {
 
       loader.state = 'HAVE_MASTER';
 
-      parser.manifest.uri = srcUrl;
+      // if the responseURL doesn't match the url requested initially, we're assuming an api call
+      if (req.responseURL != srcUrl) {
+        parser.manifest.uri = req.responseURL;
+        loader.trigger('mediasourcechange', req.responseURL);
+      } else {
+        parser.manifest.uri = srcUrl;
+      }
 
       // loaded a master playlist
       if (parser.manifest.playlists) {

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -441,6 +441,10 @@ export default class HlsHandler extends Component {
       this.blacklistCurrentPlaylist_(this.playlists.error);
     });
 
+    this.playlists.on('mediasourcechange', function (newUrl) {
+      this.source_.src = newUrl;
+    });
+
     this.playlists.on('loadedplaylist', () => {
       let updatedPlaylist = this.playlists.media();
       let seekable;


### PR DESCRIPTION
To preface, I'm fairly sure that this isn't the best solution to this problem, but it works for my case, and thought it might at least be helpful to look at.

#### The problem
We are using a live video provider that doesn't give us a raw m3u8 URL, but rather, an API URL that redirects to the m3u8. For example, we'd give the player www.streamingsite.com/api?video=1234, which would redirect to an m3u8 hosted on a CDN. The problem was that the player would attempt to play www.streamingsite.com/api/video.m3u8 instead of www.cdn.com/video.m3u8. For various reasons, we don't want to, say, CURL the API URL before feeding it to the player.

#### A solution
With this PR, if the initial response URL doesn't match the source URL, it is assumed (perhaps dangerously?) that we're dealing with a redirect of some kind, and we update the source URL in the HLS Handler.