### PR TITLE
fix flash failing first segment load part 2

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -220,7 +220,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       seekable: () => this.seekable(),
       seeking: () => this.tech_.seeking(),
       setCurrentTime: (a) => this.tech_.setCurrentTime(a),
-      hasPlayed: () => this.hasPlayed_ || this.tech_.played().length !== 0,
+      hasPlayed: () => this.hasPlayed_,
       bandwidth
     };
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -441,7 +441,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Under normal playback conditions fetching is a simple walk forward
     if (mediaIndex !== null) {
       log('++', mediaIndex + 1);
-      startOfSegment = playlist.segments[mediaIndex].end || lastBufferedEnd;
+      let segment = playlist.segments[mediaIndex];
+      startOfSegment = segment ? segment.end : lastBufferedEnd;
       return this.generateSegmentInfo_(playlist, mediaIndex + 1, startOfSegment, false);
     }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -221,8 +221,9 @@ export default class SyncController {
     }
 
     if (timingInfo) {
-      this.calculateSegmentTimeMapping_(segmentInfo, timingInfo);
-      this.saveDiscontinuitySyncInfo_(segmentInfo);
+      if (this.calculateSegmentTimeMapping_(segmentInfo, timingInfo)) {
+        this.saveDiscontinuitySyncInfo_(segmentInfo);
+      }
     }
   }
 
@@ -305,10 +306,13 @@ export default class SyncController {
 
       segment.start = segmentInfo.timestampOffset;
       segment.end = timingInfo.end + mappingObj.mapping;
-    } else {
+    } else if (mappingObj) {
       segment.start = timingInfo.start + mappingObj.mapping;
       segment.end = timingInfo.end + mappingObj.mapping;
+    } else {
+      return false;
     }
+    return true;
   }
 
   /**


### PR DESCRIPTION
Previous PR for this fix missed some edge cases. Notably `hasPlayed()` defaulted to checking `this.tech_.played().length !== 0` when `this.hasPlayed_` had not yet been set by `MasterPlaylistController`. This change makes it so `SegmentLoader` sees false for `hasPlayed` until `MasterPlaylistController.setupFirstPlay()` has been called and completed.

I also added a few checks to prevent crashing from trying to access from undefined.
