### PR TITLE
WIP: Media init segment support

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   ],
   "dependencies": {
     "m3u8-parser": "^1.0.2",
-    "mux.js": "^2.3.1",
+    "mux.js": "^2.4.0",
     "pkcs7": "^0.2.2",
     "video.js": "^5.10.1",
     "videojs-contrib-media-sources": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   ],
   "dependencies": {
     "m3u8-parser": "^1.0.2",
+    "mux.js": "^2.3.1",
     "pkcs7": "^0.2.2",
     "video.js": "^5.10.1",
     "videojs-contrib-media-sources": "^3.1.0",

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -80,7 +80,8 @@ const parseCodecs = function(codecs) {
 const mimeTypesForPlaylist = function(master, media) {
   let container = 'mp2t';
   let codecs = {
-    videoCodec: 'avc1.4d400d',
+    videoCodec: 'avc1',
+    videoObjectTypeIndicator: '.4d400d',
     audioProfile: '2'
   };
   let audioGroup = [];

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -471,6 +471,12 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       // loaded a media playlist
       // infer a master playlist if none was previously requested
       loader.master = {
+        mediaGroups: {
+          'AUDIO': {},
+          'VIDEO': {},
+          'CLOSED-CAPTIONS': {},
+          'SUBTITLES': {}
+        },
         uri: window.location.href,
         playlists: [{
           uri: srcUrl

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -96,6 +96,9 @@ const updateMaster = function(master, media) {
         if (segment.key && !segment.key.resolvedUri) {
           segment.key.resolvedUri = resolveUrl(playlist.resolvedUri, segment.key.uri);
         }
+        if (segment.map && !segment.map.resolvedUri) {
+          segment.map.resolvedUri = resolveUrl(playlist.resolvedUri, segment.map.uri);
+        }
       }
       changed = true;
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -804,7 +804,7 @@ export default class SegmentLoader extends videojs.EventTarget {
         let initSegment = this.initSegments_[initId];
 
         this.sourceUpdater_.appendBuffer(initSegment.bytes, () => {
-          this.activeInitSegmentid_ = initId;
+          this.activeInitSegmentId_ = initId;
         });
       }
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -104,6 +104,21 @@ const segmentXhrHeaders = function(segment) {
 };
 
 /**
+ * Returns a unique string identifier for a media initialization
+ * segment.
+ */
+const initSegmentId = function(initSegment) {
+  let byterange = initSegment.byterange || {
+    length: Infinity,
+    offset: 0
+  };
+
+  return [
+    byterange.length, byterange.offset, initSegment.resolvedUri
+  ].join(',');
+};
+
+/**
  * An object that manages segment loading and appending.
  *
  * @class SegmentLoader
@@ -133,7 +148,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.roundTrip = NaN;
     this.resetStats_();
 
-    // private properties
+    // private settings
     this.hasPlayed_ = settings.hasPlayed;
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
@@ -141,6 +156,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.setCurrentTime_ = settings.setCurrentTime;
     this.mediaSource_ = settings.mediaSource;
     this.withCredentials_ = settings.withCredentials;
+
+    this.hls_ = settings.hls;
+
+    // private instance variables
     this.checkBufferTimeout_ = null;
     this.error_ = void 0;
     this.expired_ = 0;
@@ -149,7 +168,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.xhr_ = null;
     this.pendingSegment_ = null;
     this.sourceUpdater_ = null;
-    this.hls_ = settings.hls;
+
+    this.activeInitSegmentId_ = null;
+    this.initSegments_ = {};
   }
 
   /**
@@ -307,7 +328,8 @@ export default class SegmentLoader extends videojs.EventTarget {
   }
 
   /**
-   * asynchronously/recursively monitor the buffer
+   * As long as the SegmentLoader is in the READY state, periodically
+   * invoke fillBuffer_().
    *
    * @private
    */
@@ -453,24 +475,24 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     // see if we need to begin loading immediately
-    let request = this.checkBuffer_(this.sourceUpdater_.buffered(),
-                                    this.playlist_,
-                                    this.currentTime_(),
-                                    this.timestampOffset_);
+    let segmentInfo = this.checkBuffer_(this.sourceUpdater_.buffered(),
+                                        this.playlist_,
+                                        this.currentTime_(),
+                                        this.timestampOffset_);
 
-    if (!request) {
+    if (!segmentInfo) {
       return;
     }
 
-    if (request.mediaIndex === this.playlist_.segments.length - 1 &&
+    if (segmentInfo.mediaIndex === this.playlist_.segments.length - 1 &&
         this.mediaSource_.readyState === 'ended' &&
         !this.seeking_()) {
       return;
     }
 
-    let segment = this.playlist_.segments[request.mediaIndex];
+    let segment = this.playlist_.segments[segmentInfo.mediaIndex];
     let startOfSegment = duration(this.playlist_,
-                                  this.playlist_.mediaSequence + request.mediaIndex,
+                                  this.playlist_.mediaSequence + segmentInfo.mediaIndex,
                                   this.expired_);
 
     // Sanity check the segment-index determining logic by calcuating the
@@ -496,7 +518,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    this.loadSegment_(request);
+    this.loadSegment_(segmentInfo);
   }
 
   /**
@@ -508,6 +530,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     let segment;
     let requestTimeout;
     let keyXhr;
+    let initSegmentXhr;
     let segmentXhr;
     let seekable = this.seekable_();
     let currentTime = this.currentTime_();
@@ -539,11 +562,23 @@ export default class SegmentLoader extends videojs.EventTarget {
     // decrease in network performance or a server issue.
     requestTimeout = (segment.duration * 1.5) * 1000;
 
+    // optionally, request the decryption key
     if (segment.key) {
       keyXhr = this.hls_.xhr({
         uri: segment.key.resolvedUri,
         responseType: 'arraybuffer',
         withCredentials: this.withCredentials_,
+        timeout: requestTimeout
+      }, this.handleResponse_.bind(this));
+    }
+    // optionally, request the associated media init segment
+    if (segment.map &&
+        !this.initSegments_[initSegmentId(segment.map)]) {
+      initSegmentXhr = this.hls_.xhr({
+        uri: segment.map.resolvedUri,
+        responseType: 'arraybuffer',
+        withCredentials_: this.withCredentials_,
+        headers: segmentXhrHeaders(segment.map),
         timeout: requestTimeout
       }, this.handleResponse_.bind(this));
     }
@@ -558,6 +593,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.xhr_ = {
       keyXhr,
+      initSegmentXhr,
       segmentXhr,
       abort() {
         if (this.segmentXhr) {
@@ -591,7 +627,9 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // timeout of previously aborted request
     if (!this.xhr_ ||
-        (request !== this.xhr_.segmentXhr && request !== this.xhr_.keyXhr)) {
+        (request !== this.xhr_.segmentXhr &&
+         request !== this.xhr_.keyXhr &&
+         request !== this.xhr_.initSegmentXhr)) {
       return;
     }
 
@@ -682,7 +720,14 @@ export default class SegmentLoader extends videojs.EventTarget {
       ]);
     }
 
-    if (!this.xhr_.segmentXhr && !this.xhr_.keyXhr) {
+    if (request === this.xhr_.initSegmentXhr) {
+      // the init segment request is no longer outstanding
+      this.xhr_.initSegmentXhr = null;
+      segment.map.bytes = new Uint8Array(request.response);
+      this.initSegments_[initSegmentId(segment.map)] = segment.map;
+    }
+
+    if (!this.xhr_.segmentXhr && !this.xhr_.keyXhr && !this.initSegmentXhr) {
       this.xhr_ = null;
       this.processResponse_();
     }
@@ -737,14 +782,31 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   handleSegment_() {
     let segmentInfo;
+    let segment;
 
     this.state = 'APPENDING';
     segmentInfo = this.pendingSegment_;
     segmentInfo.buffered = this.sourceUpdater_.buffered();
+    segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
     this.currentTimeline_ = segmentInfo.timeline;
 
     if (segmentInfo.timestampOffset !== this.sourceUpdater_.timestampOffset()) {
       this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);
+    }
+
+    // if the media initialization segment is changing, append it
+    // before the content segment
+    if (segment.map) {
+      let initId = initSegmentId(segment.map);
+
+      if (!this.activeInitSegmentId_ ||
+          this.activeInitSegmentId_ !== initId) {
+        let initSegment = this.initSegments_[initId];
+
+        this.sourceUpdater_.appendBuffer(initSegment.bytes, () => {
+          this.activeInitSegmentid_ = initId;
+        });
+      }
     }
 
     this.sourceUpdater_.appendBuffer(segmentInfo.bytes,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -757,6 +757,13 @@ export default class SegmentLoader extends videojs.EventTarget {
     segmentInfo = this.pendingSegment_;
     segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
+    // some videos don't start from presentation time zero
+    //if that is the case, use timestamp offset to adjust them so that
+    //it is not necessary to seek before playback can begin
+    if (true) {
+      console.log('implement me');
+    }
+
     if (segment.key) {
       // this is an encrypted segment
       // incrementally decrypt the segment

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -334,7 +334,7 @@ class HlsHandler extends Component {
     });
 
     this.audioTrackChange_ = () => {
-      this.masterPlaylistController_.useAudio();
+      this.masterPlaylistController_.setupAudio();
     };
 
     this.on(this.tech_, 'play', this.play);
@@ -468,13 +468,14 @@ class HlsHandler extends Component {
       }
 
       videojs.log.warn(error);
-      this.masterPlaylistController_.useAudio();
+      this.masterPlaylistController_.setupAudio();
     });
+
     this.masterPlaylistController_.on('selectedinitialmedia', () => {
       // clear current audioTracks
       this.tech_.clearTracks('audio');
-      this.masterPlaylistController_.audioTracks_.forEach((track) => {
-        this.tech_.audioTracks().addTrack(track);
+      this.masterPlaylistController_.activeAudioGroup().forEach((audioTrack) => {
+        this.tech_.audioTracks().addTrack(audioTrack);
       });
 
       // Add the manual rendition mix-in to HlsHandler

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -7,6 +7,7 @@ import {
   standardXHRResponse,
   openMediaSource
 } from './test-helpers.js';
+import manifests from './test-manifests.js';
 import MasterPlaylistController from '../src/master-playlist-controller';
 /* eslint-disable no-unused-vars */
 // we need this so that it can register hls with videojs
@@ -272,6 +273,32 @@ function() {
               '16 bytes downloaded');
 });
 
+QUnit.test('updates the enabled track when switching audio groups', function() {
+  openMediaSource(this.player, this.clock);
+  // master
+  this.requests.shift().respond(200, null,
+                                manifests.multipleAudioGroupsCombinedMain);
+  // media
+  standardXHRResponse(this.requests.shift());
+  // audio media
+  standardXHRResponse(this.requests.shift());
+
+  let mpc = this.masterPlaylistController;
+  let combinedPlaylist = mpc.master().playlists[0];
+
+  mpc.masterPlaylistLoader_.media(combinedPlaylist);
+  // updated media
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXTINF:5.0\n' +
+                                '0.ts\n' +
+                                '#EXT-X-ENDLIST\n');
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.ok(mpc.activeAudioGroup().find((track) => track.enabled),
+           'enabled a track in the new audio group');
+});
+
 QUnit.test('blacklists switching from video+audio playlists to audio only', function() {
   let audioPlaylist;
 
@@ -384,6 +411,34 @@ function() {
   QUnit.equal(alternatePlaylist.excludeUntil, Infinity, 'excluded incompatible playlist');
   // verify stats
   QUnit.equal(this.player.tech_.hls.stats.bandwidth, 1, 'bandwidth we set above');
+});
+
+QUnit.test('blacklists the current playlist when audio changes in Firefox', function() {
+  videojs.browser.IS_FIREFOX = true;
+
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  let media = this.masterPlaylistController.media();
+
+  // initial audio config
+  this.masterPlaylistController.mediaSource.trigger({
+    type: 'audioinfo',
+    info: {}
+  });
+  // updated audio config
+
+  this.masterPlaylistController.mediaSource.trigger({
+    type: 'audioinfo',
+    info: {
+      different: true
+    }
+  });
+  QUnit.ok(media.excludeUntil > 0, 'blacklisted the old playlist');
+  QUnit.equal(this.env.log.warn.callCount, 2, 'logged two warnings');
+  this.env.log.warn.callCount = 0;
 });
 
 QUnit.test('updates the combined segment loader on media changes', function() {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -121,6 +121,21 @@ QUnit.test('resolves relative media playlist URIs', function() {
               'resolved media URI');
 });
 
+QUnit.test('resolves media initialization segment URIs', function() {
+  let loader = new PlaylistLoader('video/fmp4.m3u8', this.fakeHls);
+
+  loader.load();
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-MAP:URI="main.mp4",BYTERANGE="720@0"\n' +
+                                '#EXTINF:10,\n' +
+                                '0.ts\n' +
+                                '#EXT-X-ENDLIST\n');
+
+  QUnit.equal(loader.media().segments[0].map.resolvedUri, urlTo('video/main.mp4'),
+              'resolved init segment URI');
+});
+
 QUnit.test('recognizes absolute URIs and requests them unmodified', function() {
   let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -319,6 +319,21 @@ QUnit.test('moves to HAVE_METADATA after loading a media playlist', function() {
   QUnit.strictEqual(loader.state, 'HAVE_METADATA', 'the state is correct');
 });
 
+QUnit.test('defaults missing media groups for a media playlist', function() {
+  let loader = new PlaylistLoader('master.m3u8', this.fakeHls);
+
+  loader.load();
+  this.requests.pop().respond(200, null,
+                              '#EXTM3U\n' +
+                              '#EXTINF:10,\n' +
+                              '0.ts\n');
+
+  QUnit.ok(loader.master.mediaGroups.AUDIO, 'defaulted audio');
+  QUnit.ok(loader.master.mediaGroups.VIDEO, 'defaulted video');
+  QUnit.ok(loader.master.mediaGroups['CLOSED-CAPTIONS'], 'defaulted closed captions');
+  QUnit.ok(loader.master.mediaGroups.SUBTITLES, 'defaulted subtitles');
+});
+
 QUnit.test('moves to HAVE_CURRENT_METADATA when refreshing the playlist', function() {
   let loader = new PlaylistLoader('live.m3u8', this.fakeHls);
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -236,6 +236,18 @@ QUnit.test('segment request timeouts reset bandwidth', function() {
   QUnit.ok(isNaN(loader.roundTrip), 'reset round trip time');
 });
 
+QUnit.test('updates timestamps when segments do not start at zero', function() {
+  loader.playlist(playlistWithDuration(10));
+  loader.mimeType('video/mp4');
+  loader.load();
+
+  this.clock.tick(100);
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200,null, '');
+
+  QUnit.equal(loader.sourceUpdater_.timestampOffset, 10, 'set timestampOffset');
+});
+
 QUnit.test('appending a segment triggers progress', function() {
   let progresses = 0;
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -116,7 +116,13 @@ let fakeEnvironment = {
     this.xhr.restore();
     ['warn', 'error'].forEach((level) => {
       if (this.log && this.log[level] && this.log[level].restore) {
-        QUnit.equal(this.log[level].callCount, 0, `no unexpected logs on ${level}`);
+        let calls = this.log[level].args.map((args) => {
+          return args.join(', ');
+        }).join('\n  ');
+
+        QUnit.equal(this.log[level].callCount,
+                    0,
+                    'no unexpected logs at level "' + level + '":\n  ' + calls);
         this.log[level].restore();
       }
     });

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -89,6 +89,9 @@ QUnit.module('HLS', {
     this.old.Decrypt = videojs.Hls.Decrypter;
     videojs.Hls.Decrypter = function() {};
 
+    // save and restore browser detection for the Firefox-specific tests
+    this.old.IS_FIREFOX = videojs.browser.IS_FIREFOX;
+
     // setup a player
     this.player = createPlayer();
   },
@@ -103,6 +106,7 @@ QUnit.module('HLS', {
 
     videojs.Hls.supportsNativeHls = this.old.NativeHlsSupport;
     videojs.Hls.Decrypter = this.old.Decrypt;
+    videojs.browser.IS_FIREFOX = this.old.IS_FIREFOX;
 
     this.player.dispose();
   }
@@ -257,11 +261,11 @@ QUnit.test('codecs are passed to the source buffer', function() {
 
   this.requests.shift().respond(200, null,
                                 '#EXTM3U\n' +
-                                '#EXT-X-STREAM-INF:CODECS="video, audio"\n' +
+                                '#EXT-X-STREAM-INF:CODECS="avc1.dd00dd, mp4a.40.f"\n' +
                                 'media.m3u8\n');
   standardXHRResponse(this.requests.shift());
   QUnit.equal(codecs.length, 1, 'created a source buffer');
-  QUnit.equal(codecs[0], 'video/mp2t; codecs="video, audio"', 'specified the codecs');
+  QUnit.equal(codecs[0], 'video/mp2t; codecs="avc1.dd00dd, mp4a.40.f"', 'specified the codecs');
 });
 
 QUnit.test('including HLS as a tech does not error', function() {
@@ -1431,6 +1435,7 @@ QUnit.test('re-emits mediachange events', function() {
     type: 'application/vnd.apple.mpegurl'
   });
   openMediaSource(this.player, this.clock);
+  standardXHRResponse(this.requests.shift());
 
   this.player.tech_.hls.playlists.trigger('mediachange');
   QUnit.strictEqual(mediaChanges, 1, 'fired mediachange');
@@ -1690,7 +1695,7 @@ QUnit.test('resolves relative key URLs against the playlist', function() {
               'resolves the key URL');
 });
 
-QUnit.test('adds 1 default audio track if we have not parsed any, and the playlist is loaded', function() {
+QUnit.test('adds 1 default audio track if we have not parsed any and the playlist is loaded', function() {
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'
@@ -1702,12 +1707,11 @@ QUnit.test('adds 1 default audio track if we have not parsed any, and the playli
 
   // master
   standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
 
   QUnit.equal(this.player.audioTracks().length, 1, 'one audio track after load');
-  QUnit.ok(this.player.audioTracks()[0] instanceof HlsAudioTrack, 'audio track is an hls audio track');
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
+  QUnit.equal(this.player.audioTracks()[0].label, 'default', 'set the label');
 });
 
 QUnit.test('adds 1 default audio track if in flash mode', function() {
@@ -1731,9 +1735,11 @@ QUnit.test('adds 1 default audio track if in flash mode', function() {
 
   // master
   standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
 
   QUnit.equal(this.player.audioTracks().length, 1, 'one audio track after load');
-  QUnit.ok(this.player.audioTracks()[0] instanceof HlsAudioTrack, 'audio track is an hls audio track');
+  QUnit.equal(this.player.audioTracks()[0].label, 'default', 'set the label');
 
   videojs.options.hls = hlsOptions;
 });
@@ -1750,64 +1756,22 @@ QUnit.test('adds audio tracks if we have parsed some from a playlist', function(
 
   // master
   standardXHRResponse(this.requests.shift());
-  let hls = this.player.tech_.hls;
-  let hlsAudioTracks = hls.masterPlaylistController_.audioTracks_;
+  // media
+  standardXHRResponse(this.requests.shift());
   let vjsAudioTracks = this.player.audioTracks();
 
-  QUnit.equal(hlsAudioTracks.length, 3, '3 active hls tracks');
   QUnit.equal(vjsAudioTracks.length, 3, '3 active vjs tracks');
 
   QUnit.equal(vjsAudioTracks[0].enabled, true, 'default track is enabled');
-  QUnit.equal(hlsAudioTracks[0].enabled, true, 'default track is enabled');
 
   vjsAudioTracks[1].enabled = true;
-  QUnit.equal(hlsAudioTracks[1].enabled, true, 'new track is enabled on hls');
   QUnit.equal(vjsAudioTracks[1].enabled, true, 'new track is enabled on vjs');
-
   QUnit.equal(vjsAudioTracks[0].enabled, false, 'main track is disabled');
-  QUnit.equal(hlsAudioTracks[0].enabled, false, 'main track is disabled');
-
-  hlsAudioTracks[2].enabled = true;
-  QUnit.equal(hlsAudioTracks[2].enabled, true, 'new track is enabled on hls');
-  QUnit.equal(vjsAudioTracks[2].enabled, true, 'new track is enabled on vjs');
-
-  QUnit.equal(vjsAudioTracks[1].enabled, false, 'main track is disabled');
-  QUnit.equal(hlsAudioTracks[1].enabled, false, 'main track is disabled');
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
 });
 
-QUnit.test('audio info from audioinfo event is stored on hls', function() {
-  // force non-firefox as firefox has specific behavior
-  let oldIsFirefox = videojs.browser.IS_FIREFOX;
-
-  videojs.browser.IS_FIREFOX = false;
-
-  this.player.src({
-    src: 'manifest/multipleAudioGroups.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-
-  let hls = this.player.tech_.hls;
-  let mpc = hls.masterPlaylistController_;
-  let info = {foo: 'bar'};
-
-  QUnit.ok(!hls.audioInfo_, 'hls has no audioInfo_');
-
-  mpc.trigger({type: 'audioinfo', info});
-  QUnit.equal(hls.audioInfo_, info, 'hls has the info from the event');
-
-  info = {bar: 'foo'};
-  mpc.trigger({type: 'audioinfo', info});
-  QUnit.equal(hls.audioInfo_, info, 'hls has the new info from the event');
-
-  videojs.browser.IS_FIREFOX = oldIsFirefox;
-});
-
-QUnit.test('audioinfo changes with three tracks, enabled track is blacklisted and removed', function() {
-  let oldIsFirefox = videojs.browser.IS_FIREFOX;
-  let at = this.player.audioTracks();
+QUnit.test('when audioinfo changes on an independent audio track in Firefox, the enabled track is blacklisted and removed', function() {
+  let audioTracks = this.player.audioTracks();
+  let oldLabel;
 
   videojs.browser.IS_FIREFOX = true;
   this.player.src({
@@ -1817,54 +1781,34 @@ QUnit.test('audioinfo changes with three tracks, enabled track is blacklisted an
   let hls = this.player.tech_.hls;
   let mpc = hls.masterPlaylistController_;
 
-  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
-  QUnit.ok(!hls.audioInfo_, 'no audio info on hls');
   openMediaSource(this.player, this.clock);
-  standardXHRResponse(this.requests.shift());
-  standardXHRResponse(this.requests.shift());
-  QUnit.equal(at.length, 3, 'three audio track after load');
-  QUnit.ok(!hls.audioInfo_, 'no audio info on hls');
 
-  let defaultTrack;
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+  QUnit.equal(audioTracks.length, 3, 'three audio track after load');
 
-  mpc.audioTracks_.forEach((t) => {
-    if (!defaultTrack && t.default) {
-      defaultTrack = t;
-    }
+  let defaultTrack = mpc.activeAudioGroup().find((track) => {
+    return track.properties_.default;
   });
 
-  let blacklistPlaylistCalls = 0;
-  let info = {foo: 'bar'};
-
-  // noop as there is no real playlist
-  mpc.useAudio = () => {};
-
   // initial audio info
-  mpc.trigger({type: 'audioinfo', info});
-  QUnit.equal(hls.audioInfo_, info, 'hls has the info from the event');
+  hls.mediaSource.trigger({ type: 'audioinfo', info: { foo: 'bar' }});
+  oldLabel = audioTracks[1].label;
 
   // simulate audio info change and mock things
-  let oldLabel = at[1].label;
+  audioTracks[1].enabled = true;
+  hls.mediaSource.trigger({ type: 'audioinfo', info: { bar: 'foo' }});
 
-  at[1].enabled = true;
-  mpc.blacklistCurrentPlaylist = () => blacklistPlaylistCalls++;
-  mpc.trigger({type: 'audioinfo', info: {bar: 'foo'}});
-
-  QUnit.equal(hls.audioInfo_, info, 'hls did not store the changed audio info');
-  QUnit.equal(at.length, 2, 'two audio tracks after bad audioinfo change');
-  QUnit.notEqual(at[1].label, oldLabel, 'audio track at index 1 is not the same');
+  QUnit.equal(audioTracks.length, 2, 'two audio tracks after bad audioinfo change');
+  QUnit.notEqual(audioTracks[1].label, oldLabel, 'audio track at index 1 is not the same');
   QUnit.equal(defaultTrack.enabled, true, 'default track is enabled again');
-  QUnit.equal(blacklistPlaylistCalls, 0, 'blacklist was not called on playlist');
   QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
-  videojs.browser.IS_FIREFOX = oldIsFirefox;
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
 });
 
 QUnit.test('audioinfo changes with one track, blacklist playlist', function() {
-  let oldIsFirefox = videojs.browser.IS_FIREFOX;
-  let at = this.player.audioTracks();
+  let audioTracks = this.player.audioTracks();
 
   videojs.browser.IS_FIREFOX = true;
   this.player.src({
@@ -1872,35 +1816,28 @@ QUnit.test('audioinfo changes with one track, blacklist playlist', function() {
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
+  QUnit.equal(audioTracks.length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
   standardXHRResponse(this.requests.shift());
   standardXHRResponse(this.requests.shift());
-  QUnit.equal(at.length, 1, 'one audio track after load');
+  QUnit.equal(audioTracks.length, 1, 'one audio track after load');
 
   let mpc = this.player.tech_.hls.masterPlaylistController_;
-  let blacklistPlaylistCalls = 0;
+  let oldMedia = mpc.media();
 
-  mpc.blacklistCurrentPlaylist = () => blacklistPlaylistCalls++;
-  // noop as there is no real playlist
-  mpc.useAudio = () => {};
-  mpc.trigger({type: 'audioinfo', info: {foo: 'bar'}});
+  // initial audio info
+  mpc.mediaSource.trigger({type: 'audioinfo', info: { foo: 'bar' }});
 
   // simulate audio info change in main track
-  mpc.trigger({type: 'audioinfo', info: {bar: 'foo'}});
+  mpc.mediaSource.trigger({type: 'audioinfo', info: { bar: 'foo' }});
 
-  QUnit.equal(at.length, 1, 'still have one audio track');
-  QUnit.equal(blacklistPlaylistCalls, 1, 'blacklist was called on playlist');
-  QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
-  videojs.browser.IS_FIREFOX = oldIsFirefox;
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
+  QUnit.equal(audioTracks.length, 1, 'still have one audio track');
+  QUnit.ok(oldMedia.excludeUntil > 0, 'blacklisted old playlist');
+  QUnit.equal(this.env.log.warn.calls, 2, 'firefox issue warning logged');
 });
 
-QUnit.test('audioinfo changes with three tracks, default is enabled, blacklisted playlist', function() {
-  let oldIsFirefox = videojs.browser.IS_FIREFOX;
-  let at = this.player.audioTracks();
+QUnit.test('changing audioinfo for muxed audio blacklists the current playlist in Firefox', function() {
+  let audioTracks = this.player.audioTracks();
 
   videojs.browser.IS_FIREFOX = true;
   this.player.src({
@@ -1908,45 +1845,48 @@ QUnit.test('audioinfo changes with three tracks, default is enabled, blacklisted
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.equal(at.length, 0, 'zero audio tracks at load time');
+  QUnit.equal(audioTracks.length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
-  standardXHRResponse(this.requests.shift());
-  standardXHRResponse(this.requests.shift());
-  QUnit.equal(at.length, 3, 'three audio track after load');
-
   let hls = this.player.tech_.hls;
   let mpc = hls.masterPlaylistController_;
 
+  // master
+  standardXHRResponse(this.requests.shift());
+  // video media
+  standardXHRResponse(this.requests.shift());
+  // video segments
+  standardXHRResponse(this.requests.shift());
+  standardXHRResponse(this.requests.shift());
+  // audio media
+  standardXHRResponse(this.requests.shift());
+  // ignore audio requests
+  this.requests.length = 0;
+  QUnit.equal(audioTracks.length, 3, 'three audio track after load');
+
   // force audio group with combined audio to enabled
-  mpc.activeAudioGroup = () => 'audio-lo';
-  let defaultTrack;
+  mpc.masterPlaylistLoader_.media(mpc.master().playlists[0]);
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXTINF:10,\n' +
+                                '0.ts\n' +
+                                '#EXT-X-ENDLIST\n');
 
-  mpc.audioTracks_.forEach((t) => {
-    if (!defaultTrack && t.default) {
-      defaultTrack = t;
-    }
+  let defaultTrack = mpc.activeAudioGroup().find((track) => {
+    return track.properties_.default;
   });
-
-  let blacklistPlaylistCalls = 0;
-
-  // noop as there is no real playlist
-  mpc.useAudio = () => {};
+  let oldPlaylist = mpc.media();
 
   // initial audio info
-  mpc.trigger({type: 'audioinfo', info: {foo: 'bar'}});
+  mpc.mediaSource.trigger({type: 'audioinfo', info: { foo: 'bar' }});
 
-  // simulate audio info change and mock things
-  mpc.blacklistCurrentPlaylist = () => blacklistPlaylistCalls++;
-  mpc.trigger({type: 'audioinfo', info: {bar: 'foo'}});
+  // simulate audio info change
+  mpc.mediaSource.trigger({type: 'audioinfo', info: { bar: 'foo' }});
 
-  QUnit.equal(at.length, 3, 'three audio tracks after bad audioinfo change');
+  audioTracks = this.player.audioTracks();
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after bad audioinfo change');
   QUnit.equal(defaultTrack.enabled, true, 'default audio still enabled');
-  QUnit.equal(blacklistPlaylistCalls, 1, 'blacklist was called on playlist');
-  QUnit.equal(this.env.log.warn.calls, 1, 'firefox issue warning logged');
-  videojs.browser.IS_FIREFOX = oldIsFirefox;
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
+  QUnit.ok(oldPlaylist.excludeUntil > 0, 'blacklisted the old playlist');
+  QUnit.equal(this.env.log.warn.calls, 2, 'firefox issue warning logged');
 });
 
 QUnit.test('cleans up the buffer when loading live segments', function() {
@@ -2100,75 +2040,57 @@ QUnit.test('when mediaGroup changes enabled track should not change', function()
     src: 'manifest/multipleAudioGroups.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
-
-  QUnit.equal(this.player.audioTracks().length, 0, 'zero audio tracks at load time');
   openMediaSource(this.player, this.clock);
 
   // master
   standardXHRResponse(this.requests.shift());
+  // video media
   standardXHRResponse(this.requests.shift());
   let hls = this.player.tech_.hls;
+  let mpc = hls.masterPlaylistController_;
   let audioTracks = this.player.audioTracks();
 
   QUnit.equal(audioTracks.length, 3, 'three audio tracks after load');
-  let trackOne = audioTracks[0];
-  let trackTwo = audioTracks[1];
-  let trackThree = audioTracks[2];
-
-  QUnit.equal(trackOne.enabled, true, 'track one enabled after load');
+  QUnit.equal(audioTracks[0].enabled, true, 'track one enabled after load');
 
   let oldMediaGroup = hls.playlists.media().attributes.AUDIO;
 
+  // clear out any outstanding requests
+  this.requests.length = 0;
   // force mpc to select a playlist from a new media group
-  hls.selectPlaylist = () => {
-    let playlist;
+  mpc.masterPlaylistLoader_.media(mpc.master().playlists[0]);
+  // video media
+  standardXHRResponse(this.requests.shift());
 
-    hls.playlists.master.playlists.forEach((p) => {
-      if (!playlist && p.attributes.AUDIO !== oldMediaGroup) {
-        playlist = p;
-      }
-    });
-    return playlist;
-  };
-
-  // select a new mediaGroup
-  hls.masterPlaylistController_.blacklistCurrentPlaylist();
-  while (this.requests.length > 0) {
-    standardXHRResponse(this.requests.shift());
-  }
   QUnit.notEqual(oldMediaGroup, hls.playlists.media().attributes.AUDIO, 'selected a new playlist');
-  QUnit.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
+  audioTracks = this.player.audioTracks();
 
-  QUnit.equal(audioTracks.length, 3, 'three audio tracks after mediaGroup Change');
-  QUnit.equal(audioTracks[0], trackOne, 'track one did not change');
-  QUnit.equal(audioTracks[1], trackTwo, 'track two did not change');
-  QUnit.equal(audioTracks[2], trackThree, 'track three did not change');
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after changing mediaGroup');
+  QUnit.ok(audioTracks[0].properties_.default, 'track one should be the default');
+  QUnit.ok(audioTracks[0].enabled, 'enabled the default track');
+  QUnit.notOk(audioTracks[1].enabled, 'disabled track two');
+  QUnit.notOk(audioTracks[2].enabled, 'disabled track three');
 
-  trackTwo.enabled = true;
-  QUnit.equal(trackOne.enabled, false, 'track 1 - now disabled');
-  QUnit.equal(trackTwo.enabled, true, 'track 2 - now enabled');
-  QUnit.equal(trackThree.enabled, false, 'track 3 - disabled');
+  audioTracks[1].enabled = true;
+  QUnit.notOk(audioTracks[0].enabled, 'disabled track one');
+  QUnit.ok(audioTracks[1].enabled, 'enabled track two');
+  QUnit.notOk(audioTracks[2].enabled, 'disabled track three');
 
   oldMediaGroup = hls.playlists.media().attributes.AUDIO;
-  // select a new mediaGroup
-  hls.masterPlaylistController_.blacklistCurrentPlaylist();
-  while (this.requests.length > 0) {
-    standardXHRResponse(this.requests.shift());
-  }
+  // clear out any outstanding requests
+  this.requests.length = 0;
+  // swap back to the old media group
+  // this playlist is already loaded so no new requests are made
+  mpc.masterPlaylistLoader_.media(mpc.master().playlists[3]);
+
   QUnit.notEqual(oldMediaGroup, hls.playlists.media().attributes.AUDIO, 'selected a new playlist');
-  QUnit.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
+  audioTracks = this.player.audioTracks();
 
-  QUnit.equal(audioTracks.length, 3, 'three audio tracks after mediaGroup Change');
-  QUnit.equal(audioTracks[0], trackOne, 'track one did not change');
-  QUnit.equal(audioTracks[1], trackTwo, 'track two did not change');
-  QUnit.equal(audioTracks[2], trackThree, 'track three did not change');
-
-  QUnit.equal(trackOne.enabled, false, 'track 1 - still disabled');
-  QUnit.equal(trackTwo.enabled, true, 'track 2 - still enabled');
-  QUnit.equal(trackThree.enabled, false, 'track 3 - disabled');
-
-  // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
+  QUnit.equal(audioTracks.length, 3, 'three audio tracks after reverting mediaGroup');
+  QUnit.ok(audioTracks[0].properties_.default, 'track one should be the default');
+  QUnit.notOk(audioTracks[0].enabled, 'the default track is still disabled');
+  QUnit.ok(audioTracks[1].enabled, 'track two is still enabled');
+  QUnit.notOk(audioTracks[2].enabled, 'track three is still disabled');
 });
 
 QUnit.test('Allows specifying the beforeRequest function on the player', function() {


### PR DESCRIPTION
## Description
Work in progress. Support for initialization segments and (maybe) fragmented mp4 segments. 

## Specific Changes proposed
Resolve EXT-X-MAP URI information in the playlist loader. Add support for requesting and appending initialization segments to the segment loader.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors