### PR TITLE
Null check attributes before dereferencing

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -257,17 +257,20 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     let currentBandwidth = loader.media().attributes.BANDWIDTH || 0;
 
-    return !(loader.master.playlists.filter((element, index, array) => {
-      let enabled = typeof element.excludeUntil === 'undefined' ||
-                      element.excludeUntil <= Date.now();
+    return !(loader.master.playlists.filter((playlist) => {
+      let enabled = typeof playlist.excludeUntil === 'undefined' ||
+                      playlist.excludeUntil <= Date.now();
 
       if (!enabled) {
         return false;
       }
 
-      let item = element.attributes.BANDWIDTH;
+      let bandwidth = 0;
 
-      return item <= currentBandwidth;
+      if (playlist && playlist.attributes) {
+        bandwidth = playlist.attributes.BANDWIDTH;
+      }
+      return bandwidth <= currentBandwidth;
 
     }).length > 1);
   };

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -162,6 +162,14 @@ QUnit.test('playlist loader detects if we are on lowest rendition', function() {
   };
 
   QUnit.ok(!loader.isLowestEnabledRendition_(), 'Detected not on lowest rendition');
+
+  loader.master.playlists = [{
+    attributes: { BANDWIDTH: 10 }
+  }, {}];
+  loader.media = function() {
+    return loader.master.playlists[0];
+  };
+  QUnit.ok(!loader.isLowestEnabledRendition_(), 'detected not on lowest rendition');
 });
 
 QUnit.test('resolves media initialization segment URIs', function() {


### PR DESCRIPTION
## Description
The lowest rendition check can occur before all the playlists have loaded. If this happens, don't throw an exception trying to find out the bandwidth.