### PR TITLE
Skip gaps caused by video underflow

### DIFF
--- a/src/ranges.js
+++ b/src/ranges.js
@@ -51,8 +51,7 @@ const findRange = function(buffered, time) {
 };
 
 /**
- * Returns the TimeRanges that begin at or later than the specified
- * time.
+ * Returns the TimeRanges that begin later than the specified time.
  * @param {TimeRanges} timeRanges - the TimeRanges object to query
  * @param {number} time - the time to filter on.
  * @returns {TimeRanges} a new TimeRanges object.
@@ -61,6 +60,28 @@ const findNextRange = function(timeRanges, time) {
   return filterRanges(timeRanges, function(start) {
     return start - TIME_FUDGE_FACTOR >= time;
   });
+};
+
+/**
+ * Returns gaps within a list of TimeRanges
+ * @param {TimeRanges} buffered - the TimeRanges object
+ * @return {TimeRanges} a TimeRanges object with gaps
+ */
+const findGaps = function(buffered) {
+  if (buffered.length < 2) {
+    return videojs.createTimeRanges();
+  }
+
+  let ranges = [];
+
+  for (let i = 1; i < buffered.length; i++) {
+    let start = buffered.end(i - 1);
+    let end = buffered.start(i);
+
+    ranges.push([start, end]);
+  }
+
+  return videojs.createTimeRanges(ranges);
 };
 
 /**
@@ -300,6 +321,7 @@ const getSegmentBufferedPercent = function(startOfSegment,
 export default {
   findRange,
   findNextRange,
+  findGaps,
   findSoleUncommonTimeRangesEnd,
   getSegmentBufferedPercent,
   TIME_FUDGE_FACTOR

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -65,7 +65,7 @@ const findNextRange = function(timeRanges, time) {
 /**
  * Returns gaps within a list of TimeRanges
  * @param {TimeRanges} buffered - the TimeRanges object
- * @return {TimeRanges} a TimeRanges object with gaps
+ * @return {TimeRanges} a TimeRanges object of gaps
  */
 const findGaps = function(buffered) {
   if (buffered.length < 2) {

--- a/test/ranges.test.js
+++ b/test/ranges.test.js
@@ -278,5 +278,5 @@ QUnit.test('finds gaps within ranges', function() {
            'finds a single gap');
   QUnit.ok(rangesEqual(Ranges.findGaps(createTimeRanges([[0, 10], [11, 20], [22, 30]])),
            createTimeRanges([[10, 11], [20, 22]])),
-           'finds multiple gap');
+           'finds multiple gaps');
 });

--- a/test/ranges.test.js
+++ b/test/ranges.test.js
@@ -2,6 +2,25 @@ import Ranges from '../src/ranges';
 import {createTimeRanges} from 'video.js';
 import QUnit from 'qunit';
 
+let rangesEqual = (rangeOne, rangeTwo) => {
+  if (!rangeOne || !rangeTwo) {
+    return false;
+  }
+
+  if (rangeOne.length !== rangeTwo.length) {
+    return false;
+  }
+
+  for (let i = 0; i < rangeOne.length; i++) {
+    if (rangeOne.start(i) !== rangeTwo.start(i) ||
+        rangeOne.end(i) !== rangeTwo.end(i)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
 QUnit.module('TimeRanges Utilities');
 
 QUnit.test('finds the overlapping time range', function() {
@@ -210,4 +229,54 @@ QUnit.test('calculates the percent buffered for segments ' +
     buffered);
 
   QUnit.equal(percentBuffered, 95, 'calculated the buffered amount correctly');
+});
+
+QUnit.test('finds next range', function() {
+  QUnit.equal(Ranges.findNextRange(createTimeRanges(), 10).length,
+              0,
+              'does not find next range in empty buffer');
+  QUnit.equal(Ranges.findNextRange(createTimeRanges([[0, 20]]), 10).length,
+              0,
+              'does not find next range when no next ranges');
+  QUnit.equal(Ranges.findNextRange(createTimeRanges([[0, 20]]), 30).length,
+              0,
+              'does not find next range when current time later than buffer');
+  QUnit.equal(Ranges.findNextRange(createTimeRanges([[10, 20]]), 10).length,
+              0,
+              'does not find next range when current time is at beginning of buffer');
+  QUnit.equal(Ranges.findNextRange(createTimeRanges([[10, 20]]), 11).length,
+              0,
+              'does not find next range when current time in middle of buffer');
+  QUnit.equal(Ranges.findNextRange(createTimeRanges([[10, 20]]), 20).length,
+              0,
+              'does not find next range when current time is at end of buffer');
+
+  QUnit.ok(rangesEqual(Ranges.findNextRange(createTimeRanges([[10, 20]]), 0),
+           createTimeRanges([[10, 20]])),
+           'finds next range when buffer comes after time');
+  QUnit.ok(rangesEqual(Ranges.findNextRange(createTimeRanges([[10, 20], [25, 35]]), 22),
+           createTimeRanges([[25, 35]])),
+           'finds next range when time between buffers');
+  QUnit.ok(rangesEqual(Ranges.findNextRange(createTimeRanges([[10, 20], [25, 35]]), 15),
+           createTimeRanges([[25, 35]])),
+           'finds next range when time in previous buffer');
+});
+
+QUnit.test('finds gaps within ranges', function() {
+  QUnit.equal(Ranges.findGaps(createTimeRanges()).length,
+              0,
+              'does not find gap in empty buffer');
+  QUnit.equal(Ranges.findGaps(createTimeRanges([[0, 10]])).length,
+              0,
+              'does not find gap in single buffer');
+  QUnit.equal(Ranges.findGaps(createTimeRanges([[1, 10]])).length,
+              0,
+              'does not find gap at start of buffer');
+
+  QUnit.ok(rangesEqual(Ranges.findGaps(createTimeRanges([[0, 10], [11, 20]])),
+           createTimeRanges([[10, 11]])),
+           'finds a single gap');
+  QUnit.ok(rangesEqual(Ranges.findGaps(createTimeRanges([[0, 10], [11, 20], [22, 30]])),
+           createTimeRanges([[10, 11], [20, 22]])),
+           'finds multiple gap');
 });


### PR DESCRIPTION
## Description
In the event that there is a small gap in the video buffer, Chrome will consider it video underflow, and will continue playing audio for ~3 seconds while video remains frozen. The current time of the player will update to reflect the audio playback. Due to the audio overplay, the gap skipper will think we are in a buffered region, and will not skip over the gap.

## Specific Changes proposed
This adds support for skipping over gaps caused by a browser's interpretation of video underflow.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors