### PR TITLE
Persist representations enable function and separate blacklisting from disabling

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "url-toolkit": "^1.0.4",
     "video.js": "^5.10.1",
     "videojs-contrib-media-sources": "^4.1.2",
+    "videojs-contrib-quality-levels": "^1.0.0",
     "videojs-swf": "^5.0.2"
   },
   "devDependencies": {

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -229,8 +229,10 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
    * @return {Number} number of eneabled playlists
    */
   loader.enabledPlaylists_ = function() {
-    return loader.master.playlists.filter((element, index, array) => {
-      return !element.excludeUntil || element.excludeUntil <= Date.now();
+    return loader.master.playlists.filter((playlist) => {
+      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+
+      return (!playlist.disabled && !blacklisted);
     }).length;
   };
 
@@ -249,8 +251,8 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     let currentBandwidth = loader.media().attributes.BANDWIDTH || 0;
 
     return !(loader.master.playlists.filter((playlist) => {
-      let enabled = typeof playlist.excludeUntil === 'undefined' ||
-                      playlist.excludeUntil <= Date.now();
+      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+      let enabled = (!playlist.disabled && !blacklisted);
 
       if (!enabled) {
         return false;

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -11,21 +11,22 @@
  * or if undefined returns the current enabled-state for the playlist
  * @return {Boolean} The current enabled-state of the playlist
  */
-let enableFunction = (playlist, changePlaylistFn, enable) => {
-  let currentlyEnabled = typeof playlist.excludeUntil === 'undefined' ||
-                         playlist.excludeUntil <= Date.now();
+let enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
+  let playlist = loader.master.playlists[playlistUri];
+  let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+  let currentlyEnabled = (!playlist.disabled && !blacklisted);
 
   if (typeof enable === 'undefined') {
     return currentlyEnabled;
   }
 
-  if (enable !== currentlyEnabled) {
-    if (enable) {
-      delete playlist.excludeUntil;
-    } else {
-      playlist.excludeUntil = Infinity;
-    }
+  if (enable) {
+    delete playlist.disabled;
+  } else {
+    playlist.disabled = true;
+  }
 
+  if (enable !== currentlyEnabled && !blacklisted) {
     // Ensure the outside world knows about our changes
     changePlaylistFn();
   }
@@ -69,7 +70,10 @@ class Representation {
 
     // Partially-apply the enableFunction to create a playlist-
     // specific variant
-    this.enabled = enableFunction.bind(this, playlist, fastChangeFunction);
+    this.enabled = enableFunction.bind(this,
+                                       hlsHandler.playlists,
+                                       playlist.uri,
+                                       fastChangeFunction);
   }
 }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -103,10 +103,8 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
   sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    if (typeof localVariant.excludeUntil !== 'undefined') {
-      return now >= localVariant.excludeUntil;
-    }
-    return true;
+    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > Date.now();
+    return (!localVariant.disabled && !blacklisted)
   });
 
   // filter out any variant that has greater effective bitrate

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -103,8 +103,9 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
   sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > Date.now();
-    return (!localVariant.disabled && !blacklisted)
+    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > now;
+
+    return (!localVariant.disabled && !blacklisted);
   });
 
   // filter out any variant that has greater effective bitrate

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -34,6 +34,14 @@ const makeMockPlaylist = function(options) {
     playlist.excludeUntil = options.excludeUntil;
   }
 
+  if ('uri' in options) {
+    playlist.uri = options.uri;
+  }
+
+  if ('disabled' in options) {
+    playlist.disabled = options.disabled;
+  }
+
   return playlist;
 };
 
@@ -55,7 +63,13 @@ const makeMockHlsHandler = function(playlistOptions) {
     }
   };
 
-  hlsHandler.playlists.master.playlists = playlistOptions.map(makeMockPlaylist);
+  playlistOptions.forEach((playlist, i) => {
+    hlsHandler.playlists.master.playlists[i] = makeMockPlaylist(playlist);
+
+    if (playlist.uri) {
+      hlsHandler.playlists.master.playlists[playlist.uri] = hlsHandler.playlists.master.playlists[i];
+    }
+  });
 
   return hlsHandler;
 };
@@ -139,11 +153,13 @@ QUnit.test('representations are disabled if their excludeUntil is after Date.now
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: Infinity
+      excludeUntil: Infinity,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media1.m3u8'
     }
   ]);
 
@@ -155,15 +171,17 @@ QUnit.test('representations are disabled if their excludeUntil is after Date.now
   assert.equal(renditions[1].enabled(), true, 'rendition is enabled');
 });
 
-QUnit.test('setting a representation to disabled sets excludeUntil to Infinity', function(assert) {
+QUnit.test('setting a representation to disabled sets disabled to true', function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media1.m3u8'
     }
   ]);
   let playlists = hlsHandler.playlists.master.playlists;
@@ -174,19 +192,20 @@ QUnit.test('setting a representation to disabled sets excludeUntil to Infinity',
 
   renditions[0].enabled(false);
 
-  assert.equal(playlists[0].excludeUntil, Infinity, 'rendition has an infinite excludeUntil');
-  assert.equal(playlists[1].excludeUntil, 0, 'rendition has an excludeUntil of zero');
+  assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
+  assert.equal(playlists[1].disabled, undefined, 'rendition has not been disabled');
 });
 
 QUnit.test('changing the enabled state of a representation calls fastQualityChange_', function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: Infinity
+      disabled: true,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      uri: 'media1.m3u8'
     }
   ]);
   let mpc = hlsHandler.masterPlaylistController_;
@@ -199,9 +218,37 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 
   renditions[0].enabled(true);
 
-  assert.equal(mpc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
+  assert.equal(mpc.fastQualityChange_.calls, 1,'fastQualityChange_ was called once');
 
   renditions[1].enabled(false);
 
   assert.equal(mpc.fastQualityChange_.calls, 2, 'fastQualityChange_ was called twice');
 });
+
+QUnit.test('changing the enabled state of a blacklisted representation still (un)sets disabled',
+  function() {
+    let hlsHandler = makeMockHlsHandler([
+      {
+        bandwidth: 0,
+        excludeUntil: Infinity,
+        uri: 'media0.m3u8'
+      },
+      {
+        bandwidth: 0,
+        disabled: true,
+        excludeUntil: Date.now() + 99999,
+        uri: 'media1.m3u8'
+      }
+    ]);
+    let playlists = hlsHandler.playlists.master.playlists;
+
+    RenditionMixin(hlsHandler);
+
+    let renditions = hlsHandler.representations();
+
+    renditions[0].enabled(false);
+    renditions[1].enabled(true);
+
+    QUnit.equal(playlists[0].disabled, true, 'rendition has been disabled');
+    QUnit.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
+  });

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -218,7 +218,7 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 
   renditions[0].enabled(true);
 
-  assert.equal(mpc.fastQualityChange_.calls, 1,'fastQualityChange_ was called once');
+  assert.equal(mpc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
 
   renditions[1].enabled(false);
 
@@ -226,7 +226,7 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 });
 
 QUnit.test('changing the enabled state of a blacklisted representation still (un)sets disabled',
-  function() {
+  function(assert) {
     let hlsHandler = makeMockHlsHandler([
       {
         bandwidth: 0,
@@ -249,6 +249,6 @@ QUnit.test('changing the enabled state of a blacklisted representation still (un
     renditions[0].enabled(false);
     renditions[1].enabled(true);
 
-    QUnit.equal(playlists[0].disabled, true, 'rendition has been disabled');
-    QUnit.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
+    assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
+    assert.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
   });

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -21,6 +21,7 @@ import window from 'global/window';
 /* eslint-enable no-unused-vars */
 
 const Flash = videojs.getComponent('Flash');
+const ogHlsHandlerSetupQualityLevels = videojs.HlsHandler.setupQualityLevels_;
 let nextId = 0;
 
 // do a shallow copy of the properties of source onto the target object
@@ -1455,6 +1456,7 @@ QUnit.test('the source handler supports HLS mime types', function(assert) {
 });
 
 QUnit.test('fires loadstart manually if Flash is used', function(assert) {
+  videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   let tech = new (videojs.getTech('Flash'))({});
   let loadstarts = 0;
 
@@ -1469,6 +1471,7 @@ QUnit.test('fires loadstart manually if Flash is used', function(assert) {
   assert.equal(loadstarts, 0, 'loadstart is not synchronous');
   this.clock.tick(1);
   assert.equal(loadstarts, 1, 'fired loadstart');
+  videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
 });
 
 QUnit.test('has no effect if native HLS is available', function(assert) {
@@ -2314,6 +2317,36 @@ QUnit.test('passes useCueTags hls option to master playlist controller', functio
   videojs.options.hls = origHlsOptions;
 });
 
+QUnit.test('populates quality levels list when available', function(assert) {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  assert.ok(this.player.tech_.hls.qualityLevels_, 'added quality levels');
+
+  let qualityLevels = this.player.qualityLevels();
+  let addCount = 0;
+  let changeCount = 0;
+
+  qualityLevels.on('addqualitylevel', () => {
+    addCount++;
+  });
+
+  qualityLevels.on('change', () => {
+    changeCount++;
+  });
+
+  openMediaSource(this.player, this.clock);
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  assert.equal(addCount, 4, 'four levels added from master');
+  assert.equal(changeCount, 1, 'selected initial quality level');
+});
+
 QUnit.module('HLS Integration', {
   beforeEach(assert) {
     this.env = useFakeEnvironment(assert);
@@ -2321,10 +2354,12 @@ QUnit.module('HLS Integration', {
     this.mse = useFakeMediaSource();
     this.tech = new (videojs.getTech('Html5'))({});
     this.clock = this.env.clock;
+    videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   },
   afterEach() {
     this.env.restore();
     this.mse.restore();
+    videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
   }
 });
 
@@ -2585,10 +2620,12 @@ QUnit.module('HLS - Encryption', {
     this.requests = this.env.requests;
     this.mse = useFakeMediaSource();
     this.tech = new (videojs.getTech('Html5'))({});
+    videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   },
   afterEach() {
     this.env.restore();
     this.mse.restore();
+    videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
   }
 });
 


### PR DESCRIPTION
## Description

This PR includes two main fixes.
1. I've updated the closure for `Representation`'s enabled function to keep reference to the `PlaylistLoader` instead of the playlist object itself. This is because in `PlaylistLoader` overwrites the playlists objects with a new reference when it loads a playlist it hasnt loaded previously. This would create a new reference to an enabled function making the previous reference a user may have held onto obsolete.
2. Previously, the `Representation` enabled function would set `playlist.excludeUntil = Infinity` when disabling a playlist. However, when `MasterPlaylistController` blacklists playlists, it also uses `excludeUntil` to disable selection of that playlist. Since`Representation`s had no notion on whether a playlist was disabled through the enabled function or through blacklisting, it was possible to enable a previously blacklisted playlist, which could cause a player crash.

This change is also required for functionality of videojs-contrib-quality-levels
## Specific Changes proposed

`Representation`'s enabled function now creates closure around the `PlaylistLoader` object instead of the playlist object so the reference is not lost on new playlist loads.

Added a `disabled` property to playlist objects when using `Representation`'s enabled function so that manual enabling/disabling does not affect the blacklist status of a playlist.
## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
