### PR TITLE
Fix 'ended' event not firing after replay

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -380,7 +380,6 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     let bufferedTime;
     let currentBufferedEnd;
-    let segment;
     let mediaIndex;
 
     if (!playlist.segments.length) {
@@ -454,13 +453,12 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    let
-      buffered = this.sourceUpdater_.buffered(),
-      playlist = this.playlist_,
-      currentTime = this.currentTime_(),
-      hasPlayed = this.hasPlayed_(),
-      expired = this.expired_,
-      timeCorrection = this.timeCorrection_;
+    let buffered = this.sourceUpdater_.buffered();
+    let playlist = this.playlist_;
+    let currentTime = this.currentTime_();
+    let hasPlayed = this.hasPlayed_();
+    let expired = this.expired_;
+    let timeCorrection = this.timeCorrection_;
 
     // see if we need to begin loading immediately
     let requestIndex = this.checkBuffer_(buffered,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -413,7 +413,21 @@ export default class SegmentLoader extends videojs.EventTarget {
                                         this.expired_);
     }
 
-    if (mediaIndex < 0 || mediaIndex === playlist.segments.length) {
+    if (mediaIndex === playlist.segments.length) {
+      if (playlist.endList &&
+          buffered.length) {
+        let endOfBuffer = buffered.end(buffered.length - 1);
+        let lastSegment = playlist.segments[playlist.segments.length - 1];
+
+        if (lastSegment.end &&
+            lastSegment.end < endOfBuffer + Ranges.TIME_FUDGE_FACTOR &&
+            this.mediaSource_.readyState === 'open') {
+          this.mediaSource_.endOfStream();
+        }
+      }
+      return null;
+    }
+    if (mediaIndex < 0) {
       return null;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -523,9 +523,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    let segment = this.playlist_.segments[segmentInfo.mediaIndex];
+    let segment = this.playlist_.segments[request.mediaIndex];
     let startOfSegment = duration(this.playlist_,
-                                  this.playlist_.mediaSequence + segmentInfo.mediaIndex,
+                                  this.playlist_.mediaSequence + request.mediaIndex,
                                   this.expired_);
 
     //   (we are crossing a discontinuity somehow)
@@ -560,7 +560,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    this.loadSegment_(segmentInfo);
+    this.loadSegment_(request);
   }
 
   /**

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -736,6 +736,7 @@ QUnit.test('fires ended at the end of a playlist', function() {
     sourceBuffers: mediaSource.sourceBuffers,
     endOfStream() {
       endOfStreams++;
+      this.readyState = 'ended';
     }
   };
 
@@ -1074,6 +1075,9 @@ QUnit.test('requests the first segment with an empty buffer', function() {
 
   let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges(),
                                         playlistWithDuration(20),
+                                        0,
+                                        false,
+                                        0,
                                         0);
 
   QUnit.ok(segmentInfo, 'generated a request');
@@ -1116,7 +1120,7 @@ QUnit.test('downloads the next segment if the buffer is getting low', function()
 
   playlist.segments[1].end = 19.999;
   buffered = videojs.createTimeRanges([[0, 19.999]]);
-  segmentInfo = loader.checkBuffer_(buffered, playlist, 15);
+  segmentInfo = loader.checkBuffer_(buffered, playlist, 15, true, 0, 0);
 
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '2.ts', 'requested the third segment');
@@ -1129,12 +1133,12 @@ QUnit.test('buffers based on the correct TimeRange if multiple ranges exist', fu
   loader.mimeType(this.mimeType);
 
   buffered = videojs.createTimeRanges([[0, 10], [20, 30]]);
-  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 8);
+  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 8, true, 0, 0);
 
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '1.ts', 'requested the second segment');
 
-  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 20);
+  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 20, true, 0, 0);
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '3.ts', 'requested the fourth segment');
 });
@@ -1181,7 +1185,10 @@ QUnit.test('adjusts calculations based on expired time', function() {
 
   segmentInfo = loader.checkBuffer_(buffered,
                                     playlist,
-                                    40 - Config.GOAL_BUFFER_LENGTH);
+                                    40 - Config.GOAL_BUFFER_LENGTH,
+                                    true,
+                                    loader.expired_,
+                                    0);
 
   QUnit.ok(segmentInfo, 'fetched a segment');
   QUnit.equal(segmentInfo.uri, '2.ts', 'accounted for expired time');

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1073,12 +1073,14 @@ QUnit.module('Segment Loading Calculation', {
 QUnit.test('requests the first segment with an empty buffer', function() {
   loader.mimeType(this.mimeType);
 
-  let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges(),
-                                        playlistWithDuration(20),
+  let playlist = playlistWithDuration(20);
+  let segmentIndex = loader.checkBuffer_(videojs.createTimeRanges(),
+                                        playlist,
                                         0,
                                         false,
                                         0,
                                         0);
+  let segmentInfo = playlist.segments[segmentIndex];
 
   QUnit.ok(segmentInfo, 'generated a request');
   QUnit.equal(segmentInfo.uri, '0.ts', 'requested the first segment');
@@ -1113,6 +1115,7 @@ QUnit.test('does not download the next segment if the buffer is full', function(
 QUnit.test('downloads the next segment if the buffer is getting low', function() {
   let buffered;
   let segmentInfo;
+  let segmentIndex;
   let playlist = playlistWithDuration(30);
 
   loader.mimeType(this.mimeType);
@@ -1120,7 +1123,8 @@ QUnit.test('downloads the next segment if the buffer is getting low', function()
 
   playlist.segments[1].end = 19.999;
   buffered = videojs.createTimeRanges([[0, 19.999]]);
-  segmentInfo = loader.checkBuffer_(buffered, playlist, 15, true, 0, 0);
+  segmentIndex = loader.checkBuffer_(buffered, playlist, 15, true, 0, 0);
+  segmentInfo = playlist.segments[segmentIndex];
 
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '2.ts', 'requested the third segment');
@@ -1129,16 +1133,20 @@ QUnit.test('downloads the next segment if the buffer is getting low', function()
 QUnit.test('buffers based on the correct TimeRange if multiple ranges exist', function() {
   let buffered;
   let segmentInfo;
+  let segmentIndex;
+  let playlist = playlistWithDuration(40);
 
   loader.mimeType(this.mimeType);
 
   buffered = videojs.createTimeRanges([[0, 10], [20, 30]]);
-  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 8, true, 0, 0);
+  segmentIndex = loader.checkBuffer_(buffered, playlist, 8, true, 0, 0);
+  segmentInfo = playlist.segments[segmentIndex];
 
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '1.ts', 'requested the second segment');
 
-  segmentInfo = loader.checkBuffer_(buffered, playlistWithDuration(40), 20, true, 0, 0);
+  segmentIndex = loader.checkBuffer_(buffered, playlist, 20, true, 0, 0);
+  segmentInfo = playlist.segments[segmentIndex];
   QUnit.ok(segmentInfo, 'made a request');
   QUnit.equal(segmentInfo.uri, '3.ts', 'requested the fourth segment');
 });
@@ -1175,6 +1183,7 @@ QUnit.test('adjusts calculations based on expired time', function() {
   let buffered;
   let playlist;
   let segmentInfo;
+  let segmentIndex;
 
   loader.mimeType(this.mimeType);
 
@@ -1183,12 +1192,13 @@ QUnit.test('adjusts calculations based on expired time', function() {
 
   loader.expired(10);
 
-  segmentInfo = loader.checkBuffer_(buffered,
+  segmentIndex = loader.checkBuffer_(buffered,
                                     playlist,
                                     40 - Config.GOAL_BUFFER_LENGTH,
                                     true,
                                     loader.expired_,
                                     0);
+  segmentInfo = playlist.segments[segmentIndex];
 
   QUnit.ok(segmentInfo, 'fetched a segment');
   QUnit.equal(segmentInfo.uri, '2.ts', 'accounted for expired time');


### PR DESCRIPTION
## Description
The "ended" event fires when the video reaches to the end of the video for the first time (This is fine). However on a reply of the video (without refreshing the page), it does playback, but when the video reaches to the end of the video, it stops at the last frame and "ended" event does not fire.

## Specific Changes proposed
If the fetcher logic chose `mediaIndex === playlist.segments.length` as the next segment to fetch, the playlist is not live, the last segment in the playlist is already buffered and the media source has a ready state of `open`, then call `endOfStream()` on the media source to signal that its ready state should be changed to `ended`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
