### PR TITLE
Load the playlist into the mainSegmentLoader_ on a mediachange

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -118,6 +118,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         return;
       }
 
+      // TODO: Create a new event on the PlaylistLoader that signals
+      // that the segments have changed in some way and use that to
+      // update the SegmentLoader instead of doing it twice here and
+      // on `mediachange`
       this.mainSegmentLoader_.playlist(updatedPlaylist);
       this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
       this.updateDuration();
@@ -138,8 +142,18 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.masterPlaylistLoader_.on('mediachange', () => {
+      let media = this.masterPlaylistLoader_.media();
+
       this.mainSegmentLoader_.abort();
+
+      // TODO: Create a new event on the PlaylistLoader that signals
+      // that the segments have changed in some way and use that to
+      // update the SegmentLoader instead of doing it twice here and
+      // on `loadedplaylist`
+      this.mainSegmentLoader_.playlist(media);
+      this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
       this.mainSegmentLoader_.load();
+
       this.tech_.trigger({
         type: 'mediachange',
         bubbles: true

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -409,7 +409,7 @@ QUnit.test('updates the combined segment loader on media changes', function() {
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
   // media
   standardXHRResponse(this.requests.shift());
-  QUnit.equal(updates.length, 1, 'updated the segment list');
+  QUnit.ok(updates.length > 0, 'updated the segment list');
 
   // verify stats
   QUnit.equal(this.player.tech_.hls.stats.bandwidth, Infinity, 'Live stream');


### PR DESCRIPTION
## Description
The `PlaylistLoader` signals that the active playlist has changed by triggering a `mediachange` event and the `SegmentLoader` needs to know about the new playlist or it will continue to select segments from the old playlist.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors
