### PR TITLE
Prevent loading first segment of live manifest - seek to and load segment at current time

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -476,8 +476,6 @@ export default class MasterPlaylistController extends videojs.EventTarget {
         // 4) the player has not started playing
         !this.hasPlayed_) {
 
-      this.load();
-
       // trigger the playlist loader to start "expired time"-tracking
       this.masterPlaylistLoader_.trigger('firstplay');
       this.hasPlayed_ = true;
@@ -487,6 +485,9 @@ export default class MasterPlaylistController extends videojs.EventTarget {
       if (seekable.length) {
         this.tech_.setCurrentTime(seekable.end(0));
       }
+
+      // now that we seeked to the current time, load the segment
+      this.load();
 
       return true;
     }

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2064,7 +2064,7 @@ QUnit.test('cleans up the buffer based on currentTime when loading a live segmen
   // Change seekable so that it starts *after* the currentTime which was set
   // based on the previous seekable range (the end of 80)
   seekable = videojs.createTimeRanges([[100, 120]]);
-  
+
   // request first playable segment
   standardXHRResponse(this.requests[1]);
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2008,11 +2008,8 @@ QUnit.test('cleans up the buffer when loading live segments', function() {
   };
   this.player.tech_.trigger('play');
 
-  this.clock.tick(1);
-  // this.requests[1] is an aborted XHR
-  // since we are in a live stream that request is aborted by
-  // the seek-to-live behavior
-  standardXHRResponse(this.requests[2]);
+  // request first playable segment
+  standardXHRResponse(this.requests[1]);
 
   QUnit.strictEqual(this.requests[0].url, 'liveStart30sBefore.m3u8',
                     'master playlist requested');
@@ -2063,14 +2060,13 @@ QUnit.test('cleans up the buffer based on currentTime when loading a live segmen
   };
 
   this.player.tech_.trigger('play');
-  this.clock.tick(1);
+
   // Change seekable so that it starts *after* the currentTime which was set
   // based on the previous seekable range (the end of 80)
   seekable = videojs.createTimeRanges([[100, 120]]);
-  // this.requests[1] is an aborted XHR
-  // since we are in a live stream that request is aborted by
-  // the seek-to-live behavior
-  standardXHRResponse(this.requests[2]);
+  
+  // request first playable segment
+  standardXHRResponse(this.requests[1]);
 
   QUnit.strictEqual(this.requests[0].url, 'liveStart30sBefore.m3u8', 'master playlist requested');
   QUnit.equal(removes.length, 1, 'remove called');


### PR DESCRIPTION
## Description
Currently in setupFirstPlay() we are performing a load() followed by a seek to the current live point in the manifest. The first segment is never played, resulting in wasted bandwidth as the segment is downloaded and ignored. Speaking to core contributors, this logic appears to be left over from when earlier versions of FF could not seek without first loading some segment and has since been fixed.

This suggested fix moves the load() call to immediately after setting the seekable range to the current Time to avoid loading the first segment. This results in loading the first segment at the current point in time.

Tests were also adjusted to reflect this new behavior. 

## Specific Changes proposed
Moving load() after seeking in setupFirstPlay()

## Requirements Checklist
- [ x ]  Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ x ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ x] Reviewed by Two Core Contributors
