### PR TITLE
use can handle source options to override mode 

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -557,12 +557,18 @@ class HlsHandler extends Component {
  */
 const HlsSourceHandler = function(mode) {
   return {
-    canHandleSource(srcObj) {
+    canHandleSource(srcObj, options = {}) {
+      let modeOverride;
+
+      if (videojs.options.hls && videojs.options.hls.mode) {
+        modeOverride = videojs.options.hls.mode;
+      }
+      if (options.hls && options.hls.mode) {
+        modeOverride = options.hls.mode;
+      }
       // this forces video.js to skip this tech/mode if its not the one we have been
       // overriden to use, by returing that we cannot handle the source.
-      if (videojs.options.hls &&
-          videojs.options.hls.mode &&
-          videojs.options.hls.mode !== mode) {
+      if (options.hls.mode !== mode) {
         return false;
       }
       return HlsSourceHandler.canPlayType(srcObj.type);


### PR DESCRIPTION
## Description

Once video.js cuts a release that includes passing source handler options to canHandleSource we can merge this PR so that the mode can be overridden more easily.

This CANNOT BE MERGED YET!
## Specific Changes proposed

Implement video.js canHandleSource API change
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
