### PR TITLE
Revert "Upgrade aes-decrypter to use webcrypto for HLSe decryption where available. (#777)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test/"
   ],
   "dependencies": {
-    "aes-decrypter": "^2.0.0",
+    "aes-decrypter": "^1.0.3",
     "global": "^4.3.0",
     "m3u8-parser": "^1.0.2",
     "mux.js": "^3.0.0",

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -847,12 +847,8 @@ QUnit.test('the key is saved to the segment in the correct format', function(ass
   segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
 
   assert.deepEqual(segment.key.bytes,
-                   new Uint8Array([
-                     0x00, 0x00, 0x00, 0x00,
-                     0x01, 0x00, 0x00, 0x00,
-                     0x02, 0x00, 0x00, 0x00,
-                     0x03, 0x00, 0x00, 0x00]),
-                   'passed the specified segment key');
+                  new Uint32Array([0, 0x01000000, 0x02000000, 0x03000000]),
+                  'passed the specified segment key');
 
   // verify stats
   assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
@@ -897,21 +893,15 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   let keyRequest;
   let segmentRequest;
 
-  let doneDecrypting = assert.async();
-
   // stop processing so we can examine segment info
-  loader.handleSegment_ = function() {
-    assert.ok(loader.pendingSegment_.bytes, 'decrypted bytes in segment');
-    doneDecrypting();
-  };
+  loader.handleSegment_ = function() {};
 
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
   loader.mimeType(this.mimeType);
   loader.load();
 
   segmentRequest = this.requests.pop();
-  // this response is [0, 1, 2, 3, 4, 5, 6, 7] encrypted
-  segmentRequest.response = new Uint8Array([60, 15, 94, 17, 13, 247, 26, 97, 97, 236, 17, 188, 250, 16, 52, 39]).buffer;
+  segmentRequest.response = new Uint8Array(8).buffer;
   segmentRequest.respond(200, null, '');
   assert.ok(loader.pendingSegment_.encryptedBytes, 'encrypted bytes in segment');
   assert.ok(!loader.pendingSegment_.bytes, 'no decrypted bytes in segment');
@@ -921,10 +911,13 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   keyRequest.respond(200, null, '');
 
   // Allow the decrypter to decrypt
-  this.clock.tick(1000);
+  this.clock.tick(1);
+  // Allow the decrypter's async stream to run the callback
+  this.clock.tick(1);
+  assert.ok(loader.pendingSegment_.bytes, 'decrypted bytes in segment');
 
   // verify stats
-  assert.equal(loader.mediaBytesTransferred, 16, '16 bytes');
+  assert.equal(loader.mediaBytesTransferred, 8, '8 bytes');
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 


### PR DESCRIPTION
This reverts commit b9692e29de401a5af50a8bcbc1b04bc2008e1f4f.

We might have problems with the new web-crypto support. So this reverts those changes in contrib-hls while we get aes-decrypter sorted out.