### PR TITLE
Correct deprecation notice

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -288,7 +288,7 @@ class HlsHandler extends Component {
       if (!_player.hasOwnProperty('hls')) {
         Object.defineProperty(_player, 'hls', {
           get: () => {
-            videojs.log.warn('player.hls is deprecated. Use player.tech.hls instead.');
+            videojs.log.warn('player.hls is deprecated. Use player.tech_.hls instead.');
             return this;
           }
         });

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -127,7 +127,7 @@ QUnit.test('deprication warning is show when using player.hls', function() {
   };
   let hls = this.player.hls;
 
-  QUnit.equal(warning, 'player.hls is deprecated. Use player.tech.hls instead.', 'warning would have been shown');
+  QUnit.equal(warning, 'player.hls is deprecated. Use player.tech_.hls instead.', 'warning would have been shown');
   QUnit.ok(hls, 'an instance of hls is returned by player.hls');
   videojs.log.warn = oldWarn;
 });


### PR DESCRIPTION
The deprecation notice for `player.hls` advises to use `player.tech.hls` but should be `player.tech_.hls`.