### PR TITLE
Don't error if MediaSource isn't defined

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1006,7 +1006,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
         let codecString = variant.attributes.CODECS;
 
         variantCodecs = parseCodecs(codecString);
-        if (!MediaSource.isTypeSupported('video/mp4; codecs="' + codecString + '"')) {
+        if (window.MediaSource &&
+            window.MediaSource.isTypeSupported &&
+            !window.MediaSource.isTypeSupported('video/mp4; codecs="' + codecString + '"')) {
           variant.excludeUntil = Infinity;
         }
       }

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2284,6 +2284,23 @@ QUnit.module('HLS Integration', {
   }
 });
 
+QUnit.test('does not error when MediaSource is not defined', function() {
+  window.MediaSource = null;
+
+  let hls = HlsSourceHandler('html5').handleSource({
+    src: 'manifest/alternateAudio.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  }, this.tech);
+
+  hls.mediaSource.trigger('sourceopen');
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  QUnit.ok(true, 'did not throw an exception');
+});
+
 QUnit.test('aborts all in-flight work when disposed', function() {
   let hls = HlsSourceHandler('html5').handleSource({
     src: 'manifest/master.m3u8',


### PR DESCRIPTION
If a CODECS attribute is present on an m3u8 but MSE isn't present, don't explode. In practice, this means only exclude variants based on codec for MSE mode.