### PR TITLE
move global devDependency to normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "aes-decrypter": "^1.0.3",
     "video.js": "^5.10.1",
     "videojs-contrib-media-sources": "^3.1.0",
-    "videojs-swf": "^5.0.2"
+    "videojs-swf": "^5.0.2",
+    "global": "^4.3.0"
   },
   "devDependencies": {
     "babel": "^5.8.0",
@@ -99,7 +100,6 @@
     "cowsay": "^1.1.0",
     "doctoc": "^0.15.0",
     "glob": "^6.0.3",
-    "global": "^4.3.0",
     "jsdoc": "^3.4.0",
     "karma": "^0.13.0",
     "karma-browserify": "^4.4.0",

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -9,6 +9,7 @@ import resolveUrl from './resolve-url';
 import {mergeOptions} from 'video.js';
 import Stream from './stream';
 import m3u8 from 'm3u8-parser';
+import window from 'global/window';
 
 /**
   * Returns a new array of segments that is the result of merging

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -4,6 +4,7 @@
  * Playlist related utilities.
  */
 import {createTimeRange} from 'video.js';
+import window from 'global/window';
 
 let Playlist = {
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -7,6 +7,7 @@ import videojs from 'video.js';
 import SourceUpdater from './source-updater';
 import {Decrypter} from 'aes-decrypter';
 import Config from './config';
+import window from 'global/window';
 
 // in ms
 const CHECK_BUFFER_DELAY = 500;

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -17,6 +17,7 @@ import MasterPlaylistController from './master-playlist-controller';
 import Config from './config';
 import renditionSelectionMixin from './rendition-mixin';
 import GapSkipper from './gap-skipper';
+import window from 'global/window';
 
 /**
  * determine if an object a is differnt from
@@ -94,7 +95,7 @@ const safeGetComputedStyle = function(el, property) {
     return '';
   }
 
-  result = getComputedStyle(el);
+  result = window.getComputedStyle(el);
   if (!result) {
     return '';
   }

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -2,6 +2,7 @@ import QUnit from 'qunit';
 import PlaylistLoader from '../src/playlist-loader';
 import xhrFactory from '../src/xhr';
 import { useFakeEnvironment } from './test-helpers';
+import window from 'global/window';
 
 // Attempts to produce an absolute URL to a given relative path
 // based on window.location.href

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -8,6 +8,7 @@ import MediaSource from 'videojs-contrib-media-sources';
 /* eslint-enable */
 import testDataManifests from './test-manifests.js';
 import xhrFactory from '../src/xhr';
+import window from 'global/window';
 
 // a SourceBuffer that tracks updates but otherwise is a noop
 class MockSourceBuffer extends videojs.EventTarget {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -17,6 +17,7 @@ import {
 // we need this so that it can register hls with videojs
 import {HlsSourceHandler, HlsHandler, Hls} from '../src/videojs-contrib-hls';
 import HlsAudioTrack from '../src/hls-audio-track';
+import window from 'global/window';
 /* eslint-enable no-unused-vars */
 
 const Flash = videojs.getComponent('Flash');
@@ -117,7 +118,9 @@ QUnit.test('deprication warning is show when using player.hls', function() {
     type: 'application/vnd.apple.mpegurl'
   });
 
-  videojs.log.warn = (text) => warning = text;
+  videojs.log.warn = (text) => {
+    warning = text;
+  };
   let hls = this.player.hls;
 
   QUnit.equal(warning, 'player.hls is deprecated. Use player.tech.hls instead.', 'warning would have been shown');


### PR DESCRIPTION
## Description
global is used in the code as a normal dependency, we need to put it in the normal dependency list.

## Specific Changes proposed
change package.json to match description

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

