### PR TITLE
Fix link to generator-videojs-plugin/standards.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,4 @@ Testing is a crucial part of any software project. For all but the most trivial 
 
 [karma]: http://karma-runner.github.io/
 [local]: http://localhost:9999/test/
-[standards]: https://github.com/videojs/generator-videojs-plugin/docs/standards.md
-
+[standards]: https://github.com/videojs/generator-videojs-plugin/blob/master/docs/standards.md


### PR DESCRIPTION
## Description
Fix link to [standards.md](https://github.com/videojs/generator-videojs-plugin/blob/master/docs/standards.md) file, which is returning a 404 page at this moment.
