### PR TITLE
Ad cues

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,8 @@ for more info.
 * can be used as an initialization option
 
 When the `useCueTags` property is set to `true,` a text track is created with
-label 'hls-segment-metadata' and kind 'metadata'. The track is then added to
-`player.textTracks()`. Whenever a segment associated with a cue tag is playing,
-the cue tags will be listed as a properties inside of a stringified JSON object
-under its active cue's `text` property. The properties that are currently
-supported are cueOut, cueOutCont, and cueIn. Changes in active cue may be
+label 'ad-cues' and kind 'metadata'. The track is then added to
+`player.textTracks()`. Changes in active cue may be
 tracked by following the Video.js cue points API for text tracks. For example:
 
 ```javascript
@@ -230,7 +227,7 @@ let textTracks = player.textTracks();
 let cuesTrack;
 
 for (let i = 0; i < textTracks.length; i++) {
-  if (textTracks[i].label === 'hls-segment-metadata') {
+  if (textTracks[i].label === 'ad-cues') {
     cuesTrack = textTracks[i];
   }
 }
@@ -240,12 +237,9 @@ cuesTrack.addEventListener('cuechange', function() {
 
   for (let i = 0; i < activeCues.length; i++) {
     let activeCue = activeCues[i];
-    let cueData = JSON.parse(activeCue.text);
 
     console.log('Cue runs from ' + activeCue.startTime +
-                ' to ' + activeCue.endTime +
-                ' with cue tag contents ' +
-                (cueData.cueOut || cueData.cueOutCont || cueData.cueIn));
+                ' to ' + activeCue.endTime);
   }
 });
 ```

--- a/src/ad-cue-tags.js
+++ b/src/ad-cue-tags.js
@@ -20,10 +20,10 @@ const findAdCue = function(track, mediaTime) {
 };
 
 const initAdCueTrack = function(controller) {
-      controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata',
-        'hls-segment-metadata');
-      controller.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
-      controller.tech_.textTracks().addTrack_(controller.cueTagsTrack_);
+  controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata',
+    'hls-segment-metadata');
+  controller.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
+  controller.tech_.textTracks().addTrack_(controller.cueTagsTrack_);
 };
 
 const updateAdCues = function(media, track, offset = 0) {

--- a/src/ad-cue-tags.js
+++ b/src/ad-cue-tags.js
@@ -20,7 +20,8 @@ const findAdCue = function(track, mediaTime) {
 };
 
 const initAdCueTrack = function(controller) {
-      controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata', 'hls-segment-metadata');
+      controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata',
+        'hls-segment-metadata');
       controller.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
       controller.tech_.textTracks().addTrack_(controller.cueTagsTrack_);
 };

--- a/src/ad-cue-tags.js
+++ b/src/ad-cue-tags.js
@@ -61,7 +61,7 @@ const updateAdCues = function(media, track, offset = 0) {
       if ('cueOut' in segment) {
         cue = new window.VTTCue(mediaTime,
                                 mediaTime + segment.duration,
-                                '');
+                                segment.cueOut);
         cue.adStartTime = mediaTime;
         // Assumes tag format to be
         // #EXT-X-CUE-OUT:30

--- a/src/ad-cue-tags.js
+++ b/src/ad-cue-tags.js
@@ -19,13 +19,6 @@ const findAdCue = function(track, mediaTime) {
   return null;
 };
 
-const initAdCueTrack = function(controller) {
-  controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata',
-    'hls-segment-metadata');
-  controller.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
-  controller.tech_.textTracks().addTrack_(controller.cueTagsTrack_);
-};
-
 const updateAdCues = function(media, track, offset = 0) {
   if (!media.segments) {
     return;
@@ -46,7 +39,6 @@ const updateAdCues = function(media, track, offset = 0) {
     }
 
     if (cue) {
-
       if ('cueIn' in segment) {
         // Found a CUE-IN so end the cue
         cue.endTime = mediaTime;
@@ -94,13 +86,11 @@ const updateAdCues = function(media, track, offset = 0) {
         track.addCue(cue);
       }
     }
-
     mediaTime += segment.duration;
   }
 };
 
 export default {
-  initAdCueTrack,
   updateAdCues,
   findAdCue
 };

--- a/src/ad-cue-tags.js
+++ b/src/ad-cue-tags.js
@@ -1,0 +1,106 @@
+/**
+ * @file ad-cue-tags.js
+ */
+import window from 'global/window';
+
+/**
+ * Searches for an ad cue that overlaps with the given mediaTime
+ */
+const findAdCue = function(track, mediaTime) {
+  let cues = track.cues;
+
+  for (let i = 0; i < cues.length; i++) {
+    let cue = cues[i];
+
+    if (mediaTime >= cue.adStartTime && mediaTime <= cue.adEndTime) {
+      return cue;
+    }
+  }
+  return null;
+};
+
+const initAdCueTrack = function(controller) {
+      controller.cueTagsTrack_ = controller.tech_.addTextTrack('metadata', 'hls-segment-metadata');
+      controller.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
+      controller.tech_.textTracks().addTrack_(controller.cueTagsTrack_);
+};
+
+const updateAdCues = function(media, track, offset = 0) {
+  if (!media.segments) {
+    return;
+  }
+
+  let mediaTime = offset;
+  let cue;
+
+  for (let i = 0; i < media.segments.length; i++) {
+    let segment = media.segments[i];
+
+    if (!cue) {
+      // Since the cues will span for at least the segment duration, adding a fudge
+      // factor of half segment duration will prevent duplicate cues from being
+      // created when timing info is not exact (e.g. cue start time initialized
+      // at 10.006677, but next call mediaTime is 10.003332 )
+      cue = findAdCue(track, mediaTime + (segment.duration / 2));
+    }
+
+    if (cue) {
+
+      if ('cueIn' in segment) {
+        // Found a CUE-IN so end the cue
+        cue.endTime = mediaTime;
+        cue.adEndTime = mediaTime;
+        mediaTime += segment.duration;
+        cue = null;
+        continue;
+      }
+
+      if (mediaTime < cue.endTime) {
+        // Already processed this mediaTime for this cue
+        mediaTime += segment.duration;
+        continue;
+      }
+
+      // otherwise extend cue until a CUE-IN is found
+      cue.endTime += segment.duration;
+
+    } else {
+      if ('cueOut' in segment) {
+        cue = new window.VTTCue(mediaTime,
+                                mediaTime + segment.duration,
+                                '');
+        cue.adStartTime = mediaTime;
+        // Assumes tag format to be
+        // #EXT-X-CUE-OUT:30
+        cue.adEndTime = mediaTime + parseFloat(segment.cueOut);
+        track.addCue(cue);
+      }
+
+      if ('cueOutCont' in segment) {
+        // Entered into the middle of an ad cue
+        let adOffset;
+        let adTotal;
+
+        // Assumes tag formate to be
+        // #EXT-X-CUE-OUT-CONT:10/30
+        [adOffset, adTotal] = segment.cueOutCont.split('/').map(parseFloat);
+
+        cue = new window.VTTCue(mediaTime,
+                                mediaTime + segment.duration,
+                                '');
+        cue.adStartTime = mediaTime - adOffset;
+        cue.adEndTime = cue.adStartTime + adTotal;
+        track.addCue(cue);
+      }
+    }
+
+    mediaTime += segment.duration;
+  }
+};
+
+export default {
+  initAdCueTrack,
+  updateAdCues,
+  findAdCue
+};
+

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -36,17 +36,18 @@ const parseCodecs = function(codecs) {
 /**
  * Searches for an ad cue that overlaps with the given mediaTime
  */
-var findAdCue = function(track, mediaTime) {
+const findAdCue = function(track, mediaTime) {
   let cues = track.cues;
 
   for (let i = 0; i < cues.length; i++) {
     let cue = cues[i];
+
     if (mediaTime >= cue.adStartTime && mediaTime <= cue.adEndTime) {
       return cue;
     }
   }
   return undefined;
-}
+};
 
 /**
  * the master playlist controller controller all interactons
@@ -863,8 +864,8 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         if ('cueIn' in segment) {
           // Found a CUE-IN so end the cue
           if (mediaTime !== cue.endTime) {
-            // If the end time does not match the current mediaTime, a CUE-IN may have been
-            // inserted earlier than expected, so the cue should be updated.
+            // If the end time does not match the current mediaTime, a CUE-IN may have
+            // been inserted earlier than expected, so the cue should be updated.
             cue.endTime = mediaTime;
             cue.adEndTime = mediaTime;
           }
@@ -882,15 +883,16 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         // otherwise extend cue until a CUE-IN is found
         cue.endTime += segment.duration;
 
-      } else { // cue === undefined
-        // Since the cues will span for at least the segment duration, adding a fudge factor of
-        // half segment duration will prevent duplicate cues from being created when timing
-        // info is not exact (e.g. cue start time initialized at 10.006677, but next call
-        // mediaTime is 10.003332 )
-        cue = findAdCue(track, mediaTime + (segment.duration/2));
+      } else {
+        // Since the cues will span for at least the segment duration, adding a fudge
+        // factor of half segment duration will prevent duplicate cues from being
+        // created when timing info is not exact (e.g. cue start time initialized
+        // at 10.006677, but next call mediaTime is 10.003332 )
+        cue = findAdCue(track, mediaTime + (segment.duration / 2));
         if (cue) {
           // there is a cue already created for this mediaTime
-          // decrement i and not increase mediaTime to handle this segment again with this cue
+          // decrement i and not increase mediaTime to handle this segment
+          // again with this cue
           i--;
           continue;
         }
@@ -906,8 +908,12 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
         if ('cueOutCont' in segment) {
           // Entered into the middle of an ad cue
-          let adOffset, adTotal;
-          [adOffset, adTotal] = segment.cueOutCont.split('/').map((value) => parseFloat(value));
+          let adOffset;
+          let adTotal;
+
+          [adOffset, adTotal] = segment.cueOutCont.split('/').map((value) => {
+            parseFloat(value);
+          });
 
           cue = new window.VTTCue(mediaTime,
                                   mediaTime + segment.duration,

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -879,10 +879,15 @@ export default class MasterPlaylistController extends videojs.EventTarget {
           continue;
         }
 
+        // otherwise extend cue until a CUE-IN is found
         cue.endTime += segment.duration;
 
       } else { // cue === undefined
-        cue = findAdCue(track, mediaTime);
+        // Since the cues will span for at least the segment duration, adding a fudge factor of
+        // half segment duration will prevent duplicate cues from being created when timing
+        // info is not exact (e.g. cue start time initialized at 10.006677, but next call
+        // mediaTime is 10.003332 )
+        cue = findAdCue(track, mediaTime + (segment.duration/2));
         if (cue) {
           // there is a cue already created for this mediaTime
           // decrement i and not increase mediaTime to handle this segment again with this cue
@@ -893,7 +898,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         if ('cueOut' in segment) {
           cue = new window.VTTCue(mediaTime,
                                   mediaTime + segment.duration,
-                                  segment.cueOut);
+                                  '');
           cue.adStartTime = mediaTime;
           cue.adEndTime = mediaTime + parseFloat(segment.cueOut);
           track.addCue(cue);
@@ -906,7 +911,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
 
           cue = new window.VTTCue(mediaTime,
                                   mediaTime + segment.duration,
-                                  '' + adTotal);
+                                  '');
           cue.adStartTime = mediaTime - adOffset;
           cue.adEndTime = cue.adStartTime + adTotal;
           track.addCue(cue);

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -62,7 +62,10 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.mode_ = mode;
     this.useCueTags_ = useCueTags;
     if (this.useCueTags_) {
-      AdCueTags.initAdCueTrack(this);
+      this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
+        'hls-segment-metadata');
+      this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
+      this.tech_.textTracks().addTrack_(this.cueTagsTrack_);
     }
 
     this.audioTracks_ = [];

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -63,7 +63,7 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     this.useCueTags_ = useCueTags;
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
-        'hls-segment-metadata');
+        'ad-cues');
       this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
       this.tech_.textTracks().addTrack_(this.cueTagsTrack_);
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -6,7 +6,6 @@ import SegmentLoader from './segment-loader';
 import Ranges from './ranges';
 import videojs from 'video.js';
 import HlsAudioTrack from './hls-audio-track';
-import window from 'global/window';
 import AdCueTags from './ad-cue-tags';
 
 // 5 minute blacklist

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -37,17 +37,18 @@ const parseCodecs = function(codecs) {
 /**
  * Searches for an ad cue that overlaps with the given mediaTime
  */
-var findAdCue = function(track, mediaTime) {
+const findAdCue = function(track, mediaTime) {
   let cues = track.cues;
 
   for (let i = 0; i < cues.length; i++) {
     let cue = cues[i];
+
     if (mediaTime >= cue.adStartTime && mediaTime <= cue.adEndTime) {
       return cue;
     }
   }
   return undefined;
-}
+};
 
 /**
  * the master playlist controller controller all interactons

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -35,22 +35,6 @@ const parseCodecs = function(codecs) {
 };
 
 /**
- * Searches for an ad cue that overlaps with the given mediaTime
- */
-export const findAdCue = function(track, mediaTime) {
-  let cues = track.cues;
-
-  for (let i = 0; i < cues.length; i++) {
-    let cue = cues[i];
-
-    if (mediaTime >= cue.adStartTime && mediaTime <= cue.adEndTime) {
-      return cue;
-    }
-  }
-  return null;
-};
-
-/**
  * the master playlist controller controller all interactons
  * between playlists and segmentloaders. At this time this mainly
  * involves a master playlist and a series of audio playlists

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -35,6 +35,21 @@ const parseCodecs = function(codecs) {
 };
 
 /**
+ * Searches for an ad cue that overlaps with the given mediaTime
+ */
+var findAdCue = function(track, mediaTime) {
+  let cues = track.cues;
+
+  for (let i = 0; i < cues.length; i++) {
+    let cue = cues[i];
+    if (mediaTime >= cue.adStartTime && mediaTime <= cue.adEndTime) {
+      return cue;
+    }
+  }
+  return undefined;
+}
+
+/**
  * the master playlist controller controller all interactons
  * between playlists and segmentloaders. At this time this mainly
  * involves a master playlist and a series of audio playlists

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -37,7 +37,7 @@ const parseCodecs = function(codecs) {
 /**
  * Searches for an ad cue that overlaps with the given mediaTime
  */
-const findAdCue = function(track, mediaTime) {
+export const findAdCue = function(track, mediaTime) {
   let cues = track.cues;
 
   for (let i = 0; i < cues.length; i++) {
@@ -47,7 +47,7 @@ const findAdCue = function(track, mediaTime) {
       return cue;
     }
   }
-  return undefined;
+  return null;
 };
 
 /**

--- a/test/ad-cue-tags.test.js
+++ b/test/ad-cue-tags.test.js
@@ -258,9 +258,13 @@ QUnit.test('correctly handle multiple ad cues', function() {
 
   QUnit.equal(this.track.cues.length, 2, 'correctly created 2 cues for the ads');
   QUnit.equal(this.track.cues[0].startTime, 30, 'cue created at correct start time');
-  QUnit.equal(this.track.cues[0].endTime, 60, 'cue created at correct end time');
+  QUnit.equal(this.track.cues[0].endTime, 60, 'cue has correct end time');
+  QUnit.equal(this.track.cues[0].adStartTime, 30, 'cue has correct ad start time');
+  QUnit.equal(this.track.cues[0].adEndTime, 60, 'cue has correct ad end time');
   QUnit.equal(this.track.cues[1].startTime, 100, 'cue created at correct start time');
-  QUnit.equal(this.track.cues[1].endTime, 120, 'cue created at correct end time');
+  QUnit.equal(this.track.cues[1].endTime, 120, 'cue has correct end time');
+  QUnit.equal(this.track.cues[1].adStartTime, 100, 'cue has correct ad start time');
+  QUnit.equal(this.track.cues[1].adEndTime, 120, 'cue has correct ad end time');
 });
 
 QUnit.test('findAdCue returns correct cue', function() {
@@ -289,4 +293,7 @@ QUnit.test('findAdCue returns correct cue', function() {
 
   cue = AdCueTags.findAdCue(this.track, 120);
   QUnit.equal(cue.adStartTime, 100, 'returned correct cue');
+
+  cue = AdCueTags.findAdCue(this.track, 45);
+  QUnit.equal(cue.adStartTime, 45, 'returned correct cue');
 });

--- a/test/ad-cue-tags.test.js
+++ b/test/ad-cue-tags.test.js
@@ -1,0 +1,290 @@
+import AdCueTags from '../src/ad-cue-tags'
+
+QUnit.module('AdCueTags', {
+  beforeEach() {
+    this.track = {
+      cues: [],
+      addCue(cue) {
+        this.cues.push(cue);
+      },
+      clearTrack() {
+        this.cues = [];
+      }
+    }
+  }
+});
+
+QUnit.test('update tag cues', function() {
+
+  let testCue = new window.VTTCue(0, 10, 'test');
+
+  this.track.addCue(testCue);
+
+  AdCueTags.updateAdCues({}, this.track);
+
+  QUnit.equal(this.track.cues.length,
+              1,
+              'does not change cues if media does not have segment property');
+  QUnit.equal(this.track.cues[0],
+              testCue,
+              'does not change cues if media does not have segment property');
+
+  AdCueTags.updateAdCues({
+    segments: []
+  }, this.track);
+
+  QUnit.equal(this.track.cues.length,
+              1,
+              'does not remove cues even if no segments in playlist');
+
+  this.track.clearTrack();
+
+  AdCueTags.updateAdCues({
+    segments: [{
+      duration: 5.1,
+      cueOut: '11.5'
+    }, {
+      duration: 6.4,
+      cueOutCont: '5.1/11.5'
+    }, {
+      duration: 6,
+      cueIn: ''
+    }]
+  }, this.track, 10);
+
+  QUnit.equal(this.track.cues.length, 1, 'adds a single cue for entire ad');
+
+  testCue = this.track.cues[0];
+  QUnit.equal(testCue.startTime, 10, 'cue starts at 10');
+  QUnit.equal(testCue.endTime, 21.5, 'cue ends at start time plus duration');
+
+  this.track.clearTrack();
+
+  AdCueTags.updateAdCues({
+    segments: [{
+      duration: 10,
+      cueOutCont: '10/30'
+    }, {
+      duration: 10,
+      cueOutCont: '20/30'
+    }, {
+      duration: 10,
+      cueIn: ''
+    }]
+  }, this.track);
+
+  QUnit.equal(this.track.cues.length, 1,
+    'adds a single cue for entire ad when entering mid cue-out-cont');
+
+  testCue = this.track.cues[0];
+  QUnit.equal(testCue.startTime, 0, 'cue starts at 0');
+  QUnit.equal(testCue.endTime, 20, 'cue ends at start time plus duration');
+  QUnit.equal(testCue.adStartTime, -10, 'cue ad starts at -10');
+  QUnit.equal(testCue.adEndTime, 20, 'cue ad ends at 20');
+});
+
+QUnit.test('update incomplete cue in live playlist situation', function() {
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10,
+        cueOut: '30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      }
+    ]
+  }, this.track, 10);
+
+  QUnit.equal(this.track.cues.length, 1, 'adds a single cue for new ad');
+
+  let testCue = this.track.cues[0];
+
+  QUnit.equal(testCue.startTime, 10, 'cue starts at 10');
+  QUnit.equal(testCue.endTime, 30, 'cue ends at start time plus segment durations');
+  QUnit.equal(testCue.adStartTime, 10, 'cue ad starts at 10');
+  QUnit.equal(testCue.adEndTime, 40, 'cue ad ends at 40');
+
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      }
+    ]
+  }, this.track, 20);
+
+  QUnit.equal(this.track.cues.length, 1, 'did not remove cue or add a new one');
+
+  QUnit.equal(testCue.startTime, 10, 'cue still starts at 10');
+  QUnit.equal(testCue.endTime, 40, 'cue end updated to include next segment duration');
+  QUnit.equal(testCue.adStartTime, 10, 'cue ad still starts at 10');
+  QUnit.equal(testCue.adEndTime, 40, 'cue ad still ends at 40');
+
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      }
+    ]
+  }, this.track, 30);
+
+  QUnit.equal(this.track.cues.length, 1, 'did not remove cue or add a new one');
+
+  QUnit.equal(testCue.startTime, 10, 'cue still starts at 10');
+  QUnit.equal(testCue.endTime, 40, 'cue end still 40');
+  QUnit.equal(testCue.adStartTime, 10, 'cue ad still starts at 10');
+  QUnit.equal(testCue.adEndTime, 40, 'cue ad still ends at 40');
+});
+
+QUnit.test('adjust cue end time in event of early CUE-IN', function() {
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10,
+        cueOut: '30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      }
+    ]
+  }, this.track, 10);
+
+  QUnit.equal(this.track.cues.length, 1, 'adds a single cue for new ad');
+
+  let testCue = this.track.cues[0];
+
+  QUnit.equal(testCue.startTime, 10, 'cue starts at 10');
+  QUnit.equal(testCue.endTime, 40, 'cue ends at start time plus segment durations');
+  QUnit.equal(testCue.adStartTime, 10, 'cue ad starts at 10');
+  QUnit.equal(testCue.adEndTime, 40, 'cue ad ends at 40');
+
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      }
+    ]
+  }, this.track, 20);
+
+  QUnit.equal(this.track.cues.length, 1, 'did not remove cue or add a new one');
+
+  QUnit.equal(testCue.startTime, 10, 'cue still starts at 10');
+  QUnit.equal(testCue.endTime, 30, 'cue end updated to 30');
+  QUnit.equal(testCue.adStartTime, 10, 'cue ad still starts at 10');
+  QUnit.equal(testCue.adEndTime, 30,
+    'cue ad end updated to 30 to account for early cueIn');
+});
+
+QUnit.test('correctly handle multiple ad cues', function() {
+  AdCueTags.updateAdCues({
+    segments: [
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '20'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/20'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      }
+    ]
+  }, this.track);
+
+  QUnit.equal(this.track.cues.length, 2, 'correctly created 2 cues for the ads');
+  QUnit.equal(this.track.cues[0].startTime, 30, 'cue created at correct start time');
+  QUnit.equal(this.track.cues[0].endTime, 60, 'cue created at correct end time');
+  QUnit.equal(this.track.cues[1].startTime, 100, 'cue created at correct start time');
+  QUnit.equal(this.track.cues[1].endTime, 120, 'cue created at correct end time');
+});
+
+QUnit.test('findAdCue returns correct cue', function() {
+  this.track.cues = [
+    {
+      adStartTime: 0,
+      adEndTime: 30
+    },
+    {
+      adStartTime: 45,
+      adEndTime: 55
+    },
+    {
+      adStartTime: 100,
+      adEndTime: 120
+    }
+  ];
+
+  let cue;
+
+  cue = AdCueTags.findAdCue(this.track, 15);
+  QUnit.equal(cue.adStartTime, 0, 'returned correct cue');
+
+  cue = AdCueTags.findAdCue(this.track, 40);
+  QUnit.equal(cue, null, 'cue not found, returned null');
+
+  cue = AdCueTags.findAdCue(this.track, 120);
+  QUnit.equal(cue.adStartTime, 100, 'returned correct cue');
+});

--- a/test/ad-cue-tags.test.js
+++ b/test/ad-cue-tags.test.js
@@ -1,4 +1,6 @@
-import AdCueTags from '../src/ad-cue-tags'
+import QUnit from 'qunit';
+import AdCueTags from '../src/ad-cue-tags';
+import window from 'global/window';
 
 QUnit.module('AdCueTags', {
   beforeEach() {
@@ -10,7 +12,7 @@ QUnit.module('AdCueTags', {
       clearTrack() {
         this.cues = [];
       }
-    }
+    };
   }
 });
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -7,7 +7,7 @@ import {
   standardXHRResponse,
   openMediaSource
 } from './test-helpers.js';
-import MasterPlaylistController from '../src/master-playlist-controller';
+import {default as MasterPlaylistController, findAdCue} from '../src/master-playlist-controller';
 /* eslint-disable no-unused-vars */
 // we need this so that it can register hls with videojs
 import { Hls } from '../src/videojs-contrib-hls';
@@ -702,4 +702,34 @@ QUnit.test('respects useCueTags option', function() {
            'adds cueTagsTrack as a text track if useCueTags is truthy');
 
   videojs.options.hls = origHlsOptions;
+});
+
+QUnit.test('findAdCue returns correct cue', function() {
+  let track = {
+    cues: [
+      {
+        adStartTime: 0,
+        adEndTime: 30
+      },
+      {
+        adStartTime: 45,
+        adEndTime: 55
+      },
+      {
+        adStartTime: 100,
+        adEndTime: 120
+      }
+    ]
+  };
+
+  let cue;
+
+  cue = findAdCue(track, 15);
+  QUnit.equal(cue.adStartTime, 0, 'returned correct cue');
+
+  cue = findAdCue(track, 40);
+  QUnit.equal(cue, null, 'cue not found, returned null');
+
+  cue = findAdCue(track, 120);
+  QUnit.equal(cue.adStartTime, 100, 'returned correct cue');
 });

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -957,6 +957,85 @@ QUnit.test('adjust cue end time in event of early CUE-IN', function() {
   videojs.options.hls = origHlsOptions;
 });
 
+QUnit.test('correctly handle multiple ad cues', function() {
+  let origHlsOptions = videojs.options.hls;
+
+  videojs.options.hls = {
+    useCueTags: true
+  };
+
+  this.player = createPlayer();
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+  let cueTagsTrack = this.masterPlaylistController.cueTagsTrack_;
+
+  this.masterPlaylistController.updateCues_({
+    segments: [
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '20'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/20'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      }
+    ]
+  });
+
+  QUnit.equal(cueTagsTrack.cues.length, 2, 'correctly created 2 cues for the ads');
+  QUnit.equal(cueTagsTrack.cues[0].startTime, 30, 'cue created at correct start time');
+  QUnit.equal(cueTagsTrack.cues[0].endTime, 60, 'cue created at correct end time');
+  QUnit.equal(cueTagsTrack.cues[1].startTime, 100, 'cue created at correct start time');
+  QUnit.equal(cueTagsTrack.cues[1].endTime, 120, 'cue created at correct end time');
+
+  videojs.options.hls = origHlsOptions;
+});
+
 QUnit.test('findAdCue returns correct cue', function() {
   let track = {
     cues: [

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -704,6 +704,85 @@ QUnit.test('respects useCueTags option', function() {
   videojs.options.hls = origHlsOptions;
 });
 
+QUnit.test('correctly handle multiple ad cues', function() {
+  let origHlsOptions = videojs.options.hls;
+
+  videojs.options.hls = {
+    useCueTags: true
+  };
+
+  this.player = createPlayer();
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+  let cueTagsTrack = this.masterPlaylistController.cueTagsTrack_;
+
+  this.masterPlaylistController.updateCues_({
+    segments: [
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/30'
+      },
+      {
+        duration: 10,
+        cueOutCont: '20/30'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10
+      },
+      {
+        duration: 10,
+        cueOut: '20'
+      },
+      {
+        duration: 10,
+        cueOutCont: '10/20'
+      },
+      {
+        duration: 10,
+        cueIn: ''
+      },
+      {
+        duration: 10
+      }
+    ]
+  });
+
+  QUnit.equal(cueTagsTrack.cues.length, 2, 'correctly created 2 cues for the ads');
+  QUnit.equal(cueTagsTrack.cues[0].startTime, 30, 'cue created at correct start time');
+  QUnit.equal(cueTagsTrack.cues[0].endTime, 60, 'cue created at correct end time');
+  QUnit.equal(cueTagsTrack.cues[1].startTime, 100, 'cue created at correct start time');
+  QUnit.equal(cueTagsTrack.cues[1].endTime, 120, 'cue created at correct end time');
+
+  videojs.options.hls = origHlsOptions;
+});
+
 QUnit.test('findAdCue returns correct cue', function() {
   let track = {
     cues: [

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -7,7 +7,7 @@ import {
   standardXHRResponse,
   openMediaSource
 } from './test-helpers.js';
-import MasterPlaylistController from '../src/master-playlist-controller';
+import {default as MasterPlaylistController, findAdCue} from '../src/master-playlist-controller';
 /* eslint-disable no-unused-vars */
 // we need this so that it can register hls with videojs
 import { Hls } from '../src/videojs-contrib-hls';
@@ -804,8 +804,6 @@ QUnit.test('update tag cues', function() {
   QUnit.equal(testCue.adStartTime, -10, 'cue ad starts at -10');
   QUnit.equal(testCue.adEndTime, 20, 'cue ad ends at 20');
 
-  cueTagsTrack.removeCue(testCue);
-
   videojs.options.hls = origHlsOptions;
 });
 
@@ -957,4 +955,34 @@ QUnit.test('adjust cue end time in event of early CUE-IN', function() {
     'cue ad end updated to 30 to account for early cueIn');
 
   videojs.options.hls = origHlsOptions;
+});
+
+QUnit.test('findAdCue returns correct cue', function() {
+  let track = {
+    cues: [
+      {
+        adStartTime: 0,
+        adEndTime: 30
+      },
+      {
+        adStartTime: 45,
+        adEndTime: 55
+      },
+      {
+        adStartTime: 100,
+        adEndTime: 120
+      }
+    ]
+  };
+
+  let cue;
+
+  cue = findAdCue(track, 15);
+  QUnit.equal(cue.adStartTime, 0, 'returned correct cue');
+
+  cue = findAdCue(track, 40);
+  QUnit.equal(cue, null, 'cue not found, returned null');
+
+  cue = findAdCue(track, 120);
+  QUnit.equal(cue.adStartTime, 100, 'returned correct cue');
 });

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -695,8 +695,8 @@ QUnit.test('respects useCueTags option', function() {
   QUnit.ok(this.masterPlaylistController.cueTagsTrack_,
            'creates cueTagsTrack_ if useCueTags is truthy');
   QUnit.equal(this.masterPlaylistController.cueTagsTrack_.label,
-              'hls-segment-metadata',
-              'cueTagsTrack_ has label of hls-segment-metadata');
+              'ad-cues',
+              'cueTagsTrack_ has label of ad-cues');
   QUnit.equal(this.player.textTracks()[0], this.masterPlaylistController.cueTagsTrack_,
            'adds cueTagsTrack as a text track if useCueTags is truthy');
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -7,7 +7,7 @@ import {
   standardXHRResponse,
   openMediaSource
 } from './test-helpers.js';
-import {default as MasterPlaylistController, findAdCue} from '../src/master-playlist-controller';
+import MasterPlaylistController from '../src/master-playlist-controller';
 /* eslint-disable no-unused-vars */
 // we need this so that it can register hls with videojs
 import { Hls } from '../src/videojs-contrib-hls';
@@ -702,113 +702,4 @@ QUnit.test('respects useCueTags option', function() {
            'adds cueTagsTrack as a text track if useCueTags is truthy');
 
   videojs.options.hls = origHlsOptions;
-});
-
-QUnit.test('correctly handle multiple ad cues', function() {
-  let origHlsOptions = videojs.options.hls;
-
-  videojs.options.hls = {
-    useCueTags: true
-  };
-
-  this.player = createPlayer();
-  this.player.src({
-    src: 'manifest/master.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
-
-  let cueTagsTrack = this.masterPlaylistController.cueTagsTrack_;
-
-  this.masterPlaylistController.updateCues_({
-    segments: [
-      {
-        duration: 10
-      },
-      {
-        duration: 10
-      },
-      {
-        duration: 10
-      },
-      {
-        duration: 10,
-        cueOut: '30'
-      },
-      {
-        duration: 10,
-        cueOutCont: '10/30'
-      },
-      {
-        duration: 10,
-        cueOutCont: '20/30'
-      },
-      {
-        duration: 10,
-        cueIn: ''
-      },
-      {
-        duration: 10
-      },
-      {
-        duration: 10
-      },
-      {
-        duration: 10
-      },
-      {
-        duration: 10,
-        cueOut: '20'
-      },
-      {
-        duration: 10,
-        cueOutCont: '10/20'
-      },
-      {
-        duration: 10,
-        cueIn: ''
-      },
-      {
-        duration: 10
-      }
-    ]
-  });
-
-  QUnit.equal(cueTagsTrack.cues.length, 2, 'correctly created 2 cues for the ads');
-  QUnit.equal(cueTagsTrack.cues[0].startTime, 30, 'cue created at correct start time');
-  QUnit.equal(cueTagsTrack.cues[0].endTime, 60, 'cue created at correct end time');
-  QUnit.equal(cueTagsTrack.cues[1].startTime, 100, 'cue created at correct start time');
-  QUnit.equal(cueTagsTrack.cues[1].endTime, 120, 'cue created at correct end time');
-
-  videojs.options.hls = origHlsOptions;
-});
-
-QUnit.test('findAdCue returns correct cue', function() {
-  let track = {
-    cues: [
-      {
-        adStartTime: 0,
-        adEndTime: 30
-      },
-      {
-        adStartTime: 45,
-        adEndTime: 55
-      },
-      {
-        adStartTime: 100,
-        adEndTime: 120
-      }
-    ]
-  };
-
-  let cue;
-
-  cue = findAdCue(track, 15);
-  QUnit.equal(cue.adStartTime, 0, 'returned correct cue');
-
-  cue = findAdCue(track, 40);
-  QUnit.equal(cue, null, 'cue not found, returned null');
-
-  cue = findAdCue(track, 120);
-  QUnit.equal(cue.adStartTime, 100, 'returned correct cue');
 });

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -841,6 +841,7 @@ QUnit.test('update incomplete cue in live playlist situation', function() {
   QUnit.equal(cueTagsTrack.cues.length, 1, 'adds a single cue for new ad');
 
   let testCue = cueTagsTrack.cues[0];
+
   QUnit.equal(testCue.startTime, 10, 'cue starts at 10');
   QUnit.equal(testCue.endTime, 30, 'cue ends at start time plus segment durations');
   QUnit.equal(testCue.adStartTime, 10, 'cue ad starts at 10');
@@ -925,6 +926,7 @@ QUnit.test('adjust cue end time in event of early CUE-IN', function() {
   QUnit.equal(cueTagsTrack.cues.length, 1, 'adds a single cue for new ad');
 
   let testCue = cueTagsTrack.cues[0];
+
   QUnit.equal(testCue.startTime, 10, 'cue starts at 10');
   QUnit.equal(testCue.endTime, 40, 'cue ends at start time plus segment durations');
   QUnit.equal(testCue.adStartTime, 10, 'cue ad starts at 10');
@@ -951,7 +953,8 @@ QUnit.test('adjust cue end time in event of early CUE-IN', function() {
   QUnit.equal(testCue.startTime, 10, 'cue still starts at 10');
   QUnit.equal(testCue.endTime, 30, 'cue end updated to 30');
   QUnit.equal(testCue.adStartTime, 10, 'cue ad still starts at 10');
-  QUnit.equal(testCue.adEndTime, 30, 'cue ad end updated to 30 to account for early cueIn');
+  QUnit.equal(testCue.adEndTime, 30,
+    'cue ad end updated to 30 to account for early cueIn');
 
   videojs.options.hls = origHlsOptions;
 });

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -13,7 +13,6 @@ import MasterPlaylistController from '../src/master-playlist-controller';
 import { Hls } from '../src/videojs-contrib-hls';
 /* eslint-enable no-unused-vars */
 import Playlist from '../src/playlist';
-import window from 'global/window';
 
 QUnit.module('MasterPlaylistController', {
   beforeEach() {


### PR DESCRIPTION
## Description
Provide a better cue structure for ad related cues. This PR only handles creating cues for `#EXT-X-CUE-OUT`, `#EXT-X-CUE-OUT-CONT` and `#EXT-X-CUE-IN` tags. Other ad related cues will eventually be represented in this format as well.

This will also make #802 unnecessary.

Current TextTrack layout:
```
----------------------
  ^co   ^coc   ^ci 
```

Proposed TextTrack layout:
```
-----------------------
  ^^^^^^^^^^ad-cue
```

Proposed cue-format:
```
{
  startTime: 0,
  endTime: 120,
  adStartTime: -10,
  adEndTime: 240
}
```

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
