### PR TITLE
Restore backwards compatibility for overriding HlsHandler's selectPlaylist

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -381,7 +381,8 @@ class HlsHandler extends Component {
     // `this` in selectPlaylist should be the HlsHandler for backwards
     // compatibility with < v2
     this.masterPlaylistController_.selectPlaylist =
-      Hls.STANDARD_PLAYLIST_SELECTOR.bind(this);
+      this.selectPlaylist ?
+        this.selectPlaylist.bind(this) : Hls.STANDARD_PLAYLIST_SELECTOR.bind(this);
 
     // re-expose some internal objects for backwards compatibility with < v2
     this.playlists = this.masterPlaylistController_.masterPlaylistLoader_;


### PR DESCRIPTION
## Description

Restores backwards compatibility for overriding HlsHandler's selectPlaylist. For instance, it used to be OK to have:

```javascript
videojs.HlsHandler.prototype.selectPlaylist = function() {
  ...
};
```

This was lost during one of the migrations. This restores that functionality.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
