### PR TITLE
Fix the issue #776

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -1,0 +1,38 @@
+/**
+ * @file key.js
+ *
+ * 
+ * Store the unique key for the video data;
+ * @type {Object}
+ * @private
+ */
+
+let keyObject = {
+    uri: '',
+    keyData: {}
+};
+
+/**
+ * Test if wo have stored the key
+ *
+ * @param  {String}  The uri of the key which we need to load;
+ * @return {Boolean} do we have stored the key which we want to load;
+ * @function getStoredKey
+ */
+export function getStoredKey(uri) {
+    if (keyObject.uri === uri) {
+        return keyObject.keyData[uri];
+    }
+    return false;
+}
+
+/**
+ * Store the key and uri
+ * @param {String} uri The uri of the key
+ * @param {Unit32Array} key The data of key in Uint32Array Typed Array
+ */
+export function setStoredKey(uri, key) {
+    keyObject.uri = uri;
+    keyObject.keyData = {};
+    keyObject.keyData[uri] = key;
+}

--- a/src/key.js
+++ b/src/key.js
@@ -7,10 +7,7 @@
  * @private
  */
 
-let keyObject = {
-    uri: '',
-    keyData: {}
-};
+let keyObject = {};
 
 /**
  * Test if wo have stored the key
@@ -20,8 +17,8 @@ let keyObject = {
  * @function getStoredKey
  */
 export function getStoredKey(uri) {
-    if (keyObject.uri === uri) {
-        return keyObject.keyData[uri];
+    if (keyObject[uri]) {
+        return keyObject[uri];
     }
     return false;
 }
@@ -32,7 +29,5 @@ export function getStoredKey(uri) {
  * @param {Unit32Array} key The data of key in Uint32Array Typed Array
  */
 export function setStoredKey(uri, key) {
-    keyObject.uri = uri;
-    keyObject.keyData = {};
-    keyObject.keyData[uri] = key;
+    keyObject[uri] = key;
 }


### PR DESCRIPTION
## Description

Fix the issue https://github.com/videojs/videojs-contrib-hls/issues/776
At first,please accept my apologies for my poor English.Thank you for your patience.
As we know When the segement is Encrypted,we will get the key for every segment.But the key is the same for the same video as usually.So the request is a waste.
I store the key in code and check if it is exist for every XMLHttpRequest.
## Specific Changes proposed
- Add a key.js to store the key we get.
- Check if the key is exist for every segement.So the segement-loader.js is changed.
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Docs/guides updated
  - [ ] Example created ([Example Link](http://default.prod.dev.qiqiuyun.cn:9071/video-player/examples/demo-sdk-play-rate-display.html))
- [ ] Reviewed by Two Core Contributors
