### PR TITLE
Use a single default audio track when not in html5 mode

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -187,9 +187,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         Object.keys(mediaGroups.AUDIO).length === 0 ||
         this.mode_ !== 'html5') {
       // "main" audio group, track name "default"
-      mediaGroups = videojs.mergeOptions(mediaGroups, {AUDIO: {
-        main: {default: {default: true}}}
-      });
+      mediaGroups.AUDIO = {main: {default: {default: true }}};
     }
 
     let tracks = {};

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1643,6 +1643,34 @@ QUnit.test('adds 1 default audio track if we have not parsed any, and the playli
   QUnit.ok(this.player.audioTracks()[0] instanceof HlsAudioTrack, 'audio track is an hls audio track');
 });
 
+QUnit.test('adds 1 default audio track if in flash mode', function() {
+  let hlsOptions = videojs.options.hls;
+
+  this.player.dispose();
+  videojs.options.hls = {
+    mode: 'flash'
+  };
+
+  this.player = createPlayer();
+
+  this.player.src({
+    src: 'manifest/multipleAudioGroups.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  QUnit.equal(this.player.audioTracks().length, 0, 'zero audio tracks at load time');
+
+  openMediaSource(this.player, this.clock);
+
+  // master
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.equal(this.player.audioTracks().length, 1, 'one audio track after load');
+  QUnit.ok(this.player.audioTracks()[0] instanceof HlsAudioTrack, 'audio track is an hls audio track');
+
+  videojs.options.hls = hlsOptions;
+});
+
 QUnit.test('adds audio tracks if we have parsed some from a playlist', function() {
   this.player.src({
     src: 'manifest/multipleAudioGroups.m3u8',


### PR DESCRIPTION
This PR is to make sure there is only one audio track when in Flash mode. Previously if a video had audio media groups in flash mode the track list would have a default track and all the audio groups (ex. "default", "track A", "track B").