### PR TITLE
Fix desyncing audio and video when using alternate audio (not muxed t…

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -738,8 +738,25 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.currentTimeline_ = segmentInfo.timeline;
 
     if (segmentInfo.timestampOffset !== this.sourceUpdater_.timestampOffset()) {
-      this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);
+      this.discontinuityTimestampOffset = segmentInfo.timestampOffset;
+      this.trigger('discontinuity');
+      // wait to be told to continue
+      return;
     }
+
+    this.appendSegment_();
+  }
+
+  appendWithTimestampOffset(timestampOffset) {
+    let segmentInfo = this.pendingSegment_;
+
+    segmentInfo.timestampOffset = timestampOffset;
+    this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);
+    this.appendSegment_();
+  }
+
+  appendSegment_() {
+    let segmentInfo = this.pendingSegment_;
 
     this.sourceUpdater_.appendBuffer(segmentInfo.bytes,
                                      this.handleUpdateEnd_.bind(this));

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -426,6 +426,11 @@ QUnit.test('abort does not cancel segment processing in progress', function() {
 
 QUnit.test('sets the timestampOffset on timeline change', function() {
   let playlist = playlistWithDuration(40);
+  let discontinuityCount = 0;
+
+  loader.on('discontinuity', () => {
+    discontinuityCount++;
+  });
 
   playlist.discontinuityStarts = [1];
   playlist.segments[1].timeline = 1;
@@ -439,9 +444,21 @@ QUnit.test('sets the timestampOffset on timeline change', function() {
   mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
   mediaSource.sourceBuffers[0].trigger('updateend');
 
+  QUnit.ok(!discontinuityCount, 'did not trigger a discontinuity');
+
   // segment 1, discontinuity
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
+
+  QUnit.equal(discontinuityCount, 1, 'triggered a discontinuity');
+  QUnit.equal(loader.discontinuityTimestampOffset, 10,
+              'set discontinuityTimestampOffset');
+
+  // timestamp offset not set until an outside listener calls appendWithTimestampOffset
+  QUnit.ok(!mediaSource.sourceBuffers[0].timestampOffset, 'did not set timestampOffset');
+
+  loader.appendWithTimestampOffset(loader.discontinuityTimestampOffset);
+
   QUnit.equal(mediaSource.sourceBuffers[0].timestampOffset, 10, 'set timestampOffset');
 });
 


### PR DESCRIPTION
NOT READY FOR MERGE. This requires changes within mux.js in order to function appropriately. Namely, gaps may be created with this change, and mux.js must fill those gaps to allow the video to continue playing.
## Description

Bug fix for desyncing audio and video when using alternate audio.
When audio and video are not muxed together, two segment loaders act independently to retrieve segments. When a discontinuity is reached, each one independently determines a timestamp offset, and that is used as the baseMediaDecodeTime in mux.js. However, since the baseMediaDecodeTimes do not necessarily match, the difference will create desyncing.
## Specific Changes proposed

First, this enables expired time tracking for the audio segment loader. Then, when encountering discontinuities, segment loaders pause, trigger a discontinuity event, and wait to be told to continue with a timestamp offset. Master playlist controller listens for the discontinuity event, determines if there are two active segment loaders, and if there are, waits for the second, chooses the greatest timestamp offset, then calls into the segment loaders with that timestamp offset to continue.
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors

…ogether)

Track expired time in audio segment loader. Pause segment loader on discontinuity and wait for timestamp offset from master playlist controller. When using audio and video muxed together, master playlist controller will immediately use the only timestamp offset available. When using separate audio and video, the greatest of the two timestamp offsets will be selected and given to both segment loaders, syncing the two together.
