### PR TITLE
If manifest returns 301/302, build the segment list relative to the redirect

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -354,8 +354,9 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     if (this.media_) {
       this.trigger('mediachanging');
     }
+
     request = this.hls_.xhr({
-      uri: resolveUrl(loader.master.uri, playlist.uri),
+      uri: playlist.resolvedUri,
       withCredentials
     }, function(error, req) {
       // disposed
@@ -367,6 +368,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 	      // if the playlist returns a 302 redirect for manifest,
 	      // build the segment list relative to the redirected URI
 	      playlist.resolvedUri = request.responseURL;
+	      loader.master.playlists[playlist.uri].resolvedUri = request.responseURL;
       }
 
       if (error) {
@@ -406,7 +408,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     loader.state = 'HAVE_CURRENT_METADATA';
     request = this.hls_.xhr({
-      uri: resolveUrl(loader.master.uri, loader.media().uri),
+      uri: loader.media().resolvedUri,
       withCredentials
     }, function(error, req) {
       // disposed

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -363,6 +363,12 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
         return;
       }
 
+      if(request.responseURL) {
+	      // if the playlist returns a 302 redirect for manifest,
+	      // build the segment list relative to the redirected URI
+	      playlist.resolvedUri = request.responseURL;
+      }
+
       if (error) {
         return playlistRequestError(request, playlist.uri, startingState);
       }


### PR DESCRIPTION

If manifest returns 301/302, build the segment list relative to the redirect. Update code to make requests relative to the URL returned by the 301/302.

Most HTML5 players used to behave badly with 301/302, since the XMLHttpRequest object did not, until recently, expose the final manifest location. HTML5 based players can now utilize the responseUrl attribute to fix this.

The segment list should be built off of the redirected manifest.

Broken Player Flow
http://some.host.org/path/manifest.m3u8 -> 302 -> http://other.host.org/path/manifest.m3u8
http://some.host.org/path/chunk1.ts (302)
http://some.host.org/path/chunk2.ts (302)

If the server has been configured to 302 redirect for everything, this will result in each of the above chunks also having a 302 redirect. If the server hasn't been configured, then they will fail.

Correct Player Flow
http://some.host.org/path/manifest.m3u8 -> 302 -> http://other.host.org/path/manifest.m3u8
http://other.host.org/path/chunk1.ts (200)
http://other.host.org/path/chunk2.ts (200)
(manifest update)
http://some.host.org/path/manifest.m3u8 -> 302 -> http://another.host.org/path/manifest.m3u8
http://another.host.org/path/chunk1.ts (200)
http://another.host.org/path/chunk2.ts (200)


- We have resolved this issue on Shaka player (https://github.com/google/shaka-player/pull/266)
- It has also been resolved on google chrome cast (https://code.google.com/p/google-cast-sdk/issues/detail?id=746)
- It has been resolved upstream in Dash.js

