### PR TITLE
Fix time correction

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -823,7 +823,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   updateTimeline_(segmentInfo) {
     let segment;
-    let updateTime;
+    let segmentEnd;
     let timelineUpdated;
     let segmentLength = this.playlist_.targetDuration;
     let playlist = segmentInfo.playlist;
@@ -836,11 +836,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (segment &&
         segmentInfo &&
         segmentInfo.playlist.uri === this.playlist_.uri) {
-      updateTime = Ranges.findSoleUncommonTimeRangesEnd(segmentInfo.buffered,
+      segmentEnd = Ranges.findSoleUncommonTimeRangesEnd(segmentInfo.buffered,
                                                         this.sourceUpdater_.buffered());
       timelineUpdated = updateSegmentMetadata(playlist,
                                               currentMediaIndex,
-                                              updateTime);
+                                              segmentEnd);
       segmentLength = segment.duration;
     }
 
@@ -850,16 +850,16 @@ export default class SegmentLoader extends videojs.EventTarget {
     // to the buffered time ranges and improves subsequent media
     // index calculations.
     if (!timelineUpdated) {
-      this.timeCorrection_ += segmentLength;
-
       // appends haven't produced any new information for at least 5
       // consecutive segments loads it is time to signal an error
       // and stop
       if (this.timeCorrection_ > this.playlist_.targetDuration * 5) {
         this.timeCorrection_ = 0;
         this.pause();
-        this.trigger('error');
+        return this.trigger('error');
       }
+
+      this.timeCorrection_ += segmentLength;
     } else {
       this.timeCorrection_ = 0;
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -303,6 +303,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.state === 'READY') {
       this.fillBuffer_();
     }
+
+    if (this.checkBufferTimeout_) {
+      window.clearTimeout(this.checkBufferTimeout_);
+    }
+
     this.checkBufferTimeout_ = window.setTimeout(this.monitorBuffer_.bind(this),
                                                  CHECK_BUFFER_DELAY);
   }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -364,8 +364,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (currentBuffered.length === 0) {
       // find the segment containing currentTime
       mediaIndex = getMediaIndexForTime(playlist,
-                                        currentTime,
-                                        this.expired_ + this.timeCorrection_);
+                                        currentTime + this.timeCorrection_,
+                                        this.expired_);
     } else {
       // find the segment adjacent to the end of the current
       // buffered region
@@ -384,8 +384,8 @@ export default class SegmentLoader extends videojs.EventTarget {
         return null;
       }
       mediaIndex = getMediaIndexForTime(playlist,
-                                        currentBufferedEnd,
-                                        this.expired_ + this.timeCorrection_);
+                                        currentBufferedEnd + this.timeCorrection_,
+                                        this.expired_);
     }
 
     if (mediaIndex < 0 || mediaIndex === playlist.segments.length) {
@@ -757,12 +757,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     let currentTime = this.currentTime_();
 
     this.pendingSegment_ = null;
-    // add segment timeline information if we're still using the
-    // same playlist
-    if (segmentInfo && segmentInfo.playlist.uri === this.playlist_.uri) {
-      this.updateTimeline_(segmentInfo);
-      this.trigger('progress');
-    }
+
+    // add segment metadata if it we have gained information during the
+    // last append
+    this.updateTimeline_(segmentInfo);
+    this.trigger('progress');
 
     let currentMediaIndex = segmentInfo.mediaIndex;
 
@@ -819,24 +818,26 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   updateTimeline_(segmentInfo) {
     let segment;
-    let timelineUpdate;
+    let updateTime;
+    let timelineUpdated;
+    let segmentLength = this.playlist_.targetDuration;
     let playlist = segmentInfo.playlist;
     let currentMediaIndex = segmentInfo.mediaIndex;
 
     currentMediaIndex += playlist.mediaSequence - this.playlist_.mediaSequence;
     segment = playlist.segments[currentMediaIndex];
 
-    if (!segment) {
-      return;
-    }
-
-    timelineUpdate = Ranges.findSoleUncommonTimeRangesEnd(segmentInfo.buffered,
-                                                          this.sourceUpdater_.buffered());
-
     // Update segment meta-data (duration and end-point) based on timeline
-    let timelineUpdated = updateSegmentMetadata(playlist,
-                                                currentMediaIndex,
-                                                timelineUpdate);
+    if (segment &&
+        segmentInfo &&
+        segmentInfo.playlist.uri === this.playlist_.uri) {
+      updateTime = Ranges.findSoleUncommonTimeRangesEnd(segmentInfo.buffered,
+                                                        this.sourceUpdater_.buffered());
+      timelineUpdated = updateSegmentMetadata(playlist,
+                                              currentMediaIndex,
+                                              updateTime);
+      segmentLength = segment.duration;
+    }
 
     // the last segment append must have been entirely in the
     // already buffered time ranges. adjust the timeCorrection
@@ -844,7 +845,16 @@ export default class SegmentLoader extends videojs.EventTarget {
     // to the buffered time ranges and improves subsequent media
     // index calculations.
     if (!timelineUpdated) {
-      this.timeCorrection_ -= segment.duration;
+      this.timeCorrection_ += segmentLength;
+
+      // appends haven't produced any new information for at least 5
+      // consecutive segments loads it is time to signal an error
+      // and stop
+      if (this.timeCorrection_ > this.playlist_.targetDuration * 5) {
+        this.timeCorrection_ = 0;
+        this.pause();
+        this.trigger('error');
+      }
     } else {
       this.timeCorrection_ = 0;
     }

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -984,11 +984,8 @@ QUnit.test('downloads the next segment if the buffer is getting low', function()
   loader.mimeType(this.mimeType);
   loader.playlist(playlist);
 
+  playlist.segments[1].end = 19.999;
   buffered = videojs.createTimeRanges([[0, 19.999]]);
-  segmentInfo = loader.checkBuffer_(buffered, playlist, 15);
-
-  QUnit.equal(segmentInfo, undefined, 'returned undefined');
-
   segmentInfo = loader.checkBuffer_(buffered, playlist, 15);
 
   QUnit.ok(segmentInfo, 'made a request');


### PR DESCRIPTION
* Always apply timeCorrection_ when we haven't learned anything even if playlists have changed
* Apply timeCorrection_ directly to the currentTime when calling getMediaIndexForTime so that we can work around bad segment.end metadata in the playlist
* Emit an error if we have been stuck in a "timeCorrection" loop for more than 5 fetch attempts