### PR TITLE
Remove unnecessary updateDuration

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -157,7 +157,6 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // figure out what stream the next segment should be downloaded from
       // with the updated bandwidth information
       this.masterPlaylistLoader_.media(this.selectPlaylist());
-      this.updateDuration();
 
       this.trigger('progress');
     });


### PR DESCRIPTION
Duration is updated when new playlists are loaded so it's not necessary to update duration on all progress events. Also, this may cause SourceBuffers to go into an updating state which causes endOfStream to fail when it's triggered later by the progress event.