### PR TITLE
Replace linear search with binary search to incorporate large live streams

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -525,35 +525,42 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // If we have a seekable range use that as the limit for what can be removed safely
     // otherwise remove anything older than 1 minute before the current play head
-    if (seekable.length &&
-        seekable.start(0) > 0 &&
-        seekable.start(0) < currentTime) {
+    if (seekable.length && seekable.start(0) > 0 && seekable.start(0) < currentTime) {
       removeToTime = seekable.start(0);
     } else {
       removeToTime = currentTime - 60;
     }
-
     // If we are going to remove time from the front of the buffer, make
     // sure we aren't discarding a partial segment to avoid throwing
     // PLAYER_ERR_TIMEOUT while trying to read a partially discarded segment
-    for (let i = 0; i <= segmentInfo.playlist.segments.length; i++) {
-      // Loop through the segments and calculate the duration to compare
-      // against the removeToTime
-      let removeDuration = duration(segmentInfo.playlist,
-                                    segmentInfo.playlist.mediaSequence + i,
-                                    this.expired_);
 
-      // If we are close to next segment begining, remove to end of previous
-      // segment instead
-      let previousDuration = duration(segmentInfo.playlist,
-                                    segmentInfo.playlist.mediaSequence + (i - 1),
-                                    this.expired_);
+    // Get the previous duration
+    let minIndex = 0;
+    let maxIndex = segmentInfo.playlist.segments.length;
+    let currentIndex;
+    let removeDuration;
 
-      if (removeDuration >= removeToTime) {
-        removeToTime = previousDuration;
+    // Execute Binary search to find what time to trim the buffer
+    while (minIndex <= maxIndex) {
+      currentIndex = (minIndex + maxIndex) / 2 | 0;
+      removeDuration = duration(segmentInfo.playlist,
+                                segmentInfo.playlist.mediaSequence + currentIndex,
+                                this.expired_);
+      if (removeDuration < removeToTime) {
+        minIndex = currentIndex + 1;
+      } else if (removeDuration > removeToTime) {
+        maxIndex = currentIndex - 1;
+        if (minIndex > maxIndex) {
+          currentIndex = currentIndex - 1;
+        }
+      } else {
+        currentIndex = currentIndex - 1;
         break;
       }
     }
+    removeToTime = duration(segmentInfo.playlist,
+                            segmentInfo.playlist.mediaSequence + currentIndex,
+                            this.expired_);
     return removeToTime;
   }
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2113,7 +2113,7 @@ QUnit.test('cleans up the buffer when loading VOD segments', function() {
   QUnit.strictEqual(this.requests[1].url, absoluteUrl('manifest/media3.m3u8'),
                     'media playlist requested');
   QUnit.equal(removes.length, 1, 'remove called');
-  QUnit.deepEqual(removes[0], [0, 120 - 60], 'remove called with the right range');
+  QUnit.deepEqual(removes[0], [0, 120 - 80], 'remove called with the right range which is the end of the playlist length');
 
   // verify stats
   QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');


### PR DESCRIPTION
## Description

The VideoJS player was slowing down and buffering in large HLS streams with small GOP sizes (1 hour+ streams). I traced the results to the buffer and more specifically how the buffer was being trimmed. I ended up replacing the linear search to find the time segment to trim the buffer for large streams with a binary search and the results are a lot faster.  
## Specific Changes proposed

Replacing linear search with binary search to improve the amount of iterations taken to find the time segment to trim the buffer at. 
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
  - [x] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [x] Reviewed by Two Core Contributors

… discard previous content on buffer for large scale hls streams
