### PR TITLE
Change timing of SegmentLoader abort on media change

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -155,14 +155,13 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.masterPlaylistLoader_.on('mediachanging', () => {
+      this.mainSegmentLoader_.abort();
       this.mainSegmentLoader_.pause();
     });
 
     this.masterPlaylistLoader_.on('mediachange', () => {
       let media = this.masterPlaylistLoader_.media();
       let requestTimeout = (this.masterPlaylistLoader_.targetDuration * 1.5) * 1000;
-
-      this.mainSegmentLoader_.abort();
 
       // If we don't have any more available playlists, we don't want to
       // timeout the request.

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1629,6 +1629,7 @@ QUnit.test('switching playlists with an outstanding key request aborts request a
   keyXhr = this.requests.shift();
   QUnit.ok(!keyXhr.aborted, 'key request outstanding');
 
+  this.player.tech_.hls.playlists.trigger('mediachanging');
   this.player.tech_.hls.playlists.trigger('mediachange');
 
   QUnit.ok(keyXhr.aborted, 'key request aborted');


### PR DESCRIPTION
## Description
Quickly going in and out of fullscreen causes a race condition that causes the SegmentLoader to get stuck in the `'WAITING'` state after a media change. This results in never requesting more segments. Aborting the SegmentLoader before pausing corrects this issue.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors

