### PR TITLE
Upgrade aes-decrypter to use webcrypto for HLSe decryption where available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test/"
   ],
   "dependencies": {
-    "aes-decrypter": "^1.0.3",
+    "aes-decrypter": "^2.0.0",
     "global": "^4.3.0",
     "m3u8-parser": "^1.0.2",
     "mux.js": "^3.0.0",

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -913,7 +913,11 @@ QUnit.test('the key is saved to the segment in the correct format', function() {
   segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
   QUnit.deepEqual(segment.key.bytes,
-                  new Uint32Array([0, 0x01000000, 0x02000000, 0x03000000]),
+                  new Uint8Array([
+                    0x00, 0x00, 0x00, 0x00,
+                    0x01, 0x00, 0x00, 0x00,
+                    0x02, 0x00, 0x00, 0x00,
+                    0x03, 0x00, 0x00, 0x00]),
                   'passed the specified segment key');
 
   // verify stats

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -963,7 +963,7 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   let keyRequest;
   let segmentRequest;
 
-  var doneDecrypting = assert.async();
+  let doneDecrypting = assert.async();
 
   // stop processing so we can examine segment info
   loader.handleSegment_ = function() {


### PR DESCRIPTION
## Description

Use the aes-decrypter@2.0.0 with new api, which uses webcrypto to decrypt AES-CBC encrypted segments where available (Chrome, Firefox, Edge, Opera).
## Specific Changes proposed

Please list the specific changes involved in this pull request.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors

Cast request.response ArrayBuffer to Uint8Array for explicit passing to
decrypt
