### PR TITLE
resolve-url.js now uses an iframe to contain the base and anchor elements used to resolve relative urls

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -5,7 +5,7 @@
  * M3U8 playlists.
  *
  */
-import resolveUrl from './resolve-url';
+import resolveUrlFactory from './resolve-url';
 import {mergeOptions} from 'video.js';
 import Stream from './stream';
 import m3u8 from 'm3u8-parser';
@@ -52,7 +52,7 @@ const updateSegments = function(original, update, offset) {
   * master playlist with the updated media playlist merged in, or
   * null if the merge produced no change.
   */
-const updateMaster = function(master, media) {
+const updateMaster = function(master, media, resolveUrl) {
   let changed = false;
   let result = mergeOptions(master, {});
   let i = master.playlists.length;
@@ -125,6 +125,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
   let request;
   let playlistRequestError;
   let haveMetadata;
+  let resolveUrl = resolveUrlFactory();
 
   PlaylistLoader.prototype.constructor.call(this);
 
@@ -179,7 +180,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     parser.manifest.uri = url;
 
     // merge this playlist into the master
-    update = updateMaster(loader.master, parser.manifest);
+    update = updateMaster(loader.master, parser.manifest, resolveUrl);
     refreshDelay = (parser.manifest.targetDuration || 10) * 1000;
     loader.targetDuration = parser.manifest.targetDuration;
     if (update) {

--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -2,43 +2,57 @@
  * @file resolve-url.js
  */
 import document from 'global/document';
+
 /**
- * Constructs a new URI by interpreting a path relative to another
- * URI.
- *
- * @see http://stackoverflow.com/questions/470832/getting-an-absolute-url-from-a-relative-one-ie6-issue
- * @param {String} basePath a relative or absolute URI
- * @param {String} path a path part to combine with the base
- * @return {String} a URI that is equivalent to composing `base`
- * with `path`
+ * Creates an iframe to contain our base and anchor elements for url resolving function
  */
-const resolveUrl = function(basePath, path) {
-  // use the base element to get the browser to handle URI resolution
-  let oldBase = document.querySelector('base');
-  let docHead = document.querySelector('head');
-  let a = document.createElement('a');
-  let base = oldBase;
-  let oldHref;
-  let result;
+const createResolverElements = () => {
+  const iframe = document.createElement('iframe');
 
-  // prep the document
-  if (oldBase) {
-    oldHref = oldBase.href;
-  } else {
-    base = docHead.appendChild(document.createElement('base'));
-  }
+  iframe.style.display = 'none';
+  iframe.src = 'about:blank';
+  document.body.appendChild(iframe);
 
-  base.href = basePath;
-  a.href = path;
-  result = a.href;
+  const iframeDoc = iframe.contentWindow.document;
 
-  // clean up
-  if (oldBase) {
-    oldBase.href = oldHref;
-  } else {
-    docHead.removeChild(base);
-  }
-  return result;
+  iframeDoc.open();
+  iframeDoc.write('<html><head><base></base></head><body><a></a></body></html>');
+  iframeDoc.close();
+
+  const base = iframeDoc.querySelector('base');
+  const anchor = iframeDoc.querySelector('a');
+
+  document.body.removeChild(iframe);
+
+  return [base, anchor];
 };
 
-export default resolveUrl;
+/**
+ * Build a new URI resolver by adding an iframe for resolving and returning a resolving function
+ * that can be disposed
+ */
+const resolveUrlFactory = () => {
+  const [base, anchor] = createResolverElements();
+
+  /**
+   * Constructs a new URI by interpreting a path relative to another
+   * URI.
+   *
+   * @see http://stackoverflow.com/questions/470832/getting-an-absolute-url-from-a-relative-one-ie6-issue
+   * @param {String} basePath a relative or absolute URI
+   * @param {String} path a path part to combine with the base
+   * @return {String} a URI that is equivalent to composing `base`
+   * with `path`
+   */
+  const resolveUrl = (basePath, path) => {
+    if (basePath !== base.href) {
+      base.href = basePath;
+    }
+    anchor.href = path;
+    return anchor.href;
+  };
+
+  return resolveUrl;
+};
+
+export default resolveUrlFactory;


### PR DESCRIPTION
## Description

Before this fix, we were using a temporary base element (created on-the-fly) to change the relative url resolution of the entire page. We did this for every single url that we needed to resolve (potentially hundreds or thousands per playlist). Some foxy browsers were particularly slow at this when the page contained many anchor tags.

This change sandboxes the base element and anchor into an iframe so that the host-page is unaffected and performance shouldn't suffer as much. In addition, this will only create a single iframe, base, and anchor element for each PlaylistLoader and reuse them for the entire lifetime of the playlist. 