### PR TITLE
Remove two-way dependency between HlsHandler and MPC

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -5,154 +5,7 @@ import videojs from 'video.js';
 
 // 5 minute blacklist
 const BLACKLIST_DURATION = 5 * 60 * 1000;
-
-// A fudge factor to apply to advertised playlist bitrates to account for
-// temporary flucations in client bandwidth
-const BANDWIDTH_VARIANCE = 1.2;
-
 let Hls;
-
-/**
- * Returns the CSS value for the specified property on an element
- * using `getComputedStyle`. Firefox has a long-standing issue where
- * getComputedStyle() may return null when running in an iframe with
- * `display: none`.
- * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
- */
-const safeGetComputedStyle = function(el, property) {
-  let result;
-
-  if (!el) {
-    return '';
-  }
-
-  result = getComputedStyle(el);
-  if (!result) {
-    return '';
-  }
-
-  return result[property];
-};
-
-/**
- * Chooses the appropriate media playlist based on the current
- * bandwidth estimate and the player size.
- * @return the highest bitrate playlist less than the currently detected
- * bandwidth, accounting for some amount of bandwidth variance
- */
-const selectPlaylist = function() {
-  let effectiveBitrate;
-  let sortedPlaylists = this.playlists.master.playlists.slice();
-  let bandwidthPlaylists = [];
-  let now = +new Date();
-  let i;
-  let variant;
-  let bandwidthBestVariant;
-  let resolutionPlusOne;
-  let resolutionPlusOneAttribute;
-  let resolutionBestVariant;
-  let width;
-  let height;
-
-  sortedPlaylists.sort(Hls.comparePlaylistBandwidth);
-
-  // filter out any playlists that have been excluded due to
-  // incompatible configurations or playback errors
-  sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    if (typeof localVariant.excludeUntil !== 'undefined') {
-      return now >= localVariant.excludeUntil;
-    }
-    return true;
-  });
-
-  // filter out any variant that has greater effective bitrate
-  // than the current estimated bandwidth
-  i = sortedPlaylists.length;
-  while (i--) {
-    variant = sortedPlaylists[i];
-
-    // ignore playlists without bandwidth information
-    if (!variant.attributes || !variant.attributes.BANDWIDTH) {
-      continue;
-    }
-
-    effectiveBitrate = variant.attributes.BANDWIDTH * BANDWIDTH_VARIANCE;
-
-    if (effectiveBitrate < this.bandwidth) {
-      bandwidthPlaylists.push(variant);
-
-      // since the playlists are sorted in ascending order by
-      // bandwidth, the first viable variant is the best
-      if (!bandwidthBestVariant) {
-        bandwidthBestVariant = variant;
-      }
-    }
-  }
-
-  i = bandwidthPlaylists.length;
-
-  // sort variants by resolution
-  bandwidthPlaylists.sort(Hls.comparePlaylistResolution);
-
-  // forget our old variant from above,
-  // or we might choose that in high-bandwidth scenarios
-  // (this could be the lowest bitrate rendition as  we go through all of them above)
-  variant = null;
-
-  width = parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10);
-  height = parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10);
-
-  // iterate through the bandwidth-filtered playlists and find
-  // best rendition by player dimension
-  while (i--) {
-    variant = bandwidthPlaylists[i];
-
-    // ignore playlists without resolution information
-    if (!variant.attributes ||
-        !variant.attributes.RESOLUTION ||
-        !variant.attributes.RESOLUTION.width ||
-        !variant.attributes.RESOLUTION.height) {
-      continue;
-    }
-
-    // since the playlists are sorted, the first variant that has
-    // dimensions less than or equal to the player size is the best
-
-    let variantResolution = variant.attributes.RESOLUTION;
-
-    if (variantResolution.width === width &&
-        variantResolution.height === height) {
-      // if we have the exact resolution as the player use it
-      resolutionPlusOne = null;
-      resolutionBestVariant = variant;
-      break;
-    } else if (variantResolution.width < width &&
-               variantResolution.height < height) {
-      // if both dimensions are less than the player use the
-      // previous (next-largest) variant
-      break;
-    } else if (!resolutionPlusOne ||
-               (variantResolution.width < resolutionPlusOneAttribute.width &&
-                variantResolution.height < resolutionPlusOneAttribute.height)) {
-      // If we still haven't found a good match keep a
-      // reference to the previous variant for the next loop
-      // iteration
-
-      // By only saving variants if they are smaller than the
-      // previously saved variant, we ensure that we also pick
-      // the highest bandwidth variant that is just-larger-than
-      // the video player
-      resolutionPlusOne = variant;
-      resolutionPlusOneAttribute = resolutionPlusOne.attributes.RESOLUTION;
-    }
-  }
-
-  // fallback chain of variants
-  return resolutionPlusOne ||
-    resolutionBestVariant ||
-    bandwidthBestVariant ||
-    sortedPlaylists[0];
-};
 
 const parseCodecs = function(codecs) {
   let result = {
@@ -176,40 +29,44 @@ const parseCodecs = function(codecs) {
 };
 
 export default class MasterPlaylistController extends videojs.EventTarget {
-  constructor({url, withCredentials, currentTimeFunc, mediaSourceMode, hlsHandler,
-    externHls}) {
+  constructor({
+    url,
+    withCredentials,
+    mode,
+    tech,
+    bandwidth,
+    externHls
+  }) {
     super();
 
     Hls = externHls;
 
     this.withCredentials = withCredentials;
-    this.currentTimeFunc = currentTimeFunc;
-    this.mediaSourceMode = mediaSourceMode;
+    this.tech_ = tech;
 
-    this.mediaSource = new videojs.MediaSource({ mode: this.mediaSourceMode });
+    this.mediaSource = new videojs.MediaSource({ mode });
     // load the media source into the player
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_.bind(this));
-
-    this.hlsHandler = hlsHandler;
-    this.hlsHandler.mediaSource = this.mediaSource;
-    this.hlsHandler.selectPlaylist = this.hlsHandler.selectPlaylist || selectPlaylist;
 
     // combined audio/video or just video when alternate audio track is selected
     this.mainSegmentLoader_ = new SegmentLoader({
       mediaSource: this.mediaSource,
-      currentTime: this.currentTimeFunc,
+      currentTime: this.tech_.currentTime.bind(this.tech_),
       withCredentials: this.withCredentials,
       seekable: () => this.seekable(),
-      seeking: () => this.hlsHandler.tech_.seeking(),
+      seeking: () => this.tech_.seeking(),
       setCurrentTime: (a) => this.setCurrentTime(a)
     });
+    // pass along the starting bandwidth estimate
+    this.mainSegmentLoader_.bandwidth = bandwidth;
+
     // alternate audio track
     this.audioSegmentLoader_ = new SegmentLoader({
       mediaSource: this.mediaSource,
-      currentTime: this.currentTimeFunc,
+      currentTime: this.tech_.currentTime.bind(this.tech_),
       withCredentials: this.withCredentials,
       seekable: () => this.seekable(),
-      seeking: () => this.hlsHandler.tech_.seeking(),
+      seeking: () => this.tech_.seeking(),
       setCurrentTime: (a) => this.setCurrentTime(a)
     });
 
@@ -218,7 +75,6 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     }
 
     this.masterPlaylistLoader_ = new PlaylistLoader(url, this.withCredentials);
-    this.hlsHandler.playlists = this.masterPlaylistLoader_;
 
     this.masterPlaylistLoader_.on('loadedmetadata', () => {
       let media = this.masterPlaylistLoader_.media();
@@ -227,8 +83,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // if this isn't a live video and preload permits, start
       // downloading segments
       if (media.endList &&
-          this.hlsHandler.tech_.preload() !== 'metadata' &&
-          this.hlsHandler.tech_.preload() !== 'none') {
+          this.tech_.preload() !== 'metadata' &&
+          this.tech_.preload() !== 'none') {
         this.mainSegmentLoader_.playlist(media);
         this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
         this.mainSegmentLoader_.load();
@@ -262,7 +118,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       if (!updatedPlaylist) {
         // select the initial variant
-        this.initialMedia_ = this.hlsHandler.selectPlaylist();
+        this.initialMedia_ = this.selectPlaylist();
 
         this.masterPlaylistLoader_.media(this.initialMedia_);
         this.trigger('selectedinitialmedia');
@@ -271,7 +127,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       this.mainSegmentLoader_.playlist(updatedPlaylist);
       this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
-      this.updateDuration(this.masterPlaylistLoader_.media());
+      this.updateDuration();
 
       // update seekable
       seekable = this.seekable();
@@ -291,7 +147,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.masterPlaylistLoader_.on('mediachange', () => {
       this.mainSegmentLoader_.abort();
       this.mainSegmentLoader_.load();
-      this.hlsHandler.tech_.trigger({
+      this.tech_.trigger({
         type: 'mediachange',
         bubbles: true
       });
@@ -300,10 +156,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.mainSegmentLoader_.on('progress', () => {
       // figure out what stream the next segment should be downloaded from
       // with the updated bandwidth information
-      this.hlsHandler.bandwidth = this.mainSegmentLoader_.bandwidth;
-      this.masterPlaylistLoader_.media(this.hlsHandler.selectPlaylist());
+      this.masterPlaylistLoader_.media(this.selectPlaylist());
+      this.updateDuration();
 
-      this.hlsHandler.tech_.trigger('progress');
+      this.trigger('progress');
     });
 
     this.mainSegmentLoader_.on('error', () => {
@@ -363,9 +219,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     let label = null;
 
     // if no label was passed in we are switching to the currently enabled audio
-    for (let i = 0; i < this.hlsHandler.tech_.audioTracks().length; i++) {
-      if (this.hlsHandler.tech_.audioTracks()[i].enabled) {
-        label = this.hlsHandler.tech_.audioTracks()[i].label;
+    for (let i = 0; i < this.tech_.audioTracks().length; i++) {
+      if (this.tech_.audioTracks()[i].enabled) {
+        label = this.tech_.audioTracks()[i].label;
         break;
       }
     }
@@ -404,10 +260,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       // if the video is already playing, or if this isn't a live video and preload
       // permits, start downloading segments
-      if (!this.hlsHandler.tech_.paused() ||
+      if (!this.tech_.paused() ||
             (media.endList &&
-            this.hlsHandler.tech_.preload() !== 'metadata' &&
-            this.hlsHandler.tech_.preload() !== 'none')) {
+            this.tech_.preload() !== 'metadata' &&
+            this.tech_.preload() !== 'none')) {
         this.audioSegmentLoader_.load();
       }
 
@@ -453,11 +309,34 @@ export default class MasterPlaylistController extends videojs.EventTarget {
    * active playlist quickly.
    */
   fastQualityChange_() {
-    let media = this.hlsHandler.selectPlaylist();
+    let media = this.selectPlaylist();
 
     if (media !== this.masterPlaylistLoader_.media()) {
       this.masterPlaylistLoader_.media(media);
       this.mainSegmentLoader_.sourceUpdater_.remove(this.currentTimeFunc() + 5, Infinity);
+    }
+  }
+
+  /**
+   * Begin playback.
+   */
+  play() {
+    if (this.tech_.ended()) {
+      this.tech_.setCurrentTime(0);
+    }
+
+    this.load();
+
+    if (this.tech_.played().length === 0) {
+      return this.setupFirstPlay();
+    }
+
+    // if the viewer has paused and we fell out of the live window,
+    // seek forward to the earliest available position
+    if (this.tech_.duration() === Infinity) {
+      if (this.tech_.currentTime() < this.tech_.seekable().start(0)) {
+        this.tech_.setCurrentTime(this.tech_.seekable().start(0));
+      }
     }
   }
 
@@ -478,14 +357,14 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         !media.endList &&
 
         // 3) the player has not played before and is not paused
-        this.hlsHandler.tech_.played().length === 0 &&
-        !this.hlsHandler.tech_.paused()) {
+        this.tech_.played().length === 0 &&
+        !this.tech_.paused()) {
 
       this.load();
 
       // 4) the video element or flash player is in a readyState of
       // at least HAVE_FUTURE_DATA
-      if (this.hlsHandler.tech_.readyState() >= 1) {
+      if (this.tech_.readyState() >= 1) {
 
         // trigger the playlist loader to start "expired time"-tracking
         this.masterPlaylistLoader_.trigger('firstplay');
@@ -493,7 +372,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         // seek to the latest media position for live videos
         seekable = this.seekable();
         if (seekable.length) {
-          this.hlsHandler.tech_.setCurrentTime(seekable.end(0));
+          this.tech_.setCurrentTime(seekable.end(0));
         }
       }
     }
@@ -508,8 +387,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // if autoplay is enabled, begin playback. This is duplicative of
     // code in video.js but is required because play() must be invoked
     // *after* the media source has opened.
-    if (this.hlsHandler.tech_.autoplay()) {
-      this.hlsHandler.play();
+    if (this.tech_.autoplay()) {
+      this.tech_.play();
     }
 
     this.trigger('sourceopen');
@@ -533,7 +412,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // If there is no current playlist, then an error occurred while we were
     // trying to load the master OR while we were disposing of the tech
     if (!currentPlaylist) {
-      this.hlsHandler.error = error;
+      this.error = error;
       return this.mediaSource.endOfStream('network');
     }
 
@@ -541,7 +420,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
 
     // Select a new playlist
-    nextPlaylist = this.hlsHandler.selectPlaylist();
+    nextPlaylist = this.selectPlaylist();
 
     if (nextPlaylist) {
       videojs.log.warn('Problem encountered with the current ' +
@@ -552,7 +431,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     videojs.log.warn('Problem encountered with the current ' +
                      'HLS playlist. No suitable alternatives found.');
     // We have no more playlists we can select so we must fail
-    this.hlsHandler.error = error;
+    this.error = error;
     return this.mediaSource.endOfStream('network');
   }
 
@@ -564,7 +443,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
   }
 
   setCurrentTime(currentTime) {
-    let buffered = Ranges.findRange(this.hlsHandler.tech_.buffered(), currentTime);
+    let buffered = Ranges.findRange(this.tech_.buffered(), currentTime);
 
     if (!(this.masterPlaylistLoader_ && this.masterPlaylistLoader_.media())) {
       // return immediately if the metadata is not ready yet
@@ -590,7 +469,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       this.audioSegmentLoader_.abort();
     }
 
-    if (!this.hlsHandler.tech_.paused()) {
+    if (!this.tech_.paused()) {
       this.mainSegmentLoader_.load();
       if (this.audioPlaylistLoader_) {
         this.audioSegmentLoader_.load();
@@ -667,13 +546,13 @@ export default class MasterPlaylistController extends videojs.EventTarget {
   /**
    * Update the player duration
    */
-  updateDuration(playlist) {
+  updateDuration() {
     let oldDuration = this.mediaSource.duration;
-    let newDuration = Hls.Playlist.duration(playlist);
-    let buffered = this.hlsHandler.tech_.buffered();
+    let newDuration = Hls.Playlist.duration(this.masterPlaylistLoader_.media());
+    let buffered = this.tech_.buffered();
     let setDuration = () => {
       this.mediaSource.duration = newDuration;
-      this.hlsHandler.tech_.trigger('durationchange');
+      this.tech_.trigger('durationchange');
 
       this.mediaSource.removeEventListener('sourceopen', setDuration);
     };

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -44,7 +44,7 @@ QUnit.test('throws error when given an empty URL', function() {
   let options = {
     url: 'test',
     currentTimeFunc: () => {},
-    hlsHandler: this.masterPlaylistController.hlsHandler
+    tech: new (videojs.getTech('Html5'))({})
   };
 
   QUnit.ok(new MasterPlaylistController(options), 'can create with options');
@@ -87,7 +87,7 @@ QUnit.test('tech fires loadedmetadata when playlist loader loads first playlist'
 function() {
   let firedLoadedMetadata = false;
 
-  this.masterPlaylistController.hlsHandler.tech_.on('loadedmetadata', () => {
+  this.masterPlaylistController.tech_.on('loadedmetadata', () => {
     firedLoadedMetadata = true;
   });
 
@@ -120,7 +120,7 @@ QUnit.test('clears some of the buffer for a fast quality change', function() {
   segmentLoader.sourceUpdater_.remove = function(start, end) {
     removes.push({ start, end });
   };
-  this.masterPlaylistController.hlsHandler.selectPlaylist = () => {
+  this.masterPlaylistController.selectPlaylist = () => {
     return this.masterPlaylistController.master().playlists[0];
   };
   this.masterPlaylistController.currentTimeFunc = () => 7;
@@ -364,7 +364,7 @@ QUnit.test('updates the combined segment loader on media changes', function() {
 
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
 
-  this.masterPlaylistController.hlsHandler.bandwidth = 1;
+  this.masterPlaylistController.mainSegmentLoader_.bandwidth = 1;
 
   // master
   standardXHRResponse(this.requests.shift());
@@ -388,7 +388,7 @@ QUnit.test('updates the combined segment loader on media changes', function() {
 QUnit.test('selects a playlist after main/combined segment downloads', function() {
   let calls = 0;
 
-  this.masterPlaylistController.hlsHandler.selectPlaylist = () => {
+  this.masterPlaylistController.selectPlaylist = () => {
     calls++;
     return this.masterPlaylistController.masterPlaylistLoader_.master.playlists[0];
   };
@@ -413,14 +413,14 @@ QUnit.test('updates the duration after switching playlists', function() {
 
   this.masterPlaylistController.mediaSource.trigger('sourceopen');
 
-  this.masterPlaylistController.hlsHandler.bandwidth = 1e20;
+  this.masterPlaylistController.bandwidth = 1e20;
 
   // master
   standardXHRResponse(this.requests[0]);
   // media
   standardXHRResponse(this.requests[1]);
 
-  this.masterPlaylistController.hlsHandler.selectPlaylist = () => {
+  this.masterPlaylistController.selectPlaylist = () => {
     selectedPlaylist = true;
 
     // this duration should be overwritten by the playlist change

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1864,54 +1864,55 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
   standardXHRResponse(this.requests.shift());
   standardXHRResponse(this.requests.shift());
   let hls = this.player.tech_.hls;
-  let mpc = hls.masterPlaylistController_;
-  let at = this.player.audioTracks();
+  let audioTracks = this.player.audioTracks();
 
-  QUnit.equal(at.length, 3, 'three audio tracks after load');
-  let trackOne = at[0];
-  let trackTwo = at[1];
-  let trackThree = at[2];
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after load');
+  let trackOne = audioTracks[0];
+  let trackTwo = audioTracks[1];
+  let trackThree = audioTracks[2];
 
   QUnit.equal(trackOne.enabled, true, 'track one enabled after load');
 
-  let oldMediaGroup = mpc.media().attributes.AUDIO;
+  let oldMediaGroup = hls.playlists.media().attributes.AUDIO;
 
-  // force mpc to select a new media group
-  mpc.hlsHandler.selectPlaylist = () => {
-    return mpc.master().playlists.find(playlist => playlist.attributes.AUDIO !== oldMediaGroup);
+  // force a new media group to be selected
+  hls.selectPlaylist = () => {
+    return hls.playlists.master.playlists.find(playlist => {
+      return playlist.attributes.AUDIO !== oldMediaGroup;
+    });
   };
 
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist_({});
+  hls.masterPlaylistController_.blacklistCurrentPlaylist_({});
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }
-  QUnit.notEqual(oldMediaGroup, mpc.media().attributes.AUDIO, 'selected a new playlist');
+  QUnit.notEqual(oldMediaGroup, hls.playlists.media().attributes.AUDIO, 'selected a new playlist');
   QUnit.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
 
-  QUnit.equal(at.length, 3, 'three audio tracks after mediaGroup Change');
-  QUnit.equal(at[0], trackOne, 'track one did not change');
-  QUnit.equal(at[1], trackTwo, 'track two did not change');
-  QUnit.equal(at[2], trackThree, 'track three did not change');
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after mediaGroup Change');
+  QUnit.equal(audioTracks[0], trackOne, 'track one did not change');
+  QUnit.equal(audioTracks[1], trackTwo, 'track two did not change');
+  QUnit.equal(audioTracks[2], trackThree, 'track three did not change');
 
   trackTwo.enabled = true;
   QUnit.equal(trackOne.enabled, false, 'track 1 - now disabled');
   QUnit.equal(trackTwo.enabled, true, 'track 2 - now enabled');
   QUnit.equal(trackThree.enabled, false, 'track 3 - disabled');
 
-  oldMediaGroup = mpc.media().attributes.AUDIO;
+  oldMediaGroup = hls.playlists.media().attributes.AUDIO;
   // select a new mediaGroup
-  mpc.blacklistCurrentPlaylist_({});
+  hls.masterPlaylistController_.blacklistCurrentPlaylist_({});
   while (this.requests.length > 0) {
     standardXHRResponse(this.requests.shift());
   }
-  QUnit.notEqual(oldMediaGroup, mpc.media().attributes.AUDIO, 'selected a new playlist');
+  QUnit.notEqual(oldMediaGroup, hls.playlists.media().attributes.AUDIO, 'selected a new playlist');
   QUnit.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
 
-  QUnit.equal(at.length, 3, 'three audio tracks after mediaGroup Change');
-  QUnit.equal(at[0], trackOne, 'track one did not change');
-  QUnit.equal(at[1], trackTwo, 'track two did not change');
-  QUnit.equal(at[2], trackThree, 'track three did not change');
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after mediaGroup Change');
+  QUnit.equal(audioTracks[0], trackOne, 'track one did not change');
+  QUnit.equal(audioTracks[1], trackTwo, 'track two did not change');
+  QUnit.equal(audioTracks[2], trackThree, 'track three did not change');
 
   QUnit.equal(trackOne.enabled, false, 'track 1 - still disabled');
   QUnit.equal(trackTwo.enabled, true, 'track 2 - still enabled');


### PR DESCRIPTION
Try to further untangle the relationship between the HlsHandler and the MasterPlaylistController by removing all references to the handler in the MPC. We're still passing the tech down to the MPC which is a backdoor to sneak a lot of shared state around but this clarifies the ownership relationship a bit.