### PR TITLE
fix flash failing first segment load

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -649,7 +649,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.tech_.setCurrentTime(0);
     }
 
-    this.load();
+    if (this.hasPlayed_) {
+      this.load();
+    }
 
     // if the viewer has paused and we fell out of the live window,
     // seek forward to the earliest available position
@@ -658,7 +660,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
         return this.tech_.setCurrentTime(this.tech_.seekable().start(0));
       }
     }
-
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -441,7 +441,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Under normal playback conditions fetching is a simple walk forward
     if (mediaIndex !== null) {
       log('++', mediaIndex + 1);
-      return this.generateSegmentInfo_(playlist, mediaIndex + 1, lastBufferedEnd, false);
+      startOfSegment = playlist.segments[mediaIndex].end || lastBufferedEnd;
+      return this.generateSegmentInfo_(playlist, mediaIndex + 1, startOfSegment, false);
     }
 
     // There is a sync-point but the lack of a mediaIndex indicates that
@@ -460,7 +461,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       mediaIndex = mediaSourceInfo.mediaIndex;
       startOfSegment = mediaSourceInfo.startTime;
     }
-    log('gMIFT', mediaIndex);
+    log('gMIFT', mediaIndex, 'sos', startOfSegment);
     return this.generateSegmentInfo_(playlist, mediaIndex, startOfSegment, false);
   }
 
@@ -565,7 +566,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // - The "timestampOffset" for the start of this segment is less than
     //   the currently set timestampOffset
     if (segmentInfo.timeline !== this.currentTimeline_ ||
-        (isNaN(segmentInfo.startOfSegment) &&
+        ((segmentInfo.startOfSegment !== null) &&
         segmentInfo.startOfSegment < this.sourceUpdater_.timestampOffset())) {
       this.syncController_.reset();
       segmentInfo.timestampOffset = segmentInfo.startOfSegment;


### PR DESCRIPTION
Calling `MasterPlaylistController.load()` before `hasPlayed_` has been set was creating a race condition in flash to break when trying to probe the sync request. With this change, the first time load is called should be within `setupFirstPlay()`. I also fixed the conditional checking for a discontinuity within `SegmentLoader`