### PR TITLE
Added support for the throughput of the whole system to the ABR algorithm

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -755,7 +755,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (request === this.xhr_.segmentXhr) {
       // the segment request is no longer outstanding
       this.xhr_.segmentXhr = null;
-      segmentInfo.startOfLoad_ = (new Date()).getTime();
+      segmentInfo.startOfLoad_ = Date.now();
 
       // calculate the download bandwidth based on segment request
       this.roundTrip = request.roundTripTime;
@@ -1036,7 +1036,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Add one to the time to ensure that we don't accidentally attempt to divide
     // by zero in the case where the throughput is ridiculously high
     let segmentProcessingTime =
-      1 + ((new Date()).getTime() - segmentInfo.startOfLoad_);
+      Date.now() - segmentInfo.startOfLoad_ + 1;
     // Multiply by 8000 to convert from bytes/millisecond to bits/second
     let segmentProcessingThroughput =
       Math.floor((segmentInfo.byteLength / segmentProcessingTime) * 8 * 1000);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -755,7 +755,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (request === this.xhr_.segmentXhr) {
       // the segment request is no longer outstanding
       this.xhr_.segmentXhr = null;
-      segmentInfo.startOfLoad_ = Date.now();
+      segmentInfo.startOfAppend = Date.now();
 
       // calculate the download bandwidth based on segment request
       this.roundTrip = request.roundTripTime;
@@ -1036,7 +1036,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Add one to the time to ensure that we don't accidentally attempt to divide
     // by zero in the case where the throughput is ridiculously high
     let segmentProcessingTime =
-      Date.now() - segmentInfo.startOfLoad_ + 1;
+      Date.now() - segmentInfo.startOfAppend + 1;
     // Multiply by 8000 to convert from bytes/millisecond to bits/second
     let segmentProcessingThroughput =
       Math.floor((segmentInfo.byteLength / segmentProcessingTime) * 8 * 1000);

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -405,6 +405,8 @@ class HlsHandler extends Component {
         },
         set(throughput) {
           this.masterPlaylistController_.mainSegmentLoader_.throughput.rate = throughput;
+          // By setting `count` to 1 the throughput value becomes the starting value
+          // for the cumulative average
           this.masterPlaylistController_.mainSegmentLoader_.throughput.count = 1;
         }
       },
@@ -415,6 +417,8 @@ class HlsHandler extends Component {
         set(bandwidth) {
           this.masterPlaylistController_.mainSegmentLoader_.bandwidth = bandwidth;
           // setting the bandwidth manually resets the throughput counter
+          // `count` is set to zero that current value of `rate` isn't included
+          // in the cumulative average
           this.masterPlaylistController_.mainSegmentLoader_.throughput = {rate: 0, count: 0};
         }
       },

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -31,7 +31,7 @@ const xhrFactory = function() {
 
     let request = videojsXHR(options, function(error, response) {
       if (!error && request.response) {
-        request.responseTime = (new Date()).getTime();
+        request.responseTime = Date.now();
         request.roundTripTime = request.responseTime - request.requestTime;
         request.bytesReceived = request.response.byteLength || request.response.length;
         if (!request.bandwidth) {
@@ -63,7 +63,7 @@ const xhrFactory = function() {
       callback(error, request);
     });
 
-    request.requestTime = (new Date()).getTime();
+    request.requestTime = Date.now();
     return request;
   };
 

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -289,7 +289,7 @@ export const standardXHRResponse = function(request, data) {
     data = testDataManifests[manifestName];
   }
 
-  request.response = new Uint8Array(16).buffer;
+  request.response = new Uint8Array(1024).buffer;
   request.respond(200, {'Content-Type': contentType}, data);
 };
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -484,7 +484,7 @@ QUnit.test('setting bandwidth resets throughput', function() {
                     'throughput is reset when bandwidth is specified');
 });
 
-QUnit.test('setting thoughput of zero is ignored in systemBandwidth', function() {
+QUnit.test('a thoughput of zero is ignored in systemBandwidth', function() {
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -511,19 +511,6 @@ QUnit.test('systemBandwidth is a combination of thoughput and bandwidth', functi
                     'systemBandwidth is the combination of bandwidth and throughput');
 });
 
-QUnit.test('setting bandwidth resets throughput', function() {
-  this.player.src({
-    src: 'manifest/master.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-  this.player.tech_.hls.throughput = 1000;
-  this.player.tech_.hls.bandwidth = 20e10;
-
-  QUnit.strictEqual(this.player.tech_.hls.throughput,
-                    0,
-                    'throughput is reset when bandwidth is specified');
-});
-
 QUnit.test('upshifts if the initial bandwidth hint is high', function() {
   this.player.src({
     src: 'manifest/master.m3u8',

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -157,7 +157,7 @@ QUnit.test('stats are reset on each new source', function() {
   standardXHRResponse(this.requests.shift());
   standardXHRResponse(this.requests.shift());
 
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, 'stat is set');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, 'stat is set');
   this.player.src({
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'
@@ -387,7 +387,7 @@ QUnit.test('starts downloading a segment on loadedmetadata', function() {
                     'the first segment is requested');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -465,8 +465,63 @@ QUnit.test('downloads media playlists after loading the master', function() {
                     'first segment requested');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
+});
+
+QUnit.test('setting bandwidth resets throughput', function() {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.player.tech_.hls.throughput = 1000;
+  QUnit.strictEqual(this.player.tech_.hls.throughput,
+                    1000,
+                    'throughput is set');
+  this.player.tech_.hls.bandwidth = 20e10;
+  QUnit.strictEqual(this.player.tech_.hls.throughput,
+                    0,
+                    'throughput is reset when bandwidth is specified');
+});
+
+QUnit.test('setting thoughput of zero is ignored in systemBandwidth', function() {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.player.tech_.hls.bandwidth = 20e10;
+  QUnit.strictEqual(this.player.tech_.hls.throughput,
+                    0,
+                    'throughput is reset when bandwidth is specified');
+  QUnit.strictEqual(this.player.tech_.hls.systemBandwidth,
+                    20e10,
+                    'systemBandwidth is the same as bandwidth');
+});
+
+QUnit.test('systemBandwidth is a combination of thoughput and bandwidth', function() {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.player.tech_.hls.bandwidth = 20e10;
+  this.player.tech_.hls.throughput = 20e10;
+  // 1 / ( 1 / 20e10 + 1 / 20e10) = 10e10
+  QUnit.strictEqual(this.player.tech_.hls.systemBandwidth,
+                    10e10,
+                    'systemBandwidth is the combination of bandwidth and throughput');
+});
+
+QUnit.test('setting bandwidth resets throughput', function() {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.player.tech_.hls.throughput = 1000;
+  this.player.tech_.hls.bandwidth = 20e10;
+
+  QUnit.strictEqual(this.player.tech_.hls.throughput,
+                    0,
+                    'throughput is reset when bandwidth is specified');
 });
 
 QUnit.test('upshifts if the initial bandwidth hint is high', function() {
@@ -498,7 +553,7 @@ QUnit.test('upshifts if the initial bandwidth hint is high', function() {
   );
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -525,7 +580,7 @@ QUnit.test('downshifts if the initial bandwidth hint is low', function() {
                     'first segment requested');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -1543,7 +1598,7 @@ QUnit.test('calling play() at the end of a video replays', function() {
   QUnit.equal(seekTime, 0, 'seeked to the beginning');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -1626,7 +1681,7 @@ QUnit.test('seeking should abort an outstanding key request and create a new one
               'urls should match');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -1672,7 +1727,7 @@ QUnit.test('switching playlists with an outstanding key request aborts request a
               'http://media.example.com/fileSequence52-A.ts',
               'requested the segment');
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2000,7 +2055,7 @@ QUnit.test('cleans up the buffer when loading live segments', function() {
                   'remove called with the right range');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2053,7 +2108,7 @@ QUnit.test('cleans up the buffer based on currentTime when loading a live segmen
   QUnit.deepEqual(removes[0], [0, 80 - 60], 'remove called with the right range');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2092,7 +2147,7 @@ QUnit.test('cleans up the buffer when loading VOD segments', function() {
   QUnit.deepEqual(removes[0], [0, 120 - 60], 'remove called with the right range');
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2237,7 +2292,7 @@ QUnit.test('Allows overriding the global beforeRequest function', function() {
   delete videojs.Hls.xhr.beforeRequest;
 
   // verify stats
-  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 16, 'seen above');
+  QUnit.equal(this.player.tech_.hls.stats.mediaBytesTransferred, 1024, 'seen above');
   QUnit.equal(this.player.tech_.hls.stats.mediaRequests, 1, 'one segment request');
 });
 
@@ -2336,7 +2391,7 @@ QUnit.test('stats are reset on dispose', function() {
   // media
   standardXHRResponse(this.requests.shift());
 
-  QUnit.equal(hls.stats.mediaBytesTransferred, 16, 'stat is set');
+  QUnit.equal(hls.stats.mediaBytesTransferred, 1024, 'stat is set');
   hls.dispose();
   QUnit.equal(hls.stats.mediaBytesTransferred, 0, 'stat is reset');
 });
@@ -2408,7 +2463,7 @@ QUnit.test('downloads additional playlists if required', function() {
 
   // verify stats
   QUnit.equal(hls.stats.bandwidth, 3000000, 'default');
-  QUnit.equal(hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2449,7 +2504,7 @@ QUnit.test('waits to download new segments until the media playlist is stable', 
 
   // verify stats
   QUnit.equal(hls.stats.bandwidth, Infinity, 'default');
-  QUnit.equal(hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(hls.stats.mediaRequests, 1, '1 request');
 });
 
@@ -2566,7 +2621,11 @@ QUnit.test('blacklists playlist if key requests fail', function() {
              '#EXT-X-ENDLIST\n');
 
   // segment 1
-  standardXHRResponse(this.requests.shift());
+  if (/key\.php/i.test(this.requests[0].url)) {
+    standardXHRResponse(this.requests.pop());
+  } else {
+    standardXHRResponse(this.requests.shift());
+  }
   // fail key
   this.requests.shift().respond(404);
   QUnit.ok(hls.playlists.media().excludeUntil > 0,
@@ -2609,6 +2668,6 @@ QUnit.test('treats invalid keys as a key request failure and blacklists playlist
   QUnit.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
 
   // verify stats
-  QUnit.equal(hls.stats.mediaBytesTransferred, 16, '16 bytes');
+  QUnit.equal(hls.stats.mediaBytesTransferred, 1024, '1024 bytes');
   QUnit.equal(hls.stats.mediaRequests, 1, '1 request');
 });


### PR DESCRIPTION
## Description
Right now the ABR algorithm only takes into account the network bandwidth when making a determination about which variant stream to select. The issue with that is that the ABR algorithm is ignoring the time it takes to decrypt, transmux, and append a segment.

With MSE this isn't too worrying since the bandwidth of that second part of the segment loading process is huge - testing shows that it is in excess of 150 Mb/s. As a result, it's effect on the total system bandwidth is relatively minor.

When using Flash, things are very very different. The reason for this is two-fold: First, Flash is typically only used as a fallback on IE and IE's JavaScript engine doesn't exactly have stellar performance. The second problem is Flash itself.

The mechanism for transferring data into Flash from JavaScript is slow and, worse, it blocks the main browser thread. To get around this problem we chunk up the data and send it piece by piece to Flash. That chunking has the effect of limiting the amount of data we are able to send to Flash per unit of time - creating a hard limit on that component of the system bandwidth.

The equation for determining the aggregate system bandwidth for segment loading is:

```
systemBandwidth = 1 / (1 / networkBandwidth + 1 / appendBandwidth)
```

An example will help to show how this affects variant selection. Let's assume that playback is happening on a computer with ~4Mb/s of network bandwidth.

Starting with the MSE case, we have:

```
1 / (1 / 4Mbps + 1 / 150Mbps) = 3.896Mbps
```

...showing that network bandwidth is a pretty good proxy for system bandwidth when the append bandwidth is so large. Since we apply a scale value to account for network variance we would select a variant around 3.3Mb/s and playback would be fine. 

Now for the Flash side:

```
1 / (1 / 4Mbps + 1 / 5Mbps) = 2.222Mbps
```

...using only the network bandwidth in this situation would result in a pretty poor playback experience. Currently, we'd select the same 3.3Mb/s variant and there is no way that the system could keep up. The results would be stuttering during playback and stalls.