### PR TITLE
Made properties of hls.stats enumerable.

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -409,19 +409,19 @@ class HlsHandler extends Component {
     });
 
     Object.defineProperties(this.stats, {
-      'bandwidth': {
+      bandwidth: {
         get: () => this.bandwidth || 0,
         enumerable: true
       },
-      'mediaRequests': {
+      mediaRequests: {
         get: () => this.masterPlaylistController_.mediaRequests_() || 0,
         enumerable: true
       },
-      'mediaTransferDuration': {
+      mediaTransferDuration: {
         get: () => this.masterPlaylistController_.mediaTransferDuration_() || 0,
         enumerable: true
       },
-      'mediaBytesTransferred': {
+      mediaBytesTransferred: {
         get: () => this.masterPlaylistController_.mediaBytesTransferred_() || 0,
         enumerable: true
       }

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -408,21 +408,23 @@ class HlsHandler extends Component {
       }
     });
 
-    Object.defineProperty(this.stats, 'bandwidth', {
-      get: () => this.bandwidth || 0,
-      enumerable: true
-    });
-    Object.defineProperty(this.stats, 'mediaRequests', {
-      get: () => this.masterPlaylistController_.mediaRequests_() || 0,
-      enumerable: true
-    });
-    Object.defineProperty(this.stats, 'mediaTransferDuration', {
-      get: () => this.masterPlaylistController_.mediaTransferDuration_() || 0,
-      enumerable: true
-    });
-    Object.defineProperty(this.stats, 'mediaBytesTransferred', {
-      get: () => this.masterPlaylistController_.mediaBytesTransferred_() || 0,
-      enumerable: true
+    Object.defineProperties(this.stats, {
+      'bandwidth': {
+        get: () => this.bandwidth || 0,
+        enumerable: true
+      },
+      'mediaRequests': {
+        get: () => this.masterPlaylistController_.mediaRequests_() || 0,
+        enumerable: true
+      },
+      'mediaTransferDuration': {
+        get: () => this.masterPlaylistController_.mediaTransferDuration_() || 0,
+        enumerable: true
+      },
+      'mediaBytesTransferred': {
+        get: () => this.masterPlaylistController_.mediaBytesTransferred_() || 0,
+        enumerable: true
+      }
     });
 
     this.tech_.one('canplay',

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -409,16 +409,20 @@ class HlsHandler extends Component {
     });
 
     Object.defineProperty(this.stats, 'bandwidth', {
-      get: () => this.bandwidth || 0
+      get: () => this.bandwidth || 0,
+      enumerable: true
     });
     Object.defineProperty(this.stats, 'mediaRequests', {
-      get: () => this.masterPlaylistController_.mediaRequests_() || 0
+      get: () => this.masterPlaylistController_.mediaRequests_() || 0,
+      enumerable: true
     });
     Object.defineProperty(this.stats, 'mediaTransferDuration', {
-      get: () => this.masterPlaylistController_.mediaTransferDuration_() || 0
+      get: () => this.masterPlaylistController_.mediaTransferDuration_() || 0,
+      enumerable: true
     });
     Object.defineProperty(this.stats, 'mediaBytesTransferred', {
-      get: () => this.masterPlaylistController_.mediaBytesTransferred_() || 0
+      get: () => this.masterPlaylistController_.mediaBytesTransferred_() || 0,
+      enumerable: true
     });
 
     this.tech_.one('canplay',


### PR DESCRIPTION
## Description
Made all properties of hls.stats enumerable in order to be able to dynamically pull the whole object into analytics rather than targeting individual properties

## Specific Changes proposed
Made all properties of hls.stats enumerable


