### PR TITLE
Changes to the underflow-detection in the gap-skipper to be less restrictive about the size of the gaps it is able to skip when an underflow is detected

### DIFF
--- a/src/gap-skipper.js
+++ b/src/gap-skipper.js
@@ -165,7 +165,7 @@ export default class GapSkipper {
     // (13 seconds), at which point it stops as well. Since current time is past the
     // gap, findNextRange will return no ranges.
     //
-    // To check for this issue, we see if there is a small gap that is somewhere within
+    // To check for this issue, we see if there is a gap that starts somewhere within
     // a 3 second range (3 seconds +/- 1 second) back from our current time.
     let gaps = Ranges.findGaps(buffered);
 
@@ -173,10 +173,8 @@ export default class GapSkipper {
       let start = gaps.start(i);
       let end = gaps.end(i);
 
-      // gap is small
-      if (end - start < 1 &&
-        // gap is 3 seconds back +/- 1 second
-        currentTime - start < 4 && currentTime - end > 2) {
+      // gap is starts no more than 4 seconds back
+      if (currentTime - start < 4 && currentTime - start > 2) {
         return {
           start,
           end

--- a/test/gap-skipper.test.js
+++ b/test/gap-skipper.test.js
@@ -174,20 +174,14 @@ QUnit.test('skips gap from video underflow', function() {
     'returns null when gap is after current time');
   QUnit.equal(
     this.gapSkipper.gapFromVideoUnderflow_(
-      videojs.createTimeRanges([[0, 10], [11.1, 20]]), 13),
+      videojs.createTimeRanges([[0, 10.1], [10.2, 20]]), 12.1),
     null,
-    'returns null when gap is too large');
-  QUnit.equal(
-    this.gapSkipper.gapFromVideoUnderflow_(
-      videojs.createTimeRanges([[0, 10], [10.1, 20]]), 12.1),
-    null,
-    'returns null when time is less than or euqal to 2 seconds ahead');
+    'returns null when time is less than or equal to 2 seconds ahead');
   QUnit.equal(
     this.gapSkipper.gapFromVideoUnderflow_(
       videojs.createTimeRanges([[0, 10], [10.1, 20]]), 14.1),
     null,
     'returns null when time is greater than or equal to 4 seconds ahead');
-
   QUnit.deepEqual(
     this.gapSkipper.gapFromVideoUnderflow_(
       videojs.createTimeRanges([[0, 10], [10.1, 20]]), 12.2),


### PR DESCRIPTION
## Description
Right now the gap-skipper detects video underflow conditions on Chrome but only skips then when there is a gap in the buffer that is less than 1 second long. There are conditions under which the gap can be greater than 1 second (a GOP being removed from the coded-frame buffer for instance) and this change allows the detection and skipping of gaps that exceed 1 second.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors