### PR TITLE
HLS no longer fires its own loadedmetadata event

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -64,27 +64,21 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // load the media source into the player
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_.bind(this));
 
-    // combined audio/video or just video when alternate audio track is selected
-    this.mainSegmentLoader_ = new SegmentLoader({
+    let segmentLoaderOptions = {
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       withCredentials: this.withCredentials,
       seekable: () => this.seekable(),
       seeking: () => this.tech_.seeking(),
-      setCurrentTime: (a) => this.setCurrentTime(a)
-    });
-    // pass along the starting bandwidth estimate
-    this.mainSegmentLoader_.bandwidth = bandwidth;
+      setCurrentTime: (a) => this.setCurrentTime(a),
+      hasPlayed: () => this.tech_.played().length !== 0,
+      bandwidth
+    };
 
+    // combined audio/video or just video when alternate audio track is selected
+    this.mainSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
     // alternate audio track
-    this.audioSegmentLoader_ = new SegmentLoader({
-      mediaSource: this.mediaSource,
-      currentTime: this.tech_.currentTime.bind(this.tech_),
-      withCredentials: this.withCredentials,
-      seekable: () => this.seekable(),
-      seeking: () => this.tech_.seeking(),
-      setCurrentTime: (a) => this.setCurrentTime(a)
-    });
+    this.audioSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
 
     if (!url) {
       throw new Error('A non-empty playlist URL is required');
@@ -97,9 +91,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       // if this isn't a live video and preload permits, start
       // downloading segments
-      if (media.endList &&
-          this.tech_.preload() !== 'metadata' &&
-          this.tech_.preload() !== 'none') {
+      if (media.endList && this.tech_.preload() !== 'none') {
         this.mainSegmentLoader_.playlist(media);
         this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
         this.mainSegmentLoader_.load();
@@ -107,6 +99,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       this.setupSourceBuffer_();
       this.setupFirstPlay();
+      this.useAudio();
       this.trigger('loadedmetadata');
     });
 
@@ -305,9 +298,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // if the video is already playing, or if this isn't a live video and preload
       // permits, start downloading segments
       if (!this.tech_.paused() ||
-            (media.endList &&
-            this.tech_.preload() !== 'metadata' &&
-            this.tech_.preload() !== 'none')) {
+          (media.endList && this.tech_.preload() !== 'none')) {
         this.audioSegmentLoader_.load();
       }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -100,7 +100,6 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       this.setupSourceBuffer_();
       this.setupFirstPlay();
       this.useAudio();
-      this.trigger('loadedmetadata');
     });
 
     this.masterPlaylistLoader_.on('loadedplaylist', () => {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -130,11 +130,12 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // public properties
     this.state = 'INIT';
-    this.bandwidth = NaN;
+    this.bandwidth = settings.bandwidth;
     this.roundTrip = NaN;
     this.bytesReceived = 0;
 
     // private properties
+    this.hasPlayed_ = settings.hasPlayed;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
     this.seeking_ = settings.seeking;
@@ -371,8 +372,15 @@ export default class SegmentLoader extends videojs.EventTarget {
       currentBufferedEnd = currentBuffered.end(0);
       bufferedTime = Math.max(0, currentBufferedEnd - currentTime);
 
-      // if there is plenty of content buffered, relax for awhile
-      if (bufferedTime >= GOAL_BUFFER_LENGTH) {
+      // if the video has not yet played only, and we already have
+      // one segment downloaded do nothing
+      if (!this.hasPlayed_() && bufferedTime >= 1) {
+        return null;
+      }
+
+      // if there is plenty of content buffered, and the video has
+      // been played before relax for awhile
+      if (this.hasPlayed_() && bufferedTime >= GOAL_BUFFER_LENGTH) {
         return null;
       }
       mediaIndex = getMediaIndexForTime(playlist,

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -423,11 +423,6 @@ export default class HlsHandler extends Component {
       });
     });
 
-    this.on(this.masterPlaylistController_, 'loadedmetadata', function() {
-      this.masterPlaylistController_.useAudio();
-      this.tech_.trigger('loadedmetadata');
-    });
-
     // the bandwidth of the primary segment loader is our best
     // estimate of overall bandwidth
     this.on(this.masterPlaylistController_, 'progress', function() {

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -91,29 +91,6 @@ QUnit.test('obeys metadata preload option', function() {
   QUnit.equal(this.requests.length, 1, '1 segment request');
 });
 
-QUnit.test('tech fires loadedmetadata when playlist loader loads first playlist',
-function() {
-  let firedLoadedMetadata = false;
-
-  this.masterPlaylistController.on('loadedmetadata', () => {
-    firedLoadedMetadata = true;
-  });
-
-  // master
-  standardXHRResponse(this.requests.shift());
-  QUnit.ok(!firedLoadedMetadata, 'did not fire loadedmetadata');
-  // playlist
-  standardXHRResponse(this.requests.shift());
-  QUnit.ok(firedLoadedMetadata, 'fired loadedmetadata');
-});
-
-QUnit.test('creates combined and audio only SegmentLoaders', function() {
-  QUnit.equal(this.masterPlaylistController.mainSegmentLoader_.state, 'INIT',
-              'created combined segment loader');
-  QUnit.equal(this.masterPlaylistController.audioSegmentLoader_.state, 'INIT',
-              'created alternate audio track segment loader');
-});
-
 QUnit.test('clears some of the buffer for a fast quality change', function() {
   let removes = [];
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -61,6 +61,7 @@ QUnit.module('Segment Loader', {
       },
       seekable: () => this.seekable,
       seeking: () => false,
+      hasPlayed: () => true,
       mediaSource
     });
   },
@@ -845,13 +846,15 @@ QUnit.module('Segment Loading Calculation', {
   beforeEach() {
     this.env = useFakeEnvironment();
     this.mse = useFakeMediaSource();
+    this.hasPlayed = true;
 
     currentTime = 0;
     loader = new SegmentLoader({
       currentTime() {
         return currentTime;
       },
-      mediaSource: new videojs.MediaSource()
+      mediaSource: new videojs.MediaSource(),
+      hasPlayed: () => this.hasPlayed
     });
   },
   afterEach() {
@@ -869,6 +872,18 @@ QUnit.test('requests the first segment with an empty buffer', function() {
 
   QUnit.ok(segmentInfo, 'generated a request');
   QUnit.equal(segmentInfo.uri, '0.ts', 'requested the first segment');
+});
+
+QUnit.test('no request if video not played and 1 segment is buffered', function() {
+  this.hasPlayed = false;
+  loader.mimeType(this.mimeType);
+
+  let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
+                                        playlistWithDuration(20),
+                                        0);
+
+  QUnit.ok(!segmentInfo, 'no request generated');
+
 });
 
 QUnit.test('does not download the next segment if the buffer is full', function() {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -952,7 +952,7 @@ QUnit.test('fire loadedmetadata once we successfully load a playlist', function(
   });
   openMediaSource(this.player, this.clock);
   this.player.tech_.hls.bandwidth = 20000;
-  this.player.on('loadedmetadata', function() {
+  this.player.tech_.hls.masterPlaylistController_.on('loadedmetadata', function() {
     count += 1;
   });
   // master

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -951,8 +951,10 @@ QUnit.test('fire loadedmetadata once we successfully load a playlist', function(
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(this.player, this.clock);
-  this.player.tech_.hls.bandwidth = 20000;
-  this.player.tech_.hls.masterPlaylistController_.on('loadedmetadata', function() {
+  let hls = this.player.tech_.hls;
+
+  hls.bandwidth = 20000;
+  hls.masterPlaylistController_.masterPlaylistLoader_.on('loadedmetadata', function() {
     count += 1;
   });
   // master


### PR DESCRIPTION
simplified SegmentLoader options in MasterPlaylistController
added bandwidth optional to SegmentLoader options
updated unit tests to reflect havePlayed_ function
verify that we don't download more than 1 segment if we have not played yet
added a unit test to verify metadata preload