### PR TITLE
use setTimeout in gap skipper instead of relying on timeupdate events

### DIFF
--- a/src/gap-skipper.js
+++ b/src/gap-skipper.js
@@ -38,7 +38,7 @@ export default class GapSkipper {
     this.consecutiveUpdates = 0;
     this.lastRecordedTime = null;
     this.timer_ = null;
-    this.timeupdateTimeout_ = null;
+    this.checkCurrentTimeTimeout_ = null;
 
     if (options.debug) {
       this.logger_ = videojs.log.bind(videojs, 'gap-skipper ->');
@@ -50,15 +50,15 @@ export default class GapSkipper {
 
     this.tech_.on('waiting', waitingHandler);
     this.tech_.on(timerCancelEvents, cancelTimerHandler);
-    this.checkTimeupdate_();
+    this.monitorCurrentTime_();
 
     // Define the dispose function to clean up our events
     this.dispose = () => {
       this.logger_('dispose');
       this.tech_.off('waiting', waitingHandler);
       this.tech_.off(timerCancelEvents, cancelTimerHandler);
-      if (this.timeupdateTimeout_) {
-        clearTimeout(this.timeupdateTimeout_);
+      if (this.checkCurrentTimeTimeout_) {
+        clearTimeout(this.checkCurrentTimeTimeout_);
       }
       this.cancelTimer_();
     };
@@ -69,15 +69,15 @@ export default class GapSkipper {
    *
    * @private
    */
-  checkTimeupdate_() {
-    this.timeupdate_();
+  monitorCurrentTime_() {
+    this.checkCurrentTime_();
 
-    if (this.timeupdateTimeout_) {
-      clearTimeout(this.timeupdateTimeout_);
+    if (this.checkCurrentTimeTimeout_) {
+      clearTimeout(this.checkCurrentTimeTimeout_);
     }
 
     // 42 = 24 fps // 250 is what Webkit uses // FF uses 15
-    this.timeupdateTimeout_ = setTimeout(this.checkTimeupdate_.bind(this), 250);
+    this.checkCurrentTimeTimeout_ = setTimeout(this.monitorCurrentTime_.bind(this), 250);
   }
 
   /**
@@ -98,7 +98,7 @@ export default class GapSkipper {
    *
    * @private
    */
-  timeupdate_() {
+  checkCurrentTime_() {
     if (this.tech_.paused() || this.tech_.seeking()) {
       return;
     }

--- a/test/gap-skipper.test.js
+++ b/test/gap-skipper.test.js
@@ -9,7 +9,7 @@ import {
 } from './test-helpers.js';
 import GapSkipper from '../src/gap-skipper';
 
-let checkTimeupdate_;
+let monitorCurrentTime_;
 
 QUnit.module('GapSkipper', {
   beforeEach() {
@@ -140,8 +140,8 @@ QUnit.test('skips over gap in Chrome due to video underflow', function() {
 
 QUnit.module('GapSkipper isolated functions', {
   beforeEach() {
-    checkTimeupdate_ = GapSkipper.prototype.checkTimeupdate_;
-    GapSkipper.prototype.checkTimeupdate_ = () => {};
+    monitorCurrentTime_ = GapSkipper.prototype.monitorCurrentTime_;
+    GapSkipper.prototype.monitorCurrentTime_ = () => {};
     this.gapSkipper = new GapSkipper({
       tech: {
         on: () => {},
@@ -151,7 +151,7 @@ QUnit.module('GapSkipper isolated functions', {
   },
   afterEach() {
     this.gapSkipper.dispose();
-    GapSkipper.prototype.checkTimeupdate_ = checkTimeupdate_;
+    GapSkipper.prototype.monitorCurrentTime_ = monitorCurrentTime_;
   }
 });
 

--- a/test/gap-skipper.test.js
+++ b/test/gap-skipper.test.js
@@ -60,11 +60,9 @@ QUnit.test('skips over gap in firefox with waiting event', function() {
   // check that player jumped the gap
   QUnit.equal(Math.round(this.player.currentTime()),
     20, 'Player seeked over gap after timer');
-
 });
 
 QUnit.test('skips over gap in chrome without waiting event', function() {
-
   this.player.autoplay(true);
 
   // create a buffer with a gap between 10 & 20 seconds
@@ -89,10 +87,8 @@ QUnit.test('skips over gap in chrome without waiting event', function() {
 
   // seek to 10 seconds & simulate chrome waiting event
   this.player.currentTime(10);
-  for (let i = 0; i < 10; i++) {
-    this.player.tech_.trigger('timeupdate');
-  }
-  this.clock.tick(2000);
+
+  this.clock.tick(4000);
 
   // checks that player doesn't seek before timer expires
   QUnit.equal(this.player.currentTime(), 10, 'Player doesnt seek over gap pre-timer');
@@ -134,22 +130,28 @@ QUnit.test('skips over gap in Chrome due to video underflow', function() {
     seeks.push(time);
   };
 
-  for (let i = 0; i < 7; i++) {
-    this.player.tech_.trigger('timeupdate');
-  }
+  this.clock.tick(2000);
 
   QUnit.equal(seeks.length, 1, 'one seek');
   QUnit.equal(seeks[0], 13, 'player seeked to current time');
 });
 
+var checkTimeupdate_;
+
 QUnit.module('GapSkipper isolated functions', {
   beforeEach() {
+    checkTimeupdate_ = GapSkipper.prototype.checkTimeupdate_;
+    GapSkipper.prototype.checkTimeupdate_ = () => {};
     this.gapSkipper = new GapSkipper({
       tech: {
         on: () => {},
         off: () => {}
       }
     });
+  },
+  afterEach() {
+    this.gapSkipper.dispose();
+    GapSkipper.prototype.checkTimeupdate_ = checkTimeupdate_;
   }
 });
 

--- a/test/gap-skipper.test.js
+++ b/test/gap-skipper.test.js
@@ -9,6 +9,8 @@ import {
 } from './test-helpers.js';
 import GapSkipper from '../src/gap-skipper';
 
+let checkTimeupdate_;
+
 QUnit.module('GapSkipper', {
   beforeEach() {
     this.env = useFakeEnvironment();
@@ -135,8 +137,6 @@ QUnit.test('skips over gap in Chrome due to video underflow', function() {
   QUnit.equal(seeks.length, 1, 'one seek');
   QUnit.equal(seeks[0], 13, 'player seeked to current time');
 });
-
-var checkTimeupdate_;
 
 QUnit.module('GapSkipper isolated functions', {
   beforeEach() {


### PR DESCRIPTION
## Description
gap skipper previously relied on `timeupdate` events from the tech to detect when the player encounters a gap. However, if the tech is using native `timeupdate` events instead of manual ones like html does in the latest release of video.js, `timeupdate` events do not fire when the player stalls at a gap.

## Specific Changes proposed
use `setTimeout` within gap skipper to periodically check the current time to detect a gap instead of relying on `timeupdate` events from the tech.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors

