### PR TITLE
Cue Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Play back HLS with video.js, even where it's not natively supported.
       - [Source](#source)
     - [List](#list)
       - [withCredentials](#withcredentials)
-      - [useTagCues](#usetagcues)
+      - [useCueTags](#usecuetags)
   - [Runtime Properties](#runtime-properties)
     - [hls.playlists.master](#hlsplaylistsmaster)
     - [hls.playlists.media](#hlsplaylistsmedia)
@@ -213,14 +213,16 @@ is set to `true`.
 See html5rocks's [article](http://www.html5rocks.com/en/tutorials/cors/)
 for more info.
 
-##### useTagCues
+##### useCueTags
 * Type: `boolean`
 * can be used as an initialization option
 
-When the `useTagCues` property is set to `true,` a text track is created with
+When the `useCueTags` property is set to `true,` a text track is created with
 the id 'hls-segment-metadata' and kind 'metadata'. The track is then added to
-`player.textTracks()`. Whenever a segment is playing, its associated tags will
-be listed as a tags property under its active cue. Changes in active cue may be
+`player.textTracks()`. Whenever a segment associated with a cue tag is playing,
+the cue tags will be listed as a properties inside of a stringified JSON object
+under its active cue's `text` property. The properties that are currently
+supported are cueOut, cueOutCont, and cueIn. Changes in active cue may be
 tracked by following the Video.js cue points API for text tracks. For example:
 
 ```javascript
@@ -239,13 +241,17 @@ tagsTrack.oncuechange = function() {
   var
     activeCues = tagsTrack.activeCues,
     i,
-    activeCue;
+    activeCue,
+    cueData;
 
   for (i = 0; i < activeCues.length; i++) {
       activeCue = activeCues[i];
+      cueData = JSON.parse(activeCue.text);
+
       console.log('Cue runs from ' + activeCue.startTime +
                   ' to ' + activeCue.endTime +
-                  '\n' + activeCue.tags.join('\n'));
+                  ' with cue tag contents ' +
+                  (cueData.cueOut || cueData.cueOutCont || cueData.cueIn));
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -226,34 +226,29 @@ supported are cueOut, cueOutCont, and cueIn. Changes in active cue may be
 tracked by following the Video.js cue points API for text tracks. For example:
 
 ```javascript
-var
-  textTracks = player.textTracks(),
-  cuesTrack,
-  i;
+let textTracks = player.textTracks();
+let cuesTrack;
 
-for (i = 0; i < textTracks.length; i++) {
+for (let i = 0; i < textTracks.length; i++) {
   if (textTracks[i].label === 'hls-segment-metadata') {
     cuesTrack = textTracks[i];
   }
 }
 
-cuesTrack.oncuechange = function() {
-  var
-    activeCues = cuesTrack.activeCues,
-    i,
-    activeCue,
-    cueData;
+cuesTrack.addEventListener('cuechange', function() {
+  let activeCues = cuesTrack.activeCues;
+  let activeCue;
 
-  for (i = 0; i < activeCues.length; i++) {
-      activeCue = activeCues[i];
-      cueData = JSON.parse(activeCue.text);
+  for (let i = 0; i < activeCues.length; i++) {
+    let activeCue = activeCues[i];
+    let cueData = JSON.parse(activeCue.text);
 
-      console.log('Cue runs from ' + activeCue.startTime +
-                  ' to ' + activeCue.endTime +
-                  ' with cue tag contents ' +
-                  (cueData.cueOut || cueData.cueOutCont || cueData.cueIn));
+    console.log('Cue runs from ' + activeCue.startTime +
+                ' to ' + activeCue.endTime +
+                ' with cue tag contents ' +
+                (cueData.cueOut || cueData.cueOutCont || cueData.cueIn));
   }
-}
+});
 ```
 
 ### Runtime Properties

--- a/README.md
+++ b/README.md
@@ -237,7 +237,6 @@ for (let i = 0; i < textTracks.length; i++) {
 
 cuesTrack.addEventListener('cuechange', function() {
   let activeCues = cuesTrack.activeCues;
-  let activeCue;
 
   for (let i = 0; i < activeCues.length; i++) {
     let activeCue = activeCues[i];

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Play back HLS with video.js, even where it's not natively supported.
       - [Source](#source)
     - [List](#list)
       - [withCredentials](#withcredentials)
+      - [useTagCues](#usetagcues)
   - [Runtime Properties](#runtime-properties)
     - [hls.playlists.master](#hlsplaylistsmaster)
     - [hls.playlists.media](#hlsplaylistsmedia)
@@ -211,6 +212,43 @@ headers require the addition of `Access-Control-Allow-Credentials` header which
 is set to `true`.
 See html5rocks's [article](http://www.html5rocks.com/en/tutorials/cors/)
 for more info.
+
+##### useTagCues
+* Type: `boolean`
+* can be used as an initialization option
+
+When the `useTagCues` property is set to `true,` a text track is created with
+the id 'hls-segment-metadata' and kind 'metadata'. The track is then added to
+`player.textTracks()`. Whenever a segment is playing, its associated tags will
+be listed as a tags property under its active cue. Changes in active cue may be
+tracked by following the Video.js cue points API for text tracks. For example:
+
+```javascript
+var
+  textTracks = player.textTracks(),
+  tagsTrack,
+  i;
+
+for (i = 0; i < textTracks.length; i++) {
+  if (textTracks[i].id === 'hls-segment-metadata') {
+    tagsTrack = textTracks[i];
+  }
+}
+
+tagsTrack.oncuechange = function() {
+  var
+    activeCues = tagsTrack.activeCues,
+    i,
+    activeCue;
+
+  for (i = 0; i < activeCues.length; i++) {
+      activeCue = activeCues[i];
+      console.log('Cue runs from ' + activeCue.startTime +
+                  ' to ' + activeCue.endTime +
+                  '\n' + activeCue.tags.join('\n'));
+  }
+}
+```
 
 ### Runtime Properties
 Runtime properties are attached to the tech object when HLS is in

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ for more info.
 * can be used as an initialization option
 
 When the `useCueTags` property is set to `true,` a text track is created with
-the id 'hls-segment-metadata' and kind 'metadata'. The track is then added to
+label 'hls-segment-metadata' and kind 'metadata'. The track is then added to
 `player.textTracks()`. Whenever a segment associated with a cue tag is playing,
 the cue tags will be listed as a properties inside of a stringified JSON object
 under its active cue's `text` property. The properties that are currently
@@ -228,18 +228,18 @@ tracked by following the Video.js cue points API for text tracks. For example:
 ```javascript
 var
   textTracks = player.textTracks(),
-  tagsTrack,
+  cuesTrack,
   i;
 
 for (i = 0; i < textTracks.length; i++) {
-  if (textTracks[i].id === 'hls-segment-metadata') {
-    tagsTrack = textTracks[i];
+  if (textTracks[i].label === 'hls-segment-metadata') {
+    cuesTrack = textTracks[i];
   }
 }
 
-tagsTrack.oncuechange = function() {
+cuesTrack.oncuechange = function() {
   var
-    activeCues = tagsTrack.activeCues,
+    activeCues = cuesTrack.activeCues,
     i,
     activeCue,
     cueData;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -848,9 +848,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       startTime = endTime;
       endTime = startTime + segment.duration;
 
-      let cueJson = {};
-
       if ('cueOut' in segment || 'cueOutCont' in segment || 'cueIn' in segment) {
+        let cueJson = {};
+
         if ('cueOut' in segment) {
           cueJson.cueOut = segment.cueOut;
         }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -61,13 +61,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.mode_ = mode;
     this.useCueTags_ = useCueTags;
     if (this.useCueTags_) {
-      this.cueTagsTrack_ = new videojs.TextTrack({
-        id: 'hls-segment-metadata',
-        tech: this.tech_,
-        kind: 'metadata',
-        mode: 'hidden',
-        inBandMetadataTrackDispatchType: ''
-      });
+      this.cueTagsTrack_ = this.tech_.addTextTrack('metadata', 'hls-segment-metadata');
+      this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
       this.tech_.textTracks().addTrack_(this.cueTagsTrack_);
     }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -6,6 +6,7 @@ import SegmentLoader from './segment-loader';
 import Ranges from './ranges';
 import videojs from 'video.js';
 import HlsAudioTrack from './hls-audio-track';
+import window from 'global/window';
 
 // 5 minute blacklist
 const BLACKLIST_DURATION = 5 * 60 * 1000;
@@ -861,9 +862,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         // transition (in this case, defined as the beginning of the segment that the tag
         // precedes), but keep it for a minimum of 0.5 seconds to remain usable (won't
         // lose it as an active cue by the time a user retrieves the active cues).
-        this.cueTagsTrack_.addCue(new VTTCue(mediaTime,
-                                             mediaTime + 0.5,
-                                             JSON.stringify(cueJson)));
+        this.cueTagsTrack_.addCue(new window.VTTCue(mediaTime,
+                                                    mediaTime + 0.5,
+                                                    JSON.stringify(cueJson)));
       }
 
       mediaTime += segment.duration;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -839,14 +839,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       this.cueTagsTrack_.removeCue(this.cueTagsTrack_.cues[0]);
     }
 
-    let startTime;
-    let endTime = 0;
+    let mediaTime = 0;
 
     for (let i = 0; i < media.segments.length; i++) {
       let segment = media.segments[i];
-
-      startTime = endTime;
-      endTime = startTime + segment.duration;
 
       if ('cueOut' in segment || 'cueOutCont' in segment || 'cueIn' in segment) {
         let cueJson = {};
@@ -861,10 +857,16 @@ export default class MasterPlaylistController extends videojs.EventTarget {
           cueJson.cueIn = segment.cueIn;
         }
 
-        this.cueTagsTrack_.addCue(new VTTCue(startTime,
-                                             endTime,
+        // Use a short duration for the cue point, as it should trigger for a segment
+        // transition (in this case, defined as the beginning of the segment that the tag
+        // precedes), but keep it for a minimum of 0.5 seconds to remain usable (won't
+        // lose it as an active cue by the time a user retrieves the active cues).
+        this.cueTagsTrack_.addCue(new VTTCue(mediaTime,
+                                             mediaTime + 0.5,
                                              JSON.stringify(cueJson)));
       }
+
+      mediaTime += segment.duration;
     }
   }
 }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -60,6 +60,17 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.hls_ = tech.hls;
     this.mode_ = mode;
     this.useTagCues_ = useTagCues;
+    if (this.useTagCues_) {
+      this.tagsTrack_ = new videojs.TextTrack({
+        id: 'hls-segment-metadata',
+        tech: this.tech_,
+        kind: 'metadata',
+        mode: 'hidden',
+        inBandMetadataTrackDispatchType: ''
+      });
+      this.tech_.textTracks().addTrack_(this.tagsTrack_);
+    }
+
     this.audioTracks_ = [];
     this.requestOptions_ = {
       withCredentials: this.withCredentials,
@@ -829,15 +840,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
-    if (this.tagsTrack_) {
-      this.tech_.textTracks().removeTrack_(this.tagsTrack_);
+    while (this.tagsTrack_.cues.length) {
+      this.tagsTrack_.removeCue(this.tagsTrack_.cues[0]);
     }
-
-    this.tagsTrack_ = new videojs.TextTrack({
-      tech: this.tech_,
-      kind: 'data',
-      mode: 'hidden'
-    });
 
     let startTime;
     let endTime = 0;
@@ -856,7 +861,5 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         });
       }
     }
-
-    this.tech_.textTracks().addTrack_(this.tagsTrack_);
   }
 }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -13,6 +13,7 @@ import MasterPlaylistController from '../src/master-playlist-controller';
 import { Hls } from '../src/videojs-contrib-hls';
 /* eslint-enable no-unused-vars */
 import Playlist from '../src/playlist';
+import window from 'global/window';
 
 QUnit.module('MasterPlaylistController', {
   beforeEach() {
@@ -734,7 +735,7 @@ QUnit.test('update tag cues', function() {
   this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
 
   let cueTagsTrack = this.masterPlaylistController.cueTagsTrack_;
-  let testCue = new VTTCue(0, 10, 'test');
+  let testCue = new window.VTTCue(0, 10, 'test');
 
   cueTagsTrack.addCue(testCue);
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -691,6 +691,9 @@ QUnit.test('respects useCueTags option', function() {
 
   QUnit.ok(this.masterPlaylistController.cueTagsTrack_,
            'creates cueTagsTrack_ if useCueTags is truthy');
+  QUnit.equal(this.masterPlaylistController.cueTagsTrack_.label,
+              'hls-segment-metadata',
+              'cueTagsTrack_ has label of hls-segment-metadata');
   QUnit.equal(this.player.textTracks()[0], this.masterPlaylistController.cueTagsTrack_,
            'adds cueTagsTrack as a text track if useCueTags is truthy');
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -710,7 +710,7 @@ QUnit.test('respects useCueTags option', function() {
               0,
               'adds cue with correct start time if useCueTags is truthy');
   QUnit.equal(cue.endTime,
-              10,
+              0.5,
               'adds cue with correct end time if useCueTags is truthy');
   QUnit.equal(cue.text,
               JSON.stringify({ cueOut: 'test' }),
@@ -771,20 +771,20 @@ QUnit.test('update tag cues', function() {
   QUnit.equal(cueTagsTrack.cues.length, 3, 'adds a cue for each segment');
 
   QUnit.equal(cueTagsTrack.cues[0].startTime, 0, 'cue starts at 0');
-  QUnit.equal(cueTagsTrack.cues[0].endTime, 5.1, 'cue ends at start time plus duration');
+  QUnit.equal(cueTagsTrack.cues[0].endTime, 0.5, 'cue ends at start time plus duration');
   QUnit.equal(JSON.parse(cueTagsTrack.cues[0].text).cueOut, '11.5', 'cueOut matches');
   QUnit.ok(!('cueOutCont' in JSON.parse(cueTagsTrack.cues[0].text)),
            'cueOutCont not in cue');
   QUnit.ok(!('cueIn' in JSON.parse(cueTagsTrack.cues[0].text)), 'cueIn not in cue');
   QUnit.equal(cueTagsTrack.cues[1].startTime, 5.1, 'cue starts at 5.1');
-  QUnit.equal(cueTagsTrack.cues[1].endTime, 11.5, 'cue ends at start time plus duration');
+  QUnit.equal(cueTagsTrack.cues[1].endTime, 5.6, 'cue ends at start time plus duration');
   QUnit.equal(JSON.parse(cueTagsTrack.cues[1].text).cueOutCont,
               '5.1/11.5',
               'cueOutCont matches');
   QUnit.ok(!('cueOut' in JSON.parse(cueTagsTrack.cues[1].text)), 'cueOut not in cue');
   QUnit.ok(!('cueIn' in JSON.parse(cueTagsTrack.cues[1].text)), 'cueIn not in cue');
   QUnit.equal(cueTagsTrack.cues[2].startTime, 11.5, 'cue starts at 11.5');
-  QUnit.equal(cueTagsTrack.cues[2].endTime, 17.5, 'cue ends at start time plus duration');
+  QUnit.equal(cueTagsTrack.cues[2].endTime, 12, 'cue ends at start time plus duration');
   QUnit.equal(JSON.parse(cueTagsTrack.cues[2].text).cueIn, '', 'cueIn matches');
   QUnit.ok(!('cueOut' in JSON.parse(cueTagsTrack.cues[2].text)), 'cueOut not in cue');
   QUnit.ok(!('cueOutCont' in JSON.parse(cueTagsTrack.cues[2].text)),

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -653,10 +653,6 @@ QUnit.test('preserves segment metadata across playlist refreshes', function() {
                               '#EXTINF:10,\n' +
                               '2.ts\n');
 
-  // tag information will be different across refreshes
-  delete segment.tags;
-  delete loader.media().segments[0].tags;
-
   QUnit.deepEqual(loader.media().segments[0], segment, 'preserved segment attributes');
 });
 

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -653,6 +653,10 @@ QUnit.test('preserves segment metadata across playlist refreshes', function() {
                               '#EXTINF:10,\n' +
                               '2.ts\n');
 
+  // tag information will be different across refreshes
+  delete segment.tags;
+  delete loader.media().segments[0].tags;
+
   QUnit.deepEqual(loader.media().segments[0], segment, 'preserved segment attributes');
 });
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2284,7 +2284,11 @@ QUnit.test('passes useTagCues hls option to master playlist controller', functio
   QUnit.ok(!this.player.tech_.hls.masterPlaylistController_.useTagCues_,
            'useTagCues is falsy by default');
 
-  videojs.options.hls.useTagCues = true;
+  let origHlsOptions = videojs.options.hls;
+
+  videojs.options.hls = {
+    useTagCues: true
+  };
 
   this.player.dispose();
   this.player = createPlayer();
@@ -2295,6 +2299,8 @@ QUnit.test('passes useTagCues hls option to master playlist controller', functio
 
   QUnit.ok(this.player.tech_.hls.masterPlaylistController_.useTagCues_,
            'useTagCues passed to master playlist controller');
+
+  videojs.options.hls = origHlsOptions;
 });
 
 QUnit.module('HLS Integration', {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2275,19 +2275,19 @@ QUnit.test('Allows overriding the global beforeRequest function', function() {
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, 'one segment request');
 });
 
-QUnit.test('passes useTagCues hls option to master playlist controller', function() {
+QUnit.test('passes useCueTags hls option to master playlist controller', function() {
   this.player.src({
     src: 'master.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.ok(!this.player.tech_.hls.masterPlaylistController_.useTagCues_,
-           'useTagCues is falsy by default');
+  QUnit.ok(!this.player.tech_.hls.masterPlaylistController_.useCueTags_,
+           'useCueTags is falsy by default');
 
   let origHlsOptions = videojs.options.hls;
 
   videojs.options.hls = {
-    useTagCues: true
+    useCueTags: true
   };
 
   this.player.dispose();
@@ -2297,8 +2297,8 @@ QUnit.test('passes useTagCues hls option to master playlist controller', functio
     type: 'application/vnd.apple.mpegurl'
   });
 
-  QUnit.ok(this.player.tech_.hls.masterPlaylistController_.useTagCues_,
-           'useTagCues passed to master playlist controller');
+  QUnit.ok(this.player.tech_.hls.masterPlaylistController_.useCueTags_,
+           'useCueTags passed to master playlist controller');
 
   videojs.options.hls = origHlsOptions;
 });

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2275,6 +2275,28 @@ QUnit.test('Allows overriding the global beforeRequest function', function() {
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, 'one segment request');
 });
 
+QUnit.test('passes useTagCues hls option to master playlist controller', function() {
+  this.player.src({
+    src: 'master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  QUnit.ok(!this.player.tech_.hls.masterPlaylistController_.useTagCues_,
+           'useTagCues is falsy by default');
+
+  videojs.options.hls.useTagCues = true;
+
+  this.player.dispose();
+  this.player = createPlayer();
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  QUnit.ok(this.player.tech_.hls.masterPlaylistController_.useTagCues_,
+           'useTagCues passed to master playlist controller');
+});
+
 QUnit.module('HLS Integration', {
   beforeEach() {
     this.env = useFakeEnvironment();


### PR DESCRIPTION
## Description
Add support for passing data via video cues when encountering #EXT-X-CUE-OUT, #EXT-X-CUE-OUT-CONT, and #EXT-X-CUE-IN in m3u8. Requires `useCueTags` to be set to true in HLS options.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [X] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors