### PR TITLE
Fix a segment hop in live

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -997,10 +997,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     currentMediaIndex +=
       segmentInfo.playlist.mediaSequence - this.playlist_.mediaSequence;
 
-    if (!segmentInfo.isSyncRequest) {
-      this.mediaIndex = currentMediaIndex;
-      this.fetchAtBuffer_ = true;
-    }
+    this.mediaIndex = currentMediaIndex;
+    this.fetchAtBuffer_ = true;
 
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -992,15 +992,15 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     log('handleUpdateEnd_');
 
-    if (!segmentInfo.isSyncRequest) {
-      this.mediaIndex = segmentInfo.mediaIndex;
-      this.fetchAtBuffer_ = true;
-    }
-
     let currentMediaIndex = segmentInfo.mediaIndex;
 
     currentMediaIndex +=
       segmentInfo.playlist.mediaSequence - this.playlist_.mediaSequence;
+
+    if (!segmentInfo.isSyncRequest) {
+      this.mediaIndex = currentMediaIndex;
+      this.fetchAtBuffer_ = true;
+    }
 
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will


### PR DESCRIPTION
## Description
In a case where the live playlist updates during processing of the first segment request, it is possible that we'd skip over the next segment and proceed down the playlist. This accounts for the change in media sequence during update end.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors