### PR TITLE
Don't try to reload if the getSource function returns null or undefined

### DIFF
--- a/src/reload-source-on-error.js
+++ b/src/reload-source-on-error.js
@@ -41,6 +41,9 @@ const initPlugin = function(player, options) {
    * @private
    */
   const setSource = function(sourceObj) {
+    if (sourceObj === null || sourceObj === undefined) {
+      return;
+    }
     seekTo = (player.duration() !== Infinity && player.currentTime()) || 0;
 
     player.one('loadedmetadata', loadedMetadataHandler);

--- a/test/reload-source-on-error.test.js
+++ b/test/reload-source-on-error.test.js
@@ -171,3 +171,21 @@ QUnit.test('errors if getSource is not a function', function() {
   QUnit.equal(this.player.src.calledWith.length, 0, 'player.src was never called');
   QUnit.equal(this.errors.length, 1, 'videojs.log.error was called once');
 });
+
+QUnit.test('should not set source if getSource returns null or undefined', function() {
+  this.player.reloadSourceOnError({
+    getSource: () => undefined
+  });
+
+  this.player.trigger('error', -2);
+
+  QUnit.equal(this.player.src.calledWith.length, 0, 'player.src was never called');
+
+  this.player.reloadSourceOnError({
+    getSource: () => null
+  });
+
+  this.player.trigger('error', -2);
+
+  QUnit.equal(this.player.src.calledWith.length, 0, 'player.src was never called');
+});


### PR DESCRIPTION
Sometimes `currentSource_` is null which is a valid source. It will clear the player error state though it eventually causes a timeout (because of the invocation of `play`). This change just doesn't try to reload the source at all if the object returned by `getSource` is null or undefined which would have the effect of passing the error (likely a PLAYER_ERR_TIMEOUT) through to display in the error modal.