### PR TITLE
Fix fastQualityChange_ to stop calling a function that no longer exists

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -352,7 +352,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
     if (media !== this.masterPlaylistLoader_.media()) {
       this.masterPlaylistLoader_.media(media);
-      this.mainSegmentLoader_.sourceUpdater_.remove(this.currentTimeFunc() + 5, Infinity);
+      this.mainSegmentLoader_.sourceUpdater_.remove(this.tech_.currentTime() + 5, Infinity);
     }
   }
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -43,7 +43,6 @@ QUnit.module('MasterPlaylistController', {
 QUnit.test('throws error when given an empty URL', function() {
   let options = {
     url: 'test',
-    currentTimeFunc: () => {},
     tech: this.player.tech_
   };
 
@@ -108,7 +107,7 @@ QUnit.test('clears some of the buffer for a fast quality change', function() {
   this.masterPlaylistController.selectPlaylist = () => {
     return this.masterPlaylistController.master().playlists[0];
   };
-  this.masterPlaylistController.currentTimeFunc = () => 7;
+  this.masterPlaylistController.tech_.currentTime = () => 7;
 
   this.masterPlaylistController.fastQualityChange_();
 


### PR DESCRIPTION
The `currentTimeFunc` variable was somehow lost during all the rebases and merges. The function `fastQualityChange_` calls that property of `this` even though it no longer exists and throws an error. This PR simply restores the property.