### PR TITLE
SegmentLoader States

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -159,13 +159,14 @@ export default class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.masterPlaylistLoader_.on('mediachanging', () => {
-      this.mainSegmentLoader_.abort();
       this.mainSegmentLoader_.pause();
     });
 
     this.masterPlaylistLoader_.on('mediachange', () => {
       let media = this.masterPlaylistLoader_.media();
       let requestTimeout = (this.masterPlaylistLoader_.targetDuration * 1.5) * 1000;
+
+      this.mainSegmentLoader_.abort();
 
       // If we don't have any more available playlists, we don't want to
       // timeout the request.

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -187,10 +187,11 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    if (this.state === 'WAITING') {
+    if (this.state === 'PRELOAD') {
+      this.state = 'INIT';
+    } else if (this.state === 'WAITING') {
       this.state = 'READY';
-    }
-    if (this.state === 'PAUSING') {
+    } else if (this.state === 'PAUSING') {
       this.state = 'PAUSED';
     }
 
@@ -256,7 +257,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // buffering now
     if (this.sourceUpdater_ &&
         media &&
-        this.state === 'INIT') {
+        this.state === 'PRELOAD') {
       this.state = 'READY';
       return this.fillBuffer_();
     }
@@ -274,19 +275,21 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       this.checkBufferTimeout_ = null;
     }
-    if (this.state === 'READY') {
-      this.state === 'PAUSED';
-    }
-    if (this.state === 'WAITING') {
-      this.state === 'PAUSING';
+    if (this.state === 'PRELOAD') {
+      this.state = 'INIT';
+    } else if (this.state === 'READY') {
+      this.state = 'PAUSED';
+    } else if (this.state === 'WAITING') {
+      this.state = 'PAUSING';
     }
   }
 
   resume() {
-    if (this.state === 'PAUSED') {
+    if (this.state === 'INIT') {
+      this.state = 'PRELOAD';
+    } else if (this.state === 'PAUSED') {
       this.state = 'READY';
-    }
-    if (this.state === 'PAUSING') {
+    } else if (this.state === 'PAUSING') {
       this.state = 'WAITING';
     }
 
@@ -317,7 +320,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       // if we were unpaused but waiting for a sourceUpdater, start
       // buffering now
       if (this.playlist_ &&
-          this.state === 'INIT') {
+          this.state === 'PRELOAD') {
         this.state = 'READY';
         return this.fillBuffer_();
       }
@@ -764,6 +767,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     segmentInfo = this.pendingSegment_;
     segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
+    // this.state = 'DECRYPTING';
+
     if (segment.key) {
       // this is an encrypted segment
       // incrementally decrypt the segment
@@ -789,6 +794,8 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   handleSegment_() {
     let segmentInfo;
+
+    // this.state = 'APPENDING';
 
     segmentInfo = this.pendingSegment_;
     segmentInfo.buffered = this.sourceUpdater_.buffered();

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -252,6 +252,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // buffering now
     if (this.sourceUpdater_ &&
         media &&
+        this.state === 'INIT' &&
         !this.paused()) {
       this.state = 'READY';
       return this.fillBuffer_();
@@ -323,6 +324,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       // if we were unpaused but waiting for a sourceUpdater, start
       // buffering now
       if (this.playlist_ &&
+          this.state === 'INIT' &&
           !this.paused()) {
         this.state = 'READY';
         return this.fillBuffer_();
@@ -809,6 +811,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     this.state = 'APPENDING';
+    this.pendingSegment_ = null;
 
     segmentInfo.buffered = this.sourceUpdater_.buffered();
     this.currentTimeline_ = segmentInfo.timeline;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -501,7 +501,7 @@ QUnit.test('abort does not cancel segment processing in progress', function() {
   this.requests.shift().respond(200, null, '');
 
   loader.abort();
-  QUnit.equal(loader.state, 'APPENDING', 'still appending');
+  QUnit.equal(loader.state, 'READY', 'loader aborted, ready for next segment');
 
   // verify stats
   QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
@@ -867,7 +867,7 @@ QUnit.test('calling load with an encrypted segment waits for both key and segmen
   keyRequest = this.requests.shift();
   keyRequest.response = new Uint32Array([0, 0, 0, 0]).buffer;
   keyRequest.respond(200, null, '');
-  QUnit.equal(loader.state, 'DECRYPTING', 'moves to decrypting state');
+  QUnit.equal(loader.state, 'WAITING', 'moves to decrypting state');
 
   // verify stats
   QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -136,7 +136,7 @@ QUnit.test('calling load should unpause', function() {
 
   loader.load();
   QUnit.ok(!loader.paused(), 'loader unpaused');
-  QUnit.equal(loader.state, 'APPENDING', 'loader still processing')
+  QUnit.equal(loader.state, 'APPENDING', 'loader still processing');
 
   loader.pause();
   sourceBuffer.trigger('updateend');
@@ -460,7 +460,7 @@ QUnit.test('abort cancels segment processing in progress', function() {
   loader.handleSegment_ = function() {};
   loader.paused = function() {
     return true;
-  }
+  };
 
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
@@ -468,7 +468,6 @@ QUnit.test('abort cancels segment processing in progress', function() {
 
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
-
 
   QUnit.equal(loader.state, 'WAITING', 'loader processing request');
   loader.abort();
@@ -486,7 +485,6 @@ QUnit.test('abort does not cancel segment processing during append', function() 
 
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
-
 
   QUnit.equal(loader.state, 'APPENDING', 'loader appending segment');
   loader.abort();
@@ -506,7 +504,6 @@ QUnit.test('pause cancels segment processing before append', function() {
 
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
-
 
   QUnit.equal(loader.state, 'WAITING', 'loader processing segment');
   loader.pause();
@@ -530,7 +527,6 @@ QUnit.test('pause does not cancel segment processing during append', function() 
 
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
-
 
   QUnit.equal(loader.state, 'APPENDING', 'loader appending segment');
   loader.pause();

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -832,8 +832,8 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   segmentRequest = this.requests.pop();
   segmentRequest.response = new Uint8Array(8).buffer;
   segmentRequest.respond(200, null, '');
-  QUnit.ok(segmentInfo.encryptedBytes, 'encrypted bytes in segment');
-  QUnit.ok(!segmentInfo.bytes, 'no decrypted bytes in segment');
+  QUnit.ok(loader.pendingSegment_.encryptedBytes, 'encrypted bytes in segment');
+  QUnit.ok(!loader.pendingSegment_.bytes, 'no decrypted bytes in segment');
 
   keyRequest = this.requests.shift();
   keyRequest.response = new Uint32Array([0, 0, 0, 0]).buffer;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -66,7 +66,7 @@ QUnit.test('fails without required initialization options', function() {
 QUnit.test('load waits until a playlist and mime type are specified to proceed',
 function() {
   loader.load();
-  QUnit.equal(loader.state, 'PRELOAD', 'waiting in init ready to preload');
+  QUnit.equal(loader.state, 'INIT', 'waiting in init ready to preload');
 
   loader.playlist(playlistWithDuration(10));
   QUnit.equal(this.requests.length, 0, 'have not made a request yet');
@@ -124,22 +124,28 @@ QUnit.test('calling load should unpause', function() {
 
   loader.load();
   QUnit.equal(loader.state, 'WAITING', 'loading unpauses');
-
-  loader.pause();
   this.clock.tick(1);
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
 
-  QUnit.equal(loader.state, 'PAUSING', 'stayed paused');
+  QUnit.equal(loader.state, 'APPENDING', 'loader processing response');
+  QUnit.ok(!loader.paused(), 'loader is unpaused');
+  loader.pause();
+  QUnit.equal(loader.state, 'APPENDING', 'loader still processing');
+  QUnit.ok(loader.paused(), 'loader is paused');
+
   loader.load();
-  QUnit.equal(loader.state, 'WAITING', 'unpaused during processing');
+  QUnit.ok(!loader.paused(), 'loader unpaused');
+  QUnit.equal(loader.state, 'APPENDING', 'loader still processing')
 
   loader.pause();
   sourceBuffer.trigger('updateend');
-  QUnit.equal(loader.state, 'PAUSED', 'finished processing and transitioned to paused');
+  QUnit.equal(loader.state, 'READY', 'finished processing and transitioned to ready');
+  QUnit.ok(loader.paused(), 'loader is paused');
 
   loader.load();
   QUnit.equal(loader.state, 'WAITING', 'unpaused');
+  QUnit.ok(!loader.paused(), 'loader unpaused');
 
   // verify stats
   QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
@@ -184,10 +190,10 @@ QUnit.test('does not check the buffer while paused', function() {
   loader.load();
   sourceBuffer = mediaSource.sourceBuffers[0];
 
-  loader.pause();
   this.clock.tick(1);
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
+  loader.pause();
   sourceBuffer.trigger('updateend');
 
   this.clock.tick(10 * 1000);
@@ -365,48 +371,6 @@ QUnit.test('never attempt to load a segment that ' +
   QUnit.equal(loader.mediaRequests, 1, '1 requests');
 });
 
-QUnit.test('adjusts the playlist offset if no buffering progress is made', function() {
-  let sourceBuffer;
-  let playlist;
-
-  playlist = playlistWithDuration(40);
-  playlist.endList = false;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  sourceBuffer = mediaSource.sourceBuffers[0];
-
-  // buffer some content and switch playlists on progress
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  loader.on('progress', function f() {
-    loader.off('progress', f);
-    // switch playlists
-    playlist = playlistWithDuration(40);
-    playlist.uri = 'alternate.m3u8';
-    playlist.endList = false;
-    loader.playlist(playlist);
-  });
-  sourceBuffer.buffered = videojs.createTimeRanges([[0, 5]]);
-  sourceBuffer.trigger('updateend');
-
-  // the next segment doesn't increase the buffer at all
-  QUnit.equal(this.requests[0].url, '0.ts', 'requested the same segment');
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  sourceBuffer.trigger('updateend');
-
-  // so the loader should try the next segment
-  QUnit.equal(this.requests[0].url, '1.ts', 'moved ahead a segment');
-
-  // verify stats
-  QUnit.equal(loader.mediaBytesTransferred, 20, '20 bytes');
-  QUnit.equal(loader.mediaTransferDuration, 2, '2 ms (clocks above)');
-  QUnit.equal(loader.mediaRequests, 2, '2 requests');
-});
-
 QUnit.test('adjusts the playlist offset even when segment.end is set if no' +
            ' buffering progress is made', function() {
   let sourceBuffer;
@@ -492,7 +456,12 @@ QUnit.test('cancels outstanding requests on abort', function() {
   QUnit.equal(loader.state, 'WAITING', 'back to the waiting state');
 });
 
-QUnit.test('abort does not cancel segment processing in progress', function() {
+QUnit.test('abort cancels segment processing in progress', function() {
+  loader.handleSegment_ = function() {};
+  loader.paused = function() {
+    return true;
+  }
+
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -500,8 +469,74 @@ QUnit.test('abort does not cancel segment processing in progress', function() {
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
 
+
+  QUnit.equal(loader.state, 'WAITING', 'loader processing request');
   loader.abort();
   QUnit.equal(loader.state, 'READY', 'loader aborted, ready for next segment');
+
+  // verify stats
+  QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+  QUnit.equal(loader.mediaRequests, 1, '1 request');
+});
+
+QUnit.test('abort does not cancel segment processing during append', function() {
+  loader.playlist(playlistWithDuration(20));
+  loader.mimeType(this.mimeType);
+  loader.load();
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+
+
+  QUnit.equal(loader.state, 'APPENDING', 'loader appending segment');
+  loader.abort();
+  QUnit.equal(loader.state, 'APPENDING', 'loader still appending');
+
+  // verify stats
+  QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+  QUnit.equal(loader.mediaRequests, 1, '1 request');
+});
+
+QUnit.test('pause cancels segment processing before append', function() {
+  loader.handleSegment_ = function() {};
+
+  loader.playlist(playlistWithDuration(20));
+  loader.mimeType(this.mimeType);
+  loader.load();
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+
+
+  QUnit.equal(loader.state, 'WAITING', 'loader processing segment');
+  loader.pause();
+  QUnit.equal(loader.state, 'READY', 'loader is ready to load another segment');
+  QUnit.ok(loader.paused(), 'loader is paused');
+  QUnit.ok(!loader.pendingSegment_, 'pending segment aborted');
+
+  // verify stats
+  QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+  QUnit.equal(loader.mediaRequests, 1, '1 request');
+});
+
+QUnit.test('pause does not cancel segment processing during append', function() {
+  loader.handleSegment_ = function() {
+    loader.state = 'APPENDING';
+  };
+
+  loader.playlist(playlistWithDuration(20));
+  loader.mimeType(this.mimeType);
+  loader.load();
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+
+
+  QUnit.equal(loader.state, 'APPENDING', 'loader appending segment');
+  loader.pause();
+  QUnit.equal(loader.state, 'APPENDING', 'loader still appending');
+  QUnit.ok(loader.paused(), 'loader is paused');
+  QUnit.ok(loader.pendingSegment_, 'loader is still processing appending segment');
 
   // verify stats
   QUnit.equal(loader.mediaBytesTransferred, 10, '10 bytes');
@@ -568,7 +603,7 @@ QUnit.test('segment 404s should trigger an error', function() {
   QUnit.equal(errors.length, 1, 'triggered an error');
   QUnit.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
   QUnit.ok(loader.error().xhr, 'included the request object');
-  QUnit.ok(loader.state === 'PAUSED', 'paused the loader');
+  QUnit.ok(loader.paused(), 'paused the loader');
 });
 
 QUnit.test('segment 5xx status codes trigger an error', function() {
@@ -585,7 +620,7 @@ QUnit.test('segment 5xx status codes trigger an error', function() {
   QUnit.equal(errors.length, 1, 'triggered an error');
   QUnit.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
   QUnit.ok(loader.error().xhr, 'included the request object');
-  QUnit.equal(loader.state, 'PAUSED', 'paused the loader');
+  QUnit.ok(loader.paused(), 'paused the loader');
 });
 
 QUnit.test('fires ended at the end of a playlist', function() {
@@ -724,7 +759,7 @@ QUnit.test('key 404s should trigger an error', function() {
   QUnit.equal(loader.error().message, 'HLS key request error at URL: 0-key.php',
         'receieved a key error message');
   QUnit.ok(loader.error().xhr, 'included the request object');
-  QUnit.equal(loader.state, 'PAUSED', 'paused the loader');
+  QUnit.ok(loader.paused(), 'paused the loader');
 });
 
 QUnit.test('key 5xx status codes trigger an error', function() {
@@ -743,7 +778,7 @@ QUnit.test('key 5xx status codes trigger an error', function() {
   QUnit.equal(loader.error().message, 'HLS key request error at URL: 0-key.php',
         'receieved a key error message');
   QUnit.ok(loader.error().xhr, 'included the request object');
-  QUnit.equal(loader.state, 'PAUSED', 'paused the loader');
+  QUnit.ok(loader.paused(), 'paused the loader');
 });
 
 QUnit.test('the key is saved to the segment in the correct format', function() {
@@ -757,9 +792,7 @@ QUnit.test('the key is saved to the segment in the correct format', function() {
   loader.load();
 
   // stop processing so we can examine segment info
-  loader.processResponse_ = function(response) {
-    segmentInfo = response;
-  };
+  loader.processResponse_ = function() {};
 
   keyRequest = this.requests.shift();
   keyRequest.response = new Uint32Array([0, 1, 2, 3]).buffer;
@@ -769,6 +802,7 @@ QUnit.test('the key is saved to the segment in the correct format', function() {
   segmentRequest.response = new Uint8Array(10).buffer;
   segmentRequest.respond(200, null, '');
 
+  segmentInfo = loader.pendingSegment_;
   segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
   QUnit.deepEqual(segment.key.bytes,
@@ -793,9 +827,7 @@ function() {
   loader.load();
 
   // stop processing so we can examine segment info
-  loader.processResponse_ = function(response) {
-    segmentInfo = response;
-  };
+  loader.processResponse_ = function() {};
 
   keyRequest = this.requests.shift();
   keyRequest.response = new Uint32Array([0, 0, 0, 0]).buffer;
@@ -805,6 +837,7 @@ function() {
   segmentRequest.response = new Uint8Array(10).buffer;
   segmentRequest.respond(200, null, '');
 
+  segmentInfo = loader.pendingSegment_;
   segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
   QUnit.deepEqual(segment.key.iv, new Uint32Array([0, 0, 0, 5]),
@@ -818,12 +851,9 @@ function() {
 QUnit.test('segment with key has decrypted bytes appended during processing', function() {
   let keyRequest;
   let segmentRequest;
-  let segmentInfo;
 
   // stop processing so we can examine segment info
-  loader.handleSegment_ = function(response) {
-    segmentInfo = response;
-  };
+  loader.handleSegment_ = function() {};
 
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
   loader.mimeType(this.mimeType);
@@ -843,7 +873,7 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   this.clock.tick(1);
   // Allow the decrypter's async stream to run the callback
   this.clock.tick(1);
-  QUnit.ok(segmentInfo.bytes, 'decrypted bytes in segment');
+  QUnit.ok(loader.pendingSegment_.bytes, 'decrypted bytes in segment');
 
   // verify stats
   QUnit.equal(loader.mediaBytesTransferred, 8, '8 bytes');


### PR DESCRIPTION
## Description

Changes the state logic in `SegmentLoader` so that the states are explicit and not combined together. This will solve issues being addressed in #810 
[Proposed State Diagram](https://docs.google.com/drawings/d/1nJJFh9Yq6cZXmjUL8suy5hVq6Y53LwzO6RczVMSxFRY/edit?usp=sharing)
## Specific Changes proposed

Remove the concept of being PAUSED and in another state such as READY or WAITING.
Adds three states, `PAUSED`, `PAUSING` and `PRELOAD`
- `PAUSED` indicates the loader has paused monitoring of the buffer
- `PAUSING` indicates that the loader will move to the `PAUSED` state once it has finished its current outstanding request.
- `PRELOAD` indicates the loader can begin fetching segments early if it has enough information despite possibly not being fully initialized.
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
