### PR TITLE
allow for initial bandwidth option of 0

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -342,7 +342,7 @@ class HlsHandler extends Component {
     // start playlist selection at a reasonable bandwidth for
     // broadband internet
     // 0.5 MB/s
-    if (typeof this.options_.bandwidth === 'undefined') {
+    if (typeof this.options_.bandwidth !== 'number') {
       this.options_.bandwidth = 4194304;
     }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -342,7 +342,9 @@ class HlsHandler extends Component {
     // start playlist selection at a reasonable bandwidth for
     // broadband internet
     // 0.5 MB/s
-    this.options_.bandwidth = this.options_.bandwidth || 4194304;
+    if (typeof this.options_.bandwidth === 'undefined') {
+      this.options_.bandwidth = 4194304;
+    }
 
     // grab options passed to player.src
     ['withCredentials', 'bandwidth'].forEach((option) => {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1262,6 +1262,32 @@ QUnit.test('if mode global option is used, mode is set to global option', functi
   videojs.options.hls = hlsOptions;
 });
 
+QUnit.test('respects bandwidth option of 0', function() {
+  this.player.dispose();
+  this.player = createPlayer({ html5: { hls: { bandwidth: 0 } } });
+
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  openMediaSource(this.player, this.clock);
+  QUnit.equal(this.player.tech_.hls.bandwidth, 0, 'set bandwidth to 0');
+});
+
+QUnit.test('uses default bandwidth option if non-numerical value provided', function() {
+  this.player.dispose();
+  this.player = createPlayer({ html5: { hls: { bandwidth: 'garbage' } } });
+
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  openMediaSource(this.player, this.clock);
+  QUnit.equal(this.player.tech_.hls.bandwidth, 4194304, 'set bandwidth to default');
+});
+
 QUnit.test('does not break if the playlist has no segments', function() {
   this.player.src({
     src: 'manifest/master.m3u8',


### PR DESCRIPTION
## Description
Setting initial bandwidth option to zero uses default bandwidth and not zero

## Specific Changes proposed
Can now set to zero.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors

