### PR TITLE
Cleanup mocked selectPlaylist

### DIFF
--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2551,6 +2551,7 @@ QUnit.test('uses user defined selectPlaylist from HlsHandler if specified', func
   QUnit.equal(setSelectPlaylistCount, 1, 'uses set playlist selector');
 
   Hls.STANDARD_PLAYLIST_SELECTOR = origStandardPlaylistSelector;
+  delete HlsHandler.prototype.selectPlaylist;
 });
 
 QUnit.module('HLS - Encryption', {


### PR DESCRIPTION
Leaving a mock version of selectPlaylist on the HlsHandler prototype leads to broken error handling in tests for encryption key fetching. Fixes current Travis test failure.