### PR TITLE
Fix excessive segment loads on seeks

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -835,11 +835,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     // cancel outstanding requests so we begin buffering at the new
     // location
-    this.mainSegmentLoader_.abort();
     this.mainSegmentLoader_.resetEverything();
+    this.mainSegmentLoader_.abort();
     if (this.audioPlaylistLoader_) {
-      this.audioSegmentLoader_.abort();
       this.audioSegmentLoader_.resetEverything();
+      this.audioSegmentLoader_.abort();
     }
 
     if (!this.tech_.paused()) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -724,7 +724,6 @@ export default class SegmentLoader extends videojs.EventTarget {
   handleResponse_(error, request) {
     let segmentInfo;
     let segment;
-    let keyXhrRequest;
     let view;
 
     // timeout of previously aborted request
@@ -750,7 +749,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // trigger an event for other errors
     if (!request.aborted && error) {
       // abort will clear xhr_
-      keyXhrRequest = this.xhr_.keyXhr;
+      let keyXhrRequest = this.xhr_.keyXhr;
       this.abort_();
       this.error({
         status: request.status,
@@ -791,7 +790,6 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (request === this.xhr_.keyXhr) {
-      keyXhrRequest = this.xhr_.segmentXhr;
       // the key request is no longer outstanding
       this.xhr_.keyXhr = null;
 
@@ -991,8 +989,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.mediaIndex = segmentInfo.mediaIndex;
       this.fetchAtBuffer_ = true;
     }
-
-    this.pendingSegment_ = null;
 
     let currentMediaIndex = segmentInfo.mediaIndex;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -465,13 +465,19 @@ export default class SegmentLoader extends videojs.EventTarget {
     // fetch
     if (this.fetchAtBuffer_) {
       // Find the segment containing the end of the buffer
-      let mediaSourceInfo = getMediaInfoForTime(playlist, lastBufferedEnd, syncPoint.segmentIndex, syncPoint.time);
+      let mediaSourceInfo = getMediaInfoForTime(playlist,
+                                                lastBufferedEnd,
+                                                syncPoint.segmentIndex,
+                                                syncPoint.time);
 
       mediaIndex = mediaSourceInfo.mediaIndex;
       startOfSegment = mediaSourceInfo.startTime;
     } else {
       // Find the segment containing currentTime
-      let mediaSourceInfo = getMediaInfoForTime(playlist, currentTime, syncPoint.segmentIndex, syncPoint.time);
+      let mediaSourceInfo = getMediaInfoForTime(playlist,
+                                                currentTime,
+                                                syncPoint.segmentIndex,
+                                                syncPoint.time);
 
       mediaIndex = mediaSourceInfo.mediaIndex;
       startOfSegment = mediaSourceInfo.startTime;
@@ -750,6 +756,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (!request.aborted && error) {
       // abort will clear xhr_
       let keyXhrRequest = this.xhr_.keyXhr;
+
       this.abort_();
       this.error({
         status: request.status,


### PR DESCRIPTION
## Description
Sometimes when seeking, buffer time can be really long and the player will load all segments between the the seek points. There are a few cases that cause this behavior. 

First being the synchronous call to `fillBuffer_()` in `abort()` to avoid waiting for the check buffer timer. This makes aborting and reseting the loader order dependent. When `fillBuffer_` is called before the reset happens, it miscalculates the segment it should fetch. The eventual goal is to make any synchronous `fillBuffer_` calls to become asynchronous with a very short delay so state modifiers such as abort and reset are not order dependent. For now this PR just uses a quick fix of swapping the order of these two calls.

The other case is that `abort()` only aborts the segment when the loader is in the `WAITING` state. However, both the `DECRYPTING` and `APPENDING` states happen asynchronously. Since `handleUpdateEnd_()` changes the loader's `mediaIndex` and `fillAtBuffer_` states, if the timing is right and a seek happens in one of these two states happens, the loader will reset and resync, but won't cancel the segment since the state is not `WAITING`. This means that when the asynchronous process of decrypting or appending finishes and we reach `handleUpdateEnd_`, `mediaIndex` and `fillAtBuffer_` get updated with an outdated segment, causing confusion for `checkBuffer_`. If we clear `pendingSegment_` on an abort while not in the `WAITING` state, and check for `null` anywhere we access `pendingSegment_` we can avoid using outdated segment information.

## Specific Changes proposed
- Change the order of `abort()` and `resetEverything()` so loader state is correct before fetching more segments.
- Null `pendingSegment_` on an abort if it exists and the loader is not in the `WAITING` state.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
