### PR TITLE
Flash live

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -581,28 +581,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         return audioSeekable;
       }
     }
-/*
-    // if the seekable start is zero, it may be because the player has
-    // been paused for a long time and stopped buffering. in that case,
-    // fall back to the playlist loader's running estimate of expired
-    // time
-    if (mainSeekable.start(0) === 0) {
-      mainSeekable = videojs.createTimeRanges([[this.masterPlaylistLoader_.expired_,
-                                                this.masterPlaylistLoader_.expired_ +
-                                                  mainSeekable.end(0)]]);
-    }
-    if (!audioSeekable) {
-      // seekable has been calculated based on buffering video data so it
-      // can be returned directly
-      return mainSeekable;
-    }
 
-    if (audioSeekable.start(0) === 0) {
-      audioSeekable = videojs.createTimeRanges([[this.audioPlaylistLoader_.expired_,
-                                                 this.audioPlaylistLoader_.expired_ +
-                                                  audioSeekable.end(0)]]);
-    }
-*/
     if (!audioSeekable) {
       // seekable has been calculated based on buffering video data so it
       // can be returned directly

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -401,18 +401,13 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
       this.load();
 
-      // 4) the video element or flash player is in a readyState of
-      // at least HAVE_FUTURE_DATA
-      if (this.tech_.readyState() >= 1) {
+      // trigger the playlist loader to start "expired time"-tracking
+      this.masterPlaylistLoader_.trigger('firstplay');
 
-        // trigger the playlist loader to start "expired time"-tracking
-        this.masterPlaylistLoader_.trigger('firstplay');
-
-        // seek to the latest media position for live videos
-        seekable = this.seekable();
-        if (seekable.length) {
-          this.tech_.setCurrentTime(seekable.end(0));
-        }
+      // seek to the latest media position for live videos
+      seekable = this.seekable();
+      if (seekable.length) {
+        this.tech_.setCurrentTime(seekable.end(0));
       }
     }
   }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -563,18 +563,20 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       return videojs.createTimeRanges();
     }
 
-    mainSeekable = Hls.Playlist.seekable(media);
+    mainSeekable = Hls.Playlist.seekable(media,
+                                         this.masterPlaylistLoader_.expired_);
     if (mainSeekable.length === 0) {
       return mainSeekable;
     }
 
     if (this.audioPlaylistLoader_) {
-      audioSeekable = Hls.Playlist.seekable(this.audioPlaylistLoader_.media());
+      audioSeekable = Hls.Playlist.seekable(this.audioPlaylistLoader_.media(),
+                                            this.audioPlaylistLoader_.expired_);
       if (audioSeekable.length === 0) {
         return audioSeekable;
       }
     }
-
+/*
     // if the seekable start is zero, it may be because the player has
     // been paused for a long time and stopped buffering. in that case,
     // fall back to the playlist loader's running estimate of expired
@@ -594,6 +596,12 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       audioSeekable = videojs.createTimeRanges([[this.audioPlaylistLoader_.expired_,
                                                  this.audioPlaylistLoader_.expired_ +
                                                   audioSeekable.end(0)]]);
+    }
+*/
+    if (!audioSeekable) {
+      // seekable has been calculated based on buffering video data so it
+      // can be returned directly
+      return mainSeekable;
     }
 
     return videojs.createTimeRanges([[

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -100,12 +100,12 @@ const forwardDuration = function(playlist, endSequence) {
   * playlist. The duration of a subinterval of the available segments
   * may be calculated by specifying an end index.
   *
-  * @param playlist {object} a media playlist object
-  * @param endSequence {number} (optional) an exclusive upper boundary
+  * @param {Object} playlist a media playlist object
+  * @param {Number=} endSequence an exclusive upper boundary
   * for the playlist.  Defaults to playlist length.
-  * @param expired {number} (optional) the amount of time that has
-  * dropped off the front of the playlist in a live scenario
-  * @return {number} the duration between the first available segment
+  * @param {Number} expired the amount of time that has dropped
+  * off the front of the playlist in a live scenario
+  * @return {Number} the duration between the first available segment
   * and end index.
   */
 const intervalDuration = function(playlist, endSequence, expired) {
@@ -152,9 +152,9 @@ const intervalDuration = function(playlist, endSequence, expired) {
   * @param {Number=} endSequence an exclusive upper
   * boundary for the playlist. Defaults to the playlist media
   * sequence number plus its length.
-  * @param expired {number} (optional) the amount of time that has
+  * @param {Number=} expired the amount of time that has
   * dropped off the front of the playlist in a live scenario
-  * @return {number} the duration between the start index and end
+  * @return {Number} the duration between the start index and end
   * index.
   */
 export const duration = function(playlist, endSequence, expired) {
@@ -195,6 +195,8 @@ export const duration = function(playlist, endSequence, expired) {
   * stream.
   *
   * @param {Object} playlist a media playlist object
+  * @param {Number=} expired the amount of time that has
+  * dropped off the front of the playlist in a live scenario
   * @return {TimeRanges} the periods of time that are valid targets
   * for seeking
   */

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -203,6 +203,10 @@ export const seekable = function(playlist, expired) {
   let end;
   let endSequence;
 
+  if (typeof expired !== 'number') {
+    expired = 0;
+  }
+
   // without segments, there are no seekable ranges
   if (!playlist || !playlist.segments) {
     return createTimeRange();

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -320,8 +320,8 @@ export default class SegmentLoader extends videojs.EventTarget {
   getSegmentBufferedPercent_(playlist, mediaIndex, currentTime, buffered) {
     let segment = playlist.segments[mediaIndex];
     let startOfSegment = duration(playlist,
-                                  playlist.mediaSequence + mediaIndex) +
-                         this.expired_;
+                                  playlist.mediaSequence + mediaIndex,
+                                  this.expired_);
     let segmentRange = videojs.createTimeRanges([[
       Math.max(currentTime, startOfSegment),
       startOfSegment + segment.duration
@@ -421,7 +421,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     segment = playlist.segments[mediaIndex];
-    let startOfSegment = duration(playlist, playlist.mediaSequence + mediaIndex);
+    let startOfSegment = duration(playlist,
+                                  playlist.mediaSequence + mediaIndex,
+                                  this.expired_);
 
     // We will need to change timestampOffset of the sourceBuffer if either of
     // the following conditions are true:

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -178,9 +178,6 @@ QUnit.test('autoplay seeks to the live point after playlist load', function() {
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(this.player, this.clock);
-  this.player.tech_.readyState = function() {
-    return 1;
-  };
   this.player.tech_.trigger('play');
   standardXHRResponse(this.requests.shift());
   this.clock.tick(1);
@@ -203,9 +200,6 @@ QUnit.test('autoplay seeks to the live point after media source open', function(
   this.clock.tick(1);
   standardXHRResponse(this.requests.shift());
   openMediaSource(this.player, this.clock);
-  this.player.tech_.readyState = function() {
-    return 1;
-  };
   this.player.tech_.trigger('play');
   this.clock.tick(1);
 
@@ -1010,9 +1004,6 @@ QUnit.test('live playlist starts with correct currentTime value', function() {
 
   this.player.tech_.paused = function() {
     return false;
-  };
-  this.player.tech_.readyState = function() {
-    return 1;
   };
   this.player.tech_.trigger('play');
   this.clock.tick(1);
@@ -1885,9 +1876,6 @@ QUnit.test('cleans up the buffer when loading live segments', function() {
   this.player.tech_.paused = function() {
     return false;
   };
-  this.player.tech_.readyState = function() {
-    return 1;
-  };
   this.player.tech_.trigger('play');
 
   this.clock.tick(1);
@@ -1936,10 +1924,6 @@ QUnit.test('cleans up the buffer based on currentTime when loading a live segmen
 
   this.player.tech_.paused = function() {
     return false;
-  };
-
-  this.player.tech_.readyState = function() {
-    return 1;
   };
 
   this.player.tech_.trigger('play');
@@ -2299,9 +2283,6 @@ QUnit.test('live playlist starts three target durations before live', function()
 
   this.tech.paused = function() {
     return false;
-  };
-  this.tech.readyState = function() {
-    return 1;
   };
   this.tech.trigger('play');
   this.clock.tick(1);


### PR DESCRIPTION
Remove a work-around that was in-place for the broken implementation of MSE events in Firefox < 45 and fix a bug that was keeping Flash from seeking to the live-point in a live HLS stream.