### PR TITLE
typo in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ npm install --save videojs-contrib-hls
 Select a version of HLS from the [CDN](https://cdnjs.com/libraries/videojs-contrib-hls)
 
 ### Releases
-Download a release of [videojs-contrib-hls](https://github.com/videojs/videojs-contrib-hls/release)
+Download a release of [videojs-contrib-hls](https://github.com/videojs/videojs-contrib-hls/releases)
 
 ### Manual Build
 Download a copy of this git repository and then follow the steps in [Building](#building)


### PR DESCRIPTION
## Description
small typo in README.md linking to a nonexistent page.

## Specific Changes proposed
I fixed the URL

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors

