### PR TITLE
Provide option to set contrib-hls first in the HTML5 tech

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -204,38 +204,6 @@ Hls.canPlaySource = function() {
 };
 
 /**
- * Whether the browser has built-in HLS support.
- */
-Hls.supportsNativeHls = (function() {
-  let video = document.createElement('video');
-
-  // native HLS is definitely not supported if HTML5 video isn't
-  if (!videojs.getComponent('Html5').isSupported()) {
-    return false;
-  }
-
-  // HLS manifests can go by many mime-types
-  let canPlay = [
-    // Apple santioned
-    'application/vnd.apple.mpegurl',
-    // Apple sanctioned for backwards compatibility
-    'audio/mpegurl',
-    // Very common
-    'audio/x-mpegurl',
-    // Very common
-    'application/x-mpegurl',
-    // Included for completeness
-    'video/x-mpegurl',
-    'video/mpegurl',
-    'application/mpegurl'
-  ];
-
-  return canPlay.some(function(canItPlay) {
-    return (/maybe|probably/i).test(video.canPlayType(canItPlay));
-  });
-}());
-
-/**
  * HLS is a source handler, not a tech. Make sure attempts to use it
  * as one do not cause exceptions.
  */
@@ -646,10 +614,6 @@ Hls.comparePlaylistResolution = function(left, right) {
 HlsSourceHandler.canPlayType = function(type) {
   let mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
 
-  // favor native HLS support if it's available
-  if (Hls.supportsNativeHls) {
-    return false;
-  }
   return mpegurlRE.test(type);
 };
 
@@ -659,9 +623,17 @@ if (typeof videojs.MediaSource === 'undefined' ||
   videojs.URL = URL;
 }
 
+videojs.options.hls = videojs.options.hls || {};
+videojs.options.hls.preferNative = typeof videojs.options.hls.preferNative === 'undefined' ?
+  true : videojs.options.hls.preferNative;
+
 // register source handlers with the appropriate techs
 if (MediaSource.supportsNativeMediaSources()) {
-  videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'));
+  if (videojs.options.hls.preferNative) {
+    videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'));
+  } else {
+    videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'), 0);
+  }
 }
 if (window.Uint8Array) {
   videojs.getComponent('Flash').registerSourceHandler(HlsSourceHandler('flash'));
@@ -672,7 +644,6 @@ videojs.HlsSourceHandler = HlsSourceHandler;
 videojs.Hls = Hls;
 videojs.m3u8 = m3u8;
 videojs.registerComponent('Hls', Hls);
-videojs.options.hls = videojs.options.hls || {};
 
 module.exports = {
   Hls,

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -647,7 +647,7 @@ HlsSourceHandler.canPlayType = function(type) {
   let mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
 
   // favor native HLS support if it's available
-  if (Hls.supportsNativeHls) {
+  if (!videojs.options.hls.overrideNative && Hls.supportsNativeHls) {
     return false;
   }
   return mpegurlRE.test(type);
@@ -661,7 +661,7 @@ if (typeof videojs.MediaSource === 'undefined' ||
 
 // register source handlers with the appropriate techs
 if (MediaSource.supportsNativeMediaSources()) {
-  videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'));
+  videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'), 0);
 }
 if (window.Uint8Array) {
   videojs.getComponent('Flash').registerSourceHandler(HlsSourceHandler('flash'));

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -83,10 +83,6 @@ QUnit.module('HLS', {
     // store functionality that some tests need to mock
     this.old.GlobalOptions = videojs.mergeOptions(videojs.options);
 
-    // force the HLS tech to run
-    this.old.NativeHlsSupport = videojs.Hls.supportsNativeHls;
-    videojs.Hls.supportsNativeHls = false;
-
     this.old.Decrypt = videojs.Hls.Decrypter;
     videojs.Hls.Decrypter = function() {};
 
@@ -105,7 +101,6 @@ QUnit.module('HLS', {
     Flash.isSupported = this.old.FlashSupported;
     merge(Flash, this.old.Flash);
 
-    videojs.Hls.supportsNativeHls = this.old.NativeHlsSupport;
     videojs.Hls.Decrypter = this.old.Decrypt;
     videojs.browser.IS_FIREFOX = this.old.IS_FIREFOX;
 
@@ -1443,20 +1438,6 @@ QUnit.test('fires loadstart manually if Flash is used', function() {
   QUnit.equal(loadstarts, 0, 'loadstart is not synchronous');
   this.clock.tick(1);
   QUnit.equal(loadstarts, 1, 'fired loadstart');
-});
-
-QUnit.test('has no effect if native HLS is available', function() {
-  let player;
-
-  Hls.supportsNativeHls = true;
-  player = createPlayer();
-  player.src({
-    src: 'http://example.com/manifest/master.m3u8',
-    type: 'application/x-mpegURL'
-  });
-
-  QUnit.ok(!player.tech_.hls, 'did not load hls tech');
-  player.dispose();
 });
 
 QUnit.test('re-emits mediachange events', function() {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1459,6 +1459,21 @@ QUnit.test('has no effect if native HLS is available', function() {
   player.dispose();
 });
 
+QUnit.test('loads if native HLS is available and override is set', function() {
+  videojs.options.hls.overrideNative = true;
+  let player;
+
+  Hls.supportsNativeHls = true;
+  player = createPlayer();
+  player.src({
+    src: 'http://example.com/manifest/master.m3u8',
+    type: 'application/x-mpegURL'
+  });
+
+  QUnit.ok(player.tech_.hls, 'did load hls tech');
+  player.dispose();
+});
+
 QUnit.test('re-emits mediachange events', function() {
   let mediaChanges = 0;
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -83,6 +83,10 @@ QUnit.module('HLS', {
     // store functionality that some tests need to mock
     this.old.GlobalOptions = videojs.mergeOptions(videojs.options);
 
+    // force the HLS tech to run
+    this.old.NativeHlsSupport = videojs.Hls.supportsNativeHls;
+    videojs.Hls.supportsNativeHls = false;
+
     this.old.Decrypt = videojs.Hls.Decrypter;
     videojs.Hls.Decrypter = function() {};
 
@@ -101,6 +105,7 @@ QUnit.module('HLS', {
     Flash.isSupported = this.old.FlashSupported;
     merge(Flash, this.old.Flash);
 
+    videojs.Hls.supportsNativeHls = this.old.NativeHlsSupport;
     videojs.Hls.Decrypter = this.old.Decrypt;
     videojs.browser.IS_FIREFOX = this.old.IS_FIREFOX;
 
@@ -1438,6 +1443,20 @@ QUnit.test('fires loadstart manually if Flash is used', function() {
   QUnit.equal(loadstarts, 0, 'loadstart is not synchronous');
   this.clock.tick(1);
   QUnit.equal(loadstarts, 1, 'fired loadstart');
+});
+
+QUnit.test('has no effect if native HLS is available', function() {
+  let player;
+
+  Hls.supportsNativeHls = true;
+  player = createPlayer();
+  player.src({
+    src: 'http://example.com/manifest/master.m3u8',
+    type: 'application/x-mpegURL'
+  });
+
+  QUnit.ok(!player.tech_.hls, 'did not load hls tech');
+  player.dispose();
 });
 
 QUnit.test('re-emits mediachange events', function() {

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -78,6 +78,12 @@
       <input type="radio" name="autoplay" value="on"> On
       <input type="radio" name="autoplay" value="off" checked> Off
     </label>
+    <br>
+    <label>
+      Override Native:
+      <input type="radio" name="override-native" value="on"> On
+      <input type="radio" name="override-native" value="off" checked> Off
+    </label>
 
     <br>
     <br>
@@ -157,6 +163,7 @@
       var techRadios = document.getElementsByName('technology-mode');
       var techMode = getCheckedValue('technology-mode') || 'auto';
       var autoplay = getCheckedValue('autoplay') || 'off';
+      var overrideNative = getCheckedValue('override-native') || 'off';
       var captionTrack = document.getElementById('caption-track').value || "";
       var url = document.getElementById('url-to-load').value || "";
       var options = {};
@@ -179,6 +186,11 @@
         } else if (techMode === 'off') {
           options.autoplay = false;
         }
+      }
+      if (overrideNative === 'on') {
+        videojs.options.hls.overrideNative = true;
+      } else if (overrideNative === 'off') {
+        videojs.options.hls.overrideNative = false;
       }
       var type = document.getElementById('url-content-type').value;
       // use the form data to add a src to the player

--- a/utils/stats/index.html
+++ b/utils/stats/index.html
@@ -187,11 +187,9 @@
           options.autoplay = false;
         }
       }
-      if (overrideNative === 'on') {
-        videojs.options.hls.overrideNative = true;
-      } else if (overrideNative === 'off') {
-        videojs.options.hls.overrideNative = false;
-      }
+
+      videojs.options.hls.overrideNative = overrideNative === 'on';
+
       var type = document.getElementById('url-content-type').value;
       // use the form data to add a src to the player
       try {


### PR DESCRIPTION
## Description
This provides an option ~~`videojs.options.hls.preferNative`~~ `videojs.options.hls.overrideNative` to set contrib-hls first in the HTML5 source handler order. This will allow MSE based HLS playback where native HLS is supported.

## Specific Changes proposed
~~- Removed `Hls.supportsNativeHls`, video.js should do this automatically~~
~~- Added `videojs.options.hls.preferNative`, defaults to `true`~~
- Added `videojs.options.hls.overrideNative`, does not exist by default, set to `true` to use contrib-hls where MSE is available.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors

