### PR TITLE
Switch quality levels quickly when going fullscreen

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -447,6 +447,21 @@ export default class MasterPlaylistController extends videojs.EventTarget {
   }
 
   /**
+   * Re-tune playback quality level for the current player
+   * conditions. This method may perform destructive actions, like
+   * removing already buffered content, to readjust the currently
+   * active playlist quickly.
+   */
+  fastQualityChange_() {
+    let media = this.hlsHandler.selectPlaylist();
+
+    if (media !== this.masterPlaylistLoader_.media()) {
+      this.masterPlaylistLoader_.media(media);
+      this.mainSegmentLoader_.sourceUpdater_.remove(this.currentTimeFunc() + 5, Infinity);
+    }
+  }
+
+  /**
    * Seek to the latest media position if this is a live video and the
    * player and video are loaded and initialized.
    */

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -3,6 +3,7 @@
  * The main file for the HLS project.
  * License: https://github.com/videojs/videojs-contrib-hls/blob/master/LICENSE
  */
+import document from 'global/document';
 import PlaylistLoader from './playlist-loader';
 import Playlist from './playlist';
 import xhr from './xhr';
@@ -94,6 +95,22 @@ export default class HlsHandler extends Component {
     // 0.5 Mbps
     this.bandwidth = this.options_.bandwidth || 4194304;
     this.bytesReceived = 0;
+
+    // listen for fullscreenchange events for this player so that we
+    // can adjust our quality selection quickly
+    this.on(document, [
+      'fullscreenchange', 'webkitfullscreenchange',
+      'mozfullscreenchange', 'MSFullscreenChange'
+    ], (event) => {
+      let fullscreenElement = document.fullscreenElement ||
+          document.webkitFullscreenElement ||
+          document.mozFullScreenElement ||
+          document.msFullscreenElement;
+
+      if (fullscreenElement && fullscreenElement.contains(this.tech_.el())) {
+        this.masterPlaylistController_.fastQualityChange_();
+      }
+    });
 
     this.on(this.tech_, 'seeking', function() {
       this.setCurrentTime(this.tech_.currentTime());


### PR DESCRIPTION
Detect when the player is taken fullscreen and clear out some of the video buffer to trigger a quicker quality switch. Fix some tests that were using bad mocks that polluted the environment.