### PR TITLE
Remove Sauce Labs credentials and tunnel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,12 @@ notifications:
     channels:
       - "chat.freenode.net#videojs"
     use_notice: true
-# Set up a virtual screen for Firefox.
+# Set up a virtual screen for Chrome.
 before_script:
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-env:
-  global:
-  - secure: dM7svnHPPu5IiUMeFWW5zg+iuWNpwt6SSDi3MmVvhSclNMRLesQoRB+7Qq5J/LiKhmjpv1/GlNVV0CTsHMRhZNwQ3fo38eEuTXv99aAflEITXwSEh/VntKViHbGFubn06EnVkJoH6MX3zJ6kbiwc2QdSQbywKzS6l6quUEpWpd0=
-  - secure: AnduYGXka5ft1x7V3SuVYqvlKLvJGhUaRNFdy4UDJr3ZVuwpQjE4TMDG8REmJIJvXfHbh4qY4N1cFSGnXkZ4bH21Xk0v9DLhsxbarKz+X2BvPgXs+Af9EQ6vLEy/5S1vMLxfT5+y+Ec5bVNGOsdUZby8Y21CRzSg6ADN9kwPGlE=
 addons:
-  sauce_connect: true
   apt:
     sources:
     - google-chrome


### PR DESCRIPTION
## Description
This PR is to remove Sauce Labs information from the .travis.yml file to shorten the build time (sauce connect doesn't start) and clean out unneeded information. The build currently works by having travis install Chrome.

## Requirements Checklist
- [x] Reviewed by Two (?) Core Contributors

