### PR TITLE
Add ability to manually pause playlist and segment loaders

### DIFF
--- a/src/hls-audio-track.js
+++ b/src/hls-audio-track.js
@@ -85,6 +85,19 @@ export default class HlsAudioTrack extends AudioTrack {
   }
 
   /**
+   * pause all media loaders
+   */
+  pause() {
+    for (let i = 0; i < this.mediaGroups_.length; i++) {
+      let mgl = this.mediaGroups_[i];
+
+      if (mgl.loader) {
+        mgl.loader.pause();
+      }
+    }
+  }
+
+  /**
    * Dispose of this audio track and
    * the playlist loader that it holds inside
    */

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -545,9 +545,16 @@ export default class MasterPlaylistController extends videojs.EventTarget {
   }
 
   /**
-   * Pause all segment loaders
+   * Pause all playlist and segment loaders
    */
   pauseLoading() {
+    // pause loading playlists
+    this.masterPlaylistLoader_.pause();
+    this.audioTracks_.forEach((track) => {
+      track.pause();
+    });
+
+    // pause segment loaders
     this.mainSegmentLoader_.pause();
     if (this.audioPlaylistLoader_) {
       this.audioSegmentLoader_.pause();

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -330,9 +330,7 @@ class HlsHandler extends Component {
       this.setCurrentTime(this.tech_.currentTime());
     });
     this.on(this.tech_, 'error', function() {
-      if (this.masterPlaylistController_) {
-        this.masterPlaylistController_.pauseLoading();
-      }
+      this.pauseLoading();
     });
 
     this.audioTrackChange_ = () => {
@@ -543,6 +541,15 @@ class HlsHandler extends Component {
    */
   seekable() {
     return this.masterPlaylistController_.seekable();
+  }
+
+  /**
+   * manually pause playlist and segment loading
+   */
+  pauseLoading() {
+    if (this.masterPlaylistController_) {
+      this.masterPlaylistController_.pauseLoading();
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Our HLS streams expire if not played. Thus when pausing video, player should not request on server anymore as stream will expire soon. To keep last frame on video when paused and prevent loading new playlists/segments all playlist and segment loaders should be paused.

This improves and replaces PR #349.
## Specific Changes proposed

`MasterPlaylistController` class already contained `pauseLoading` function, which was only executed on error. It was extended to also pause master playlist loader and all audioTrack loaders.

A public `pauseLoading` function was added to contrib to add user ability to pause loaders.

Not sure if unit tests are needed here. I can update docs/guides/examples when approved.
## Requirements Checklist
- [x] Feature implemented
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
