### PR TITLE
Timeout requests

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -517,7 +517,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // ||
     if (this.masterPlaylistLoader_.enabledPlaylists() <= 1 ||
       this.masterPlaylistLoader_.onLowestRendition()) {
-      this.mainSegmentLoader_.disableTimeout();
+      currentPlaylist.dontTimeout = true;
     }
 
     // Select a new playlist

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -513,6 +513,11 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // Blacklist this playlist
     currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
 
+    // if only 1 more available playlist, call dontTimeout
+    if (this.masterPlaylistLoader_.enabledPlaylists() <=1) {
+      this.mainSegmentLoader_.dontTimeout();
+    }
+
     // Select a new playlist
     nextPlaylist = this.selectPlaylist();
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -514,7 +514,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
 
     // if only 1 more available playlist, call dontTimeout
-    if (this.masterPlaylistLoader_.enabledPlaylists() <= 1) {
+    // ||
+    if (this.masterPlaylistLoader_.enabledPlaylists() <= 1 ||
+      this.masterPlaylistLoader_.onLowestRendition()) {
       this.mainSegmentLoader_.disableTimeout();
     }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -60,8 +60,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.mode_ = mode;
     this.audioTracks_ = [];
     this.xhrRequest = {
-      withCredentials: null,
-      requestTimeout: 1
+      withCredentials: this.withCredentials,
+      requestTimeout: null
     };
 
     this.mediaSource = new videojs.MediaSource({ mode });
@@ -94,6 +94,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
     this.masterPlaylistLoader_.on('loadedmetadata', () => {
       let media = this.masterPlaylistLoader_.media();
+      let requestTimeout = (this.masterPlaylistLoader_.targetDuration * 1.5) * 1000;
+
+      this.xhrRequest.requestTimeout = requestTimeout;
 
       // if this isn't a live video and preload permits, start
       // downloading segments

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -59,6 +59,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.hls_ = tech.hls;
     this.mode_ = mode;
     this.audioTracks_ = [];
+    this.xhrRequest = {
+      withCredentials: null,
+      requestTimeout: 1
+    };
 
     this.mediaSource = new videojs.MediaSource({ mode });
     this.mediaSource.on('audioinfo', (e) => this.trigger(e));
@@ -94,7 +98,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // if this isn't a live video and preload permits, start
       // downloading segments
       if (media.endList && this.tech_.preload() !== 'none') {
-        this.mainSegmentLoader_.playlist(media);
+        this.mainSegmentLoader_.playlist(media, this.xhrRequest);
         this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
         this.mainSegmentLoader_.load();
       }
@@ -122,7 +126,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // that the segments have changed in some way and use that to
       // update the SegmentLoader instead of doing it twice here and
       // on `mediachange`
-      this.mainSegmentLoader_.playlist(updatedPlaylist);
+      this.mainSegmentLoader_.playlist(updatedPlaylist, this.xhrRequest);
       this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
       this.updateDuration();
 
@@ -150,7 +154,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       // that the segments have changed in some way and use that to
       // update the SegmentLoader instead of doing it twice here and
       // on `loadedplaylist`
-      this.mainSegmentLoader_.playlist(media);
+      this.mainSegmentLoader_.playlist(media, this.xhrRequest);
       this.mainSegmentLoader_.expired(this.masterPlaylistLoader_.expired_);
       this.mainSegmentLoader_.load();
 
@@ -340,7 +344,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       let media = this.audioPlaylistLoader_.media();
       /* eslint-enable no-shadow */
 
-      this.audioSegmentLoader_.playlist(media);
+      this.audioSegmentLoader_.playlist(media, this.xhrRequest);
       this.addMimeType_(this.audioSegmentLoader_, 'mp4a.40.2', media);
 
       // if the video is already playing, or if this isn't a live video and preload
@@ -370,7 +374,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         return;
       }
 
-      this.audioSegmentLoader_.playlist(updatedPlaylist);
+      this.audioSegmentLoader_.playlist(updatedPlaylist, this.xhrRequest);
     });
 
     this.audioPlaylistLoader_.on('error', () => {
@@ -513,11 +517,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     // Blacklist this playlist
     currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
 
-    // if only 1 more available playlist, call dontTimeout
-    // ||
+    // if only 1 more available playlist
     if (this.masterPlaylistLoader_.enabledPlaylists() <= 1 ||
       this.masterPlaylistLoader_.onLowestRendition()) {
-      currentPlaylist.dontTimeout = true;
+      this.xhrRequest.requestTimeout = 0;
     }
 
     // Select a new playlist

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -514,7 +514,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     currentPlaylist.excludeUntil = Date.now() + BLACKLIST_DURATION;
 
     // if only 1 more available playlist, call dontTimeout
-    if (this.masterPlaylistLoader_.enabledPlaylists() <=1) {
+    if (this.masterPlaylistLoader_.enabledPlaylists() <= 1) {
       this.mainSegmentLoader_.dontTimeout();
     }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -515,7 +515,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
     // if only 1 more available playlist, call dontTimeout
     if (this.masterPlaylistLoader_.enabledPlaylists() <= 1) {
-      this.mainSegmentLoader_.dontTimeout();
+      this.mainSegmentLoader_.disableTimeout();
     }
 
     // Select a new playlist

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -155,6 +155,19 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     loader.trigger('error');
   };
 
+  // returns the number of enabled playlists on the master playlist object
+  enabledPlaylists = function() {
+    let playlists = loader.master.playlists;
+    let count = 0;
+    let i;
+    for (i = 0; i < playlists.length; i++) {
+      if (playlists[i].excludeUntil <= Date.now()) {
+        count += 1;
+      }
+    }
+    return count;
+  };
+
   // update the playlist loader's state in response to a new or
   // updated playlist.
   haveMetadata = function(xhr, url) {

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -235,6 +235,9 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
   };
 
   loader.onLowestRendition = function() {
+    if (!loader.media()) {
+      return false;
+    }
     return loader.master.playlists.filter((element, index, array) => {
       return element.attributes.BANDWIDTH <= loader.media().attributes.BANDWIDTH ? true : false;
     }).length > 1 ? false : true;

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -229,13 +229,13 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     // returns the number of enabled playlists on the master playlist object
   loader.enabledPlaylists = function() {
-    return loader.masters.playlists.filter((element, index, array) => {
-      return element.excludeUntil <= Date.now() ? true : false;
+    return loader.master.playlists.filter((element, index, array) => {
+      return element.excludeUntil <= Date.now() || !element.excludeUntil ? true : false;
     }).length;
   };
 
   loader.onLowestRendition = function() {
-    return loader.masters.playlists.filter((element, index, array) => {
+    return loader.master.playlists.filter((element, index, array) => {
       return element.attributes.BANDWIDTH <= loader.media().attributes.BANDWIDTH ? true : false;
     }).length > 1 ? false : true;
   };

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -234,6 +234,12 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     }).length;
   };
 
+  loader.onLowestRendition = function() {
+    return loader.masters.playlists.filter((element, index, array) => {
+      return element.attributes.BANDWIDTH <= loader.media().attributes.BANDWIDTH ? true : false;
+    }).length > 1 ? false : true;
+  };
+
    /**
     * When called without any arguments, returns the currently
     * active media playlist. When called with a single argument,

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -155,19 +155,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     loader.trigger('error');
   };
 
-  // returns the number of enabled playlists on the master playlist object
-  enabledPlaylists = function() {
-    let playlists = loader.master.playlists;
-    let count = 0;
-    let i;
-    for (i = 0; i < playlists.length; i++) {
-      if (playlists[i].excludeUntil <= Date.now()) {
-        count += 1;
-      }
-    }
-    return count;
-  };
-
   // update the playlist loader's state in response to a new or
   // updated playlist.
   haveMetadata = function(xhr, url) {
@@ -238,6 +225,20 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       oldRequest.onreadystatechange = null;
       oldRequest.abort();
     }
+  };
+
+    // returns the number of enabled playlists on the master playlist object
+  loader.enabledPlaylists = function() {
+    let playlists = loader.master.playlists;
+    let count = 0;
+    let i;
+
+    for (i = 0; i < playlists.length; i++) {
+      if (playlists[i].excludeUntil <= Date.now()) {
+        count += 1;
+      }
+    }
+    return count;
   };
 
    /**

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -239,7 +239,11 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       return false;
     }
     return loader.master.playlists.filter((element, index, array) => {
-      return element.attributes.BANDWIDTH <= loader.media().attributes.BANDWIDTH ? true : false;
+      let item = element.attributes.BANDWIDTH;
+      let currentPlaylist = loader.media().attributes.BANDWIDTH;
+
+      return item <= currentPlaylist ? true : false;
+
     }).length > 1 ? false : true;
   };
 

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -229,16 +229,9 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     // returns the number of enabled playlists on the master playlist object
   loader.enabledPlaylists = function() {
-    let playlists = loader.master.playlists;
-    let count = 0;
-    let i;
-
-    for (i = 0; i < playlists.length; i++) {
-      if (playlists[i].excludeUntil <= Date.now()) {
-        count += 1;
-      }
-    }
-    return count;
+    return loader.masters.playlists.filter((element, index, array) => {
+      return element.excludeUntil <= Date.now() ? true : false;
+    }).length;
   };
 
    /**

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -177,6 +177,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     // merge this playlist into the master
     update = updateMaster(loader.master, parser.manifest);
     refreshDelay = (parser.manifest.targetDuration || 10) * 1000;
+    loader.targetDuration = parser.manifest.targetDuration;
     if (update) {
       loader.master = update;
       loader.updateMediaPlaylist_(parser.manifest);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -535,29 +535,48 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (removeToTime > 0) {
       this.sourceUpdater_.remove(0, removeToTime);
     }
-
     segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
     // Set xhr timeout to 150% of the segment duration to allow us
     // some time to switch renditions in the event of a catastrophic
     // decrease in network performance or a server issue.
     requestTimeout = (segment.duration * 1.5) * 1000;
-
-    if (segment.key) {
-      keyXhr = this.hls_.xhr({
-        uri: segment.key.resolvedUri,
+    if (this.xhrRequest) {
+      // we have set our request object by calling playing
+      if (segment.key) {
+        keyXhr = this.hls_.xhr({
+          uri: segment.key.resolvedUri,
+          responseType: 'arraybuffer',
+          withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
+          timeout: requestTimeout * this.xhrRequest.requestTimeout
+        }, this.handleResponse_.bind(this));
+      }
+      this.pendingSegment_ = segmentInfo;
+      segmentXhr = this.hls_.xhr({
+        uri: segmentInfo.uri,
         responseType: 'arraybuffer',
         withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
-        timeout: requestTimeout * this.xhrRequest.requestTimeout;
+        timeout: requestTimeout * this.xhrRequest.requestTimeout,
+        headers: segmentXhrHeaders(segment)
+      }, this.handleResponse_.bind(this));
+    } else {
+      if (segment.key) {
+        keyXhr = this.hls_.xhr({
+          uri: segment.key.resolvedUri,
+          responseType: 'arraybuffer',
+          withCredentials: this.withCredentials_,
+          timeout: requestTimeout
+        }, this.handleResponse_.bind(this));
+      }
+      this.pendingSegment_ = segmentInfo;
+      segmentXhr = this.hls_.xhr({
+        uri: segmentInfo.uri,
+        responseType: 'arraybuffer',
+        withCredentials: this.withCredentials_,
+        timeout: requestTimeout,
+        headers: segmentXhrHeaders(segment)
       }, this.handleResponse_.bind(this));
     }
-    this.pendingSegment_ = segmentInfo;
-    segmentXhr = this.hls_.xhr({
-      uri: segmentInfo.uri,
-      responseType: 'arraybuffer',
-      withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
-      timeout: requestTimeout * this.xhrRequest.requestTimeout,
-      headers: segmentXhrHeaders(segment)
-    }, this.handleResponse_.bind(this));
+
 
     this.xhr_ = {
       keyXhr,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -542,7 +542,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     // decrease in network performance or a server issue.
 
     // don't timeout if we are on the last un-blacklisted playlist
-    segmentInfo.dontTimeout ? requestTimeout = 0 : requestTimeout = (segment.duration * 1.5) * 1000;
+    if (segmentInfo.dontTimeout) {
+      requestTimeout = 0;
+    } else {
+      requestTimeout = (segment.duration * 1.5) * 1000;
+    }
 
     if (segment.key) {
       keyXhr = this.hls_.xhr({

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -504,6 +504,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    *
    * @private
    */
+
+  dontTimeout() {
+    this.dontTimeout = true;
+  }
+
   loadSegment_(segmentInfo) {
     let segment;
     let requestTimeout;
@@ -538,6 +543,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     // some time to switch renditions in the event of a catastrophic
     // decrease in network performance or a server issue.
     requestTimeout = (segment.duration * 1.5) * 1000;
+
+    // don't timeout if we are on the last un-blacklisted playlist
+    if (dontTimeout) {
+      requestTimeout = 0;
+    }
 
     if (segment.key) {
       keyXhr = this.hls_.xhr({

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -425,9 +425,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       // The timeline that the segment is in
       timeline: segment.timeline,
       // The expected duration of the segment in seconds
-      duration: segment.duration,
-      // Dont timeout lowest rendition/last available playlist
-      dontTimeout: playlist.dontTimeout
+      duration: segment.duration
     };
   }
 
@@ -542,29 +540,22 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Set xhr timeout to 150% of the segment duration to allow us
     // some time to switch renditions in the event of a catastrophic
     // decrease in network performance or a server issue.
-
-    // don't timeout if we are on the last un-blacklisted playlist
-    if (segmentInfo.dontTimeout) {
-      requestTimeout = 0;
-    } else {
-      requestTimeout = (segment.duration * 1.5) * 1000;
-    }
+    requestTimeout = (segment.duration * 1.5) * 1000;
 
     if (segment.key) {
       keyXhr = this.hls_.xhr({
         uri: segment.key.resolvedUri,
         responseType: 'arraybuffer',
-        withCredentials: this.withCredentials_,
-        timeout: requestTimeout
+        withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
+        timeout: requestTimeout * this.xhrRequest.requestTimeout;
       }, this.handleResponse_.bind(this));
     }
     this.pendingSegment_ = segmentInfo;
-
     segmentXhr = this.hls_.xhr({
       uri: segmentInfo.uri,
       responseType: 'arraybuffer',
       withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
-      timeout: requestTimeout * this.requestTimeout,
+      timeout: requestTimeout * this.xhrRequest.requestTimeout,
       headers: segmentXhrHeaders(segment)
     }, this.handleResponse_.bind(this));
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -505,7 +505,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
 
-  dontTimeout() {
+  disableTimeout() {
     this.dontTimeout = true;
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -423,7 +423,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       // The timeline that the segment is in
       timeline: segment.timeline,
       // The expected duration of the segment in seconds
-      duration: segment.duration
+      duration: segment.duration,
+      // Dont timeout lowest rendition/last available playlist
+      dontTimeout: playlist.dontTimeout
     };
   }
 
@@ -505,10 +507,6 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
 
-  disableTimeout() {
-    this.dontTimeout = true;
-  }
-
   loadSegment_(segmentInfo) {
     let segment;
     let requestTimeout;
@@ -542,12 +540,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Set xhr timeout to 150% of the segment duration to allow us
     // some time to switch renditions in the event of a catastrophic
     // decrease in network performance or a server issue.
-    requestTimeout = (segment.duration * 1.5) * 1000;
 
     // don't timeout if we are on the last un-blacklisted playlist
-    if (this.dontTimeout) {
-      requestTimeout = 0;
-    }
+    segmentInfo.dontTimeout ? requestTimeout = 0 : requestTimeout = (segment.duration * 1.5) * 1000;
 
     if (segment.key) {
       keyXhr = this.hls_.xhr({

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -150,6 +150,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.pendingSegment_ = null;
     this.sourceUpdater_ = null;
     this.hls_ = settings.hls;
+    this.xhrRequest = null;
   }
 
   /**
@@ -238,10 +239,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    *
    * @param {PlaylistLoader} media the playlist to set on the segment loader
    */
-  playlist(media) {
+  playlist(media, options) {
     this.playlist_ = media;
     // if we were unpaused but waiting for a playlist, start
     // buffering now
+    this.xhrRequest = options;
     if (this.sourceUpdater_ &&
         media &&
         this.state === 'INIT' &&
@@ -557,11 +559,12 @@ export default class SegmentLoader extends videojs.EventTarget {
       }, this.handleResponse_.bind(this));
     }
     this.pendingSegment_ = segmentInfo;
+
     segmentXhr = this.hls_.xhr({
       uri: segmentInfo.uri,
       responseType: 'arraybuffer',
-      withCredentials: this.withCredentials_,
-      timeout: requestTimeout,
+      withCredentials: this.xhrRequest.withCredentials || this.withCredentials_,
+      timeout: requestTimeout * this.requestTimeout,
       headers: segmentXhrHeaders(segment)
     }, this.handleResponse_.bind(this));
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -545,7 +545,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     requestTimeout = (segment.duration * 1.5) * 1000;
 
     // don't timeout if we are on the last un-blacklisted playlist
-    if (dontTimeout) {
+    if (this.dontTimeout) {
       requestTimeout = 0;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -577,7 +577,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       }, this.handleResponse_.bind(this));
     }
 
-
     this.xhr_ = {
       keyXhr,
       segmentXhr,

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -138,6 +138,30 @@ QUnit.test('playlist loader returns the correct amount of enabled playlists', fu
   QUnit.equal(loader.enabledPlaylists(), 1, 'Returned one less playlist after simulated blacklisting');
 });
 
+QUnit.test('playlist loader detects if we are on lowest rendition', function() {
+  let loader = new PlaylistLoader('master.m3u8', this.fakeHls);
+
+  loader.load();
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:\n' +
+                                'video1/media.m3u8\n' +
+                                '#EXT-X-STREAM-INF:\n' +
+                                'video2/media.m3u8\n');
+  loader.media = function() {
+    return {attributes: {BANDWIDTH: 10}};
+  }
+
+  loader.master.playlists = [{attributes: {BANDWIDTH: 10}}, {attributes: {BANDWIDTH: 20}}]
+  QUnit.ok(loader.onLowestRendition(),  'Detected on lowest rendition');
+
+  loader.media = function() {
+    return {attributes: {BANDWIDTH: 20}};
+  }
+
+  QUnit.ok(!loader.onLowestRendition(),  'Detected not on lowest rendition');
+});
+
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
   let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -135,7 +135,7 @@ QUnit.test('playlist loader returns the correct amount of enabled playlists', fu
   QUnit.equal(loader.enabledPlaylists(), 2, 'Returned initial amount of playlists');
   loader.master.playlists[0].excludeUntil = Date.now() + 100000;
   this.clock.tick(1000);
-  QUnit.equal(loader.enabledPlaylists(), 1, 'Returned one less playlist after simulated blacklisting');
+  QUnit.equal(loader.enabledPlaylists(), 1, 'Returned one less playlist');
 });
 
 QUnit.test('playlist loader detects if we are on lowest rendition', function() {
@@ -150,16 +150,17 @@ QUnit.test('playlist loader detects if we are on lowest rendition', function() {
                                 'video2/media.m3u8\n');
   loader.media = function() {
     return {attributes: {BANDWIDTH: 10}};
-  }
+  };
 
-  loader.master.playlists = [{attributes: {BANDWIDTH: 10}}, {attributes: {BANDWIDTH: 20}}]
-  QUnit.ok(loader.onLowestRendition(),  'Detected on lowest rendition');
+  loader.master.playlists = [{attributes: {BANDWIDTH: 10}},
+                              {attributes: {BANDWIDTH: 20}}];
+  QUnit.ok(loader.onLowestRendition(), 'Detected on lowest rendition');
 
   loader.media = function() {
     return {attributes: {BANDWIDTH: 20}};
-  }
+  };
 
-  QUnit.ok(!loader.onLowestRendition(),  'Detected not on lowest rendition');
+  QUnit.ok(!loader.onLowestRendition(), 'Detected not on lowest rendition');
 });
 
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -121,6 +121,23 @@ QUnit.test('resolves relative media playlist URIs', function() {
               'resolved media URI');
 });
 
+QUnit.test('playlist loader returns the correct amount of enabled playlists', function() {
+  let loader = new PlaylistLoader('master.m3u8', this.fakeHls);
+
+  loader.load();
+
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:\n' +
+                                'video1/media.m3u8\n' +
+                                '#EXT-X-STREAM-INF:\n' +
+                                'video2/media.m3u8\n');
+  QUnit.equal(loader.enabledPlaylists(), 2, 'Returned initial amount of playlists');
+  loader.master.playlists[0].excludeUntil = Date.now() + 100000;
+  this.clock.tick(1000);
+  QUnit.equal(loader.enabledPlaylists(), 1, 'Returned one less playlist after simulated blacklisting');
+});
+
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
   let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
 


### PR DESCRIPTION
This feature will set the timeout property on a segment request to zero if we are currently requesting from the only non-blacklisted playlist. This will help us avoid entering an infinitely stalled state.  
