### PR TITLE
Updated the reloadSourceOnError plugin

### DIFF
--- a/src/reload-source-on-error.js
+++ b/src/reload-source-on-error.js
@@ -1,34 +1,74 @@
-/**
- * Reload the source when an error is detected as long as there
- * wasn't an error previously within the last 30 seconds
- */
-const reloadSourceOnError = function() {
-  const player = this;
+import videojs from 'video.js';
+
+const defaultOptions = {
+  errorInterval: 30
+};
+
+const initPlugin = function(player, options) {
   let lastCalled = 0;
-  const reloadSource = function() {
+  let seekTo = 0;
+  let localOptions = videojs.mergeOptions(defaultOptions, options);
+
+  const loadedMetadataHandler = function() {
+    if (seekTo) {
+      player.currentTime(seekTo);
+    }
+  };
+
+  const getSource = function(next) {
     let tech = player.tech({ IWillNotUseThisInPlugins: true });
     let sourceObj = tech.currentSource_;
-    let seekTo = (player.duration() !== Infinity && player.currentTime()) || 0;
 
-    if (Date.now() - lastCalled < 30 * 1000) {
+    return next(sourceObj);
+  };
+
+  const setSource = function(sourceObj) {
+    seekTo = (player.duration() !== Infinity && player.currentTime()) || 0;
+
+    // Do not attempt to reload the source if a source-reload occurred before
+    // 'errorInterval' time has elapsed since the last source-reload
+    if (Date.now() - lastCalled < localOptions.errorInterval * 1000) {
       return;
     }
     lastCalled = Date.now();
 
-    if (seekTo) {
-      player.one('loadedmetadata', () => {
-        player.currentTime(seekTo);
-      });
-    }
+    player.one('loadedmetadata', loadedMetadataHandler);
 
     player.src(sourceObj);
     player.play();
   };
 
-  player.on('error', reloadSource);
-  player.on('dispose', () => {
+  const reloadSource = function() {
+    if (localOptions.getSource &&
+        typeof localOptions.getSource === 'function') {
+      return localOptions.getSource(setSource);
+    }
+
+    return getSource(setSource);
+  };
+
+  const cleanupEvents = function() {
+    player.off('loadedmetadata', loadedMetadataHandler);
     player.off('error', reloadSource);
-  });
+    player.off('dispose', cleanupEvents);
+  };
+
+  const reinitPlugin = function(newOptions) {
+    cleanupEvents();
+    initPlugin(player, newOptions);
+  };
+
+  player.on('error', reloadSource);
+  player.on('dispose', cleanupEvents);
+  player.reloadSourceOnError = reinitPlugin;
+};
+
+/**
+ * Reload the source when an error is detected as long as there
+ * wasn't an error previously within the last 30 seconds
+ */
+const reloadSourceOnError = function(options) {
+  initPlugin(this, options);
 };
 
 export default reloadSourceOnError;

--- a/test/reload-source-on-error.test.js
+++ b/test/reload-source-on-error.test.js
@@ -51,10 +51,18 @@ QUnit.module('ReloadSourceOnError', {
 
     this.player.reloadSourceOnError = reloadSourceOnError;
     this.clock.tick(60 * 1000);
+
+    this.oldLog = videojs.log.error;
+    this.errors = [];
+
+    videojs.log.error = (...args) => {
+      this.errors.push(...args);
+    };
   },
 
   afterEach() {
     this.clock.restore();
+    videojs.log.error = this.oldLog;
   }
 });
 
@@ -151,4 +159,15 @@ QUnit.test('allows you to provide a getSource function', function() {
 
   QUnit.equal(this.player.src.calledWith.length, 1, 'player.src was only called once');
   QUnit.deepEqual(this.player.src.calledWith[0], newSource, 'player.src was called with return value of options.getSource()');
+});
+
+QUnit.test('errors if getSource is not a function', function() {
+  this.player.reloadSourceOnError({
+    getSource: 'totally not a function'
+  });
+
+  this.player.trigger('error', -2);
+
+  QUnit.equal(this.player.src.calledWith.length, 0, 'player.src was never called');
+  QUnit.equal(this.errors.length, 1, 'videojs.log.error was called once');
 });


### PR DESCRIPTION
1. Allow the ability to pass a `getSource` function that can be used to provide a new source to load on error
2. Added the ability to override the default minimum time between errors in seconds
3. Plugin now cleans up event bindings when initialized multiple times
4. Better doc-comments!