### PR TITLE
fix trim buffer to compare correct segments

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -590,7 +590,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // If we are going to remove time from the front of the buffer, make
     // sure we aren't discarding a partial segment to avoid throwing
     // PLAYER_ERR_TIMEOUT while trying to read a partially discarded segment
-    for (let i = 0; i <= segmentInfo.playlist.segments.length; i++) {
+    for (let i = 1; i <= segmentInfo.playlist.segments.length; i++) {
       // Loop through the segments and calculate the duration to compare
       // against the removeToTime
       let removeDuration = duration(segmentInfo.playlist,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -587,6 +587,10 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     removeToTime = currentTime - 60;
 
+    if (!this.playlist_.endList) {
+      return removeToTime;
+    }
+
     // If we are going to remove time from the front of the buffer, make
     // sure we aren't discarding a partial segment to avoid throwing
     // PLAYER_ERR_TIMEOUT while trying to read a partially discarded segment

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -569,7 +569,7 @@ export default class SegmentLoader extends videojs.EventTarget {
   trimBuffer_(segmentInfo) {
     let seekable = this.seekable_();
     let currentTime = this.currentTime_();
-    let removeToTime = 0;
+    let removeToTime;
 
     // Chrome has a hard limit of 150mb of
     // buffer and a very conservative "garbage collector"
@@ -582,10 +582,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (seekable.length &&
         seekable.start(0) > 0 &&
         seekable.start(0) < currentTime) {
-      removeToTime = seekable.start(0);
-    } else {
-      removeToTime = currentTime - 60;
+      return seekable.start(0);
     }
+
+    removeToTime = currentTime - 60;
 
     // If we are going to remove time from the front of the buffer, make
     // sure we aren't discarding a partial segment to avoid throwing

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1995,9 +1995,8 @@ QUnit.test('cleans up the buffer when loading live segments', function() {
   QUnit.strictEqual(this.requests[0].url, 'liveStart30sBefore.m3u8',
                     'master playlist requested');
   QUnit.equal(removes.length, 1, 'remove called');
-  // segment-loader removes up to the segment prior to seekable.start
-  // to avoid crossing segment-boundaries
-  QUnit.deepEqual(removes[0], [0, seekable.start(0) - 10],
+  // segment-loader removes at seekable.start(0)
+  QUnit.deepEqual(removes[0], [0, seekable.start(0)],
                   'remove called with the right range');
 
   // verify stats

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2050,7 +2050,7 @@ QUnit.test('cleans up the buffer based on currentTime when loading a live segmen
 
   QUnit.strictEqual(this.requests[0].url, 'liveStart30sBefore.m3u8', 'master playlist requested');
   QUnit.equal(removes.length, 1, 'remove called');
-  QUnit.deepEqual(removes[0], [0, 80 - 70], 'remove called with the right range');
+  QUnit.deepEqual(removes[0], [0, 80 - 60], 'remove called with the right range');
 
   // verify stats
   QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');


### PR DESCRIPTION
## Description
Buffer was not being trimmed in live playlist since both duration and seekable are calculated in the same way. When we try to make sure we aren't discarding a partial segment, we start at index 0 which gives a previous segment of -1. This change starts at 1 so we compare segment 1 to segment 0 to properly set removeToTime

