### PR TITLE
Representations and Quality Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ player.hls.representations().forEach(function(rep) {
 });
 ```
 
+Alternatively, you can include [videojs-contrib-quality-levels](https://github.com/videojs/videojs-contrib-quality-levels) to your page and hls will automatically populate the QualityLevelList exposed on the player by the plugin. You can access this list by calling `player.qualityLevels()`. See the [videojs-contrib-quality-levels project page](https://github.com/videojs/videojs-contrib-quality-levels) for more information on how to use the api.
+
 #### hls.xhr
 Type: `function`
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,24 @@ adaptive streaming logic.
 #### hls.representations
 Type: `function`
 
-To get all of the available representations, call the `representations()` method on `player.hls`. This will return a list of plain objects, each with `width`, `height`, `bandwidth`, and `id` properties, and an `enabled()` method.
+It is recommended to include the [videojs-contrib-quality-levels](https://github.com/videojs/videojs-contrib-quality-levels) plugin to your page so that videojs-contrib-hls will automatically populate the QualityLevelList exposed on the player by the plugin. You can access this list by calling `player.qualityLevels()`. See the [videojs-contrib-quality-levels project page](https://github.com/videojs/videojs-contrib-quality-levels) for more information on how to use the api.
+
+Example, only enabling representations with a width greater than or equal to 720:
+
+```javascript
+var qualityLevels = player.qualityLevels();
+
+for (var i = 0; i < qualityLevels.length; i++) {
+  var quality = qualityLevels[i];
+  if (quality.width >= 720) {
+    quality.enabled = true;
+  } else {
+    quality.enabled = false;
+  }
+}
+```
+
+If including [videojs-contrib-quality-levels](https://github.com/videojs/videojs-contrib-quality-levels) is not an option, you can use the representations api. To get all of the available representations, call the `representations()` method on `player.hls`. This will return a list of plain objects, each with `width`, `height`, `bandwidth`, and `id` properties, and an `enabled()` method.
 
 ```javascript
 player.hls.representations();
@@ -337,8 +354,6 @@ player.hls.representations().forEach(function(rep) {
   }
 });
 ```
-
-Alternatively, you can include [videojs-contrib-quality-levels](https://github.com/videojs/videojs-contrib-quality-levels) to your page and hls will automatically populate the QualityLevelList exposed on the player by the plugin. You can access this list by calling `player.qualityLevels()`. See the [videojs-contrib-quality-levels project page](https://github.com/videojs/videojs-contrib-quality-levels) for more information on how to use the api.
 
 #### hls.xhr
 Type: `function`

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "sinon": "1.10.2",
     "uglify-js": "^2.5.0",
     "videojs-standard": "^4.0.3",
+    "videojs-contrib-quality-levels": "^2.0.0",
     "watchify": "^3.6.0",
     "webpack": "^1.13.2"
   }

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "url-toolkit": "^1.0.4",
     "video.js": "^5.15.1",
     "videojs-contrib-media-sources": "^4.1.3",
+    "videojs-contrib-quality-levels": "^1.0.0",
     "videojs-swf": "^5.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "url-toolkit": "^1.0.4",
     "video.js": "^5.15.1",
     "videojs-contrib-media-sources": "^4.1.3",
-    "videojs-contrib-quality-levels": "^1.0.0",
     "videojs-swf": "^5.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "sinon": "1.10.2",
     "uglify-js": "^2.5.0",
     "videojs-standard": "^4.0.3",
-    "videojs-contrib-quality-levels": "^2.0.0",
+    "videojs-contrib-quality-levels": "^2.0.1",
     "watchify": "^3.6.0",
     "webpack": "^1.13.2"
   }

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "sinon": "1.10.2",
     "uglify-js": "^2.5.0",
     "videojs-standard": "^4.0.3",
-    "videojs-contrib-quality-levels": "^2.0.1",
+    "videojs-contrib-quality-levels": "^2.0.2",
     "watchify": "^3.6.0",
     "webpack": "^1.13.2"
   }

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -229,8 +229,10 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
    * @return {Number} number of eneabled playlists
    */
   loader.enabledPlaylists_ = function() {
-    return loader.master.playlists.filter((element, index, array) => {
-      return !element.excludeUntil || element.excludeUntil <= Date.now();
+    return loader.master.playlists.filter((playlist) => {
+      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+
+      return (!playlist.disabled && !blacklisted);
     }).length;
   };
 
@@ -249,8 +251,8 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     let currentBandwidth = loader.media().attributes.BANDWIDTH || 0;
 
     return !(loader.master.playlists.filter((playlist) => {
-      let enabled = typeof playlist.excludeUntil === 'undefined' ||
-                      playlist.excludeUntil <= Date.now();
+      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+      let enabled = (!playlist.disabled && !blacklisted);
 
       if (!enabled) {
         return false;

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -7,6 +7,7 @@
  */
 import resolveUrl from './resolve-url';
 import {mergeOptions} from 'video.js';
+import { isEnabled } from './playlist.js';
 import Stream from './stream';
 import m3u8 from 'm3u8-parser';
 import window from 'global/window';
@@ -229,11 +230,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
    * @return {Number} number of eneabled playlists
    */
   loader.enabledPlaylists_ = function() {
-    return loader.master.playlists.filter((playlist) => {
-      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
-
-      return (!playlist.disabled && !blacklisted);
-    }).length;
+    return loader.master.playlists.filter(isEnabled).length;
   };
 
   /**
@@ -251,8 +248,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     let currentBandwidth = loader.media().attributes.BANDWIDTH || 0;
 
     return !(loader.master.playlists.filter((playlist) => {
-      let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
-      let enabled = (!playlist.disabled && !blacklisted);
+      const enabled = isEnabled(playlist);
 
       if (!enabled) {
         return false;

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -455,14 +455,25 @@ export const getMediaInfoForTime_ = function(playlist, currentTime, startIndex, 
 };
 
 /**
+ * Check whether the playlist is blacklisted or not.
+ *
+ * @param {Object} playlist the media playlist object
+ * @return {boolean} whether the playlist is blacklisted or not
+ * @function isBlacklisted
+ */
+export const isBlacklisted = function(playlist) {
+  return playlist.excludeUntil && playlist.excludeUntil > Date.now();
+};
+
+/**
  * Check whether the playlist is enabled or not.
  *
- * @param {Object} playlist the media playlist  object
+ * @param {Object} playlist the media playlist object
  * @return {boolean} whether the playlist is enabled or not
  * @function isEnabled
  */
 export const isEnabled = function(playlist) {
-  const blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+  const blacklisted = isBlacklisted(playlist);
 
   return (!playlist.disabled && !blacklisted);
 };
@@ -471,6 +482,7 @@ Playlist.duration = duration;
 Playlist.seekable = seekable;
 Playlist.getMediaInfoForTime_ = getMediaInfoForTime_;
 Playlist.isEnabled = isEnabled;
+Playlist.isBlacklisted = isBlacklisted;
 
 // exports
 export default Playlist;

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -454,9 +454,23 @@ export const getMediaInfoForTime_ = function(playlist, currentTime, startIndex, 
   };
 };
 
+/**
+ * Check whether the playlist is enabled or not.
+ *
+ * @param {Object} playlist the media playlist  object
+ * @return {boolean} whether the playlist is enabled or not
+ * @function isEnabled
+ */
+export const isEnabled = function(playlist) {
+  const blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+
+  return (!playlist.disabled && !blacklisted);
+};
+
 Playlist.duration = duration;
 Playlist.seekable = seekable;
 Playlist.getMediaInfoForTime_ = getMediaInfoForTime_;
+Playlist.isEnabled = isEnabled;
 
 // exports
 export default Playlist;

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -92,6 +92,7 @@ let renditionSelectionMixin = function(hlsHandler) {
     return playlists
       .master
       .playlists
+      .filter((media) => !isBlacklisted(media))
       .map((e, i) => new Representation(hlsHandler, e, e.uri));
   };
 };

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -1,3 +1,4 @@
+import { isBlacklisted, isEnabled } from './playlist.js';
 /**
  * Enable/disable playlist function. It is intended to have the first two
  * arguments partially-applied in order to create the final per-playlist
@@ -11,10 +12,10 @@
  * or if undefined returns the current enabled-state for the playlist
  * @return {Boolean} The current enabled-state of the playlist
  */
-let enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
-  let playlist = loader.master.playlists[playlistUri];
-  let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
-  let currentlyEnabled = (!playlist.disabled && !blacklisted);
+const enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
+  const playlist = loader.master.playlists[playlistUri];
+  const blacklisted = isBlacklisted(playlist);
+  const currentlyEnabled = isEnabled(playlist);
 
   if (typeof enable === 'undefined') {
     return currentlyEnabled;

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -91,7 +91,7 @@ let renditionSelectionMixin = function(hlsHandler) {
     return playlists
       .master
       .playlists
-      .map((e, i) => new Representation(hlsHandler, e, i));
+      .map((e, i) => new Representation(hlsHandler, e, e.uri));
   };
 };
 

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -11,21 +11,22 @@
  * or if undefined returns the current enabled-state for the playlist
  * @return {Boolean} The current enabled-state of the playlist
  */
-let enableFunction = (playlist, changePlaylistFn, enable) => {
-  let currentlyEnabled = typeof playlist.excludeUntil === 'undefined' ||
-                         playlist.excludeUntil <= Date.now();
+let enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
+  let playlist = loader.master.playlists[playlistUri];
+  let blacklisted = playlist.excludeUntil && playlist.excludeUntil > Date.now();
+  let currentlyEnabled = (!playlist.disabled && !blacklisted);
 
   if (typeof enable === 'undefined') {
     return currentlyEnabled;
   }
 
-  if (enable !== currentlyEnabled) {
-    if (enable) {
-      delete playlist.excludeUntil;
-    } else {
-      playlist.excludeUntil = Infinity;
-    }
+  if (enable) {
+    delete playlist.disabled;
+  } else {
+    playlist.disabled = true;
+  }
 
+  if (enable !== currentlyEnabled && !blacklisted) {
     // Ensure the outside world knows about our changes
     changePlaylistFn();
   }
@@ -69,7 +70,10 @@ class Representation {
 
     // Partially-apply the enableFunction to create a playlist-
     // specific variant
-    this.enabled = enableFunction.bind(this, playlist, fastChangeFunction);
+    this.enabled = enableFunction.bind(this,
+                                       hlsHandler.playlists,
+                                       playlist.uri,
+                                       fastChangeFunction);
   }
 }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -103,10 +103,8 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
   sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    if (typeof localVariant.excludeUntil !== 'undefined') {
-      return now >= localVariant.excludeUntil;
-    }
-    return true;
+    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > Date.now();
+    return (!localVariant.disabled && !blacklisted)
   });
 
   // filter out any variant that has greater effective bitrate

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -78,7 +78,7 @@ const safeGetComputedStyle = function(el, property) {
 };
 
 /**
- * Updates the selcetedIndex of the QualityLevelList when a mediachange happens in hls.
+ * Updates the selectedIndex of the QualityLevelList when a mediachange happens in hls.
  *
  * @param {QualityLevelList} qualityLevels The QualityLevelList to update.
  * @param {PlaylistLoader} playlistLoader PlaylistLoader containing the new media info.

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -127,7 +127,6 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   let effectiveBitrate;
   let sortedPlaylists = this.playlists.master.playlists.slice();
   let bandwidthPlaylists = [];
-  let now = +new Date();
   let i;
   let variant;
   let bandwidthBestVariant;
@@ -141,11 +140,7 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
 
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
-  sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > now;
-
-    return (!localVariant.disabled && !blacklisted);
-  });
+  sortedPlaylists = sortedPlaylists.filter(Playlist.isEnabled);
 
   // filter out any variant that has greater effective bitrate
   // than the current estimated bandwidth

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -86,17 +86,18 @@ const safeGetComputedStyle = function(el, property) {
  */
 const handleHlsMediaChange = function(qualityLevels, playlistLoader) {
   let newPlaylist = playlistLoader.media();
-  let i;
+  let selectedIndex = -1;
 
-  for (i = qualityLevels.length - 1; i >= 0; i--) {
+  for (let i = 0; i < qualityLevels.length; i++) {
     if (qualityLevels[i].id === newPlaylist.uri) {
+      selectedIndex = i;
       break;
     }
   }
 
-  qualityLevels.selectedIndex_ = i;
+  qualityLevels.selectedIndex_ = selectedIndex;
   qualityLevels.trigger({
-    selectedIndex: i,
+    selectedIndex,
     type: 'change'
   });
 };

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -103,8 +103,9 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
   sortedPlaylists = sortedPlaylists.filter((localVariant) => {
-    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > Date.now();
-    return (!localVariant.disabled && !blacklisted)
+    let blacklisted = localVariant.excludeUntil && localVariant.excludeUntil > now;
+
+    return (!localVariant.disabled && !blacklisted);
   });
 
   // filter out any variant that has greater effective bitrate

--- a/test/karma/common.js
+++ b/test/karma/common.js
@@ -45,7 +45,7 @@ var DEFAULTS = {
     debug: true,
     transform: [
       'babelify',
-      'browserify-shim'
+      ['browserify-shim', { global: true }]
     ],
     noParse: [
       'test/data/**',

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -194,6 +194,8 @@ QUnit.test('setting a representation to disabled sets disabled to true', functio
 
   assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
   assert.equal(playlists[1].disabled, undefined, 'rendition has not been disabled');
+  assert.equal(playlists[0].excludeUntil, 0, 'excludeUntil not touched when disabling a rendition');
+  assert.equal(playlists[1].excludeUntil, 0, 'excludeUntil not touched when disabling a rendition');
 });
 
 QUnit.test('changing the enabled state of a representation calls fastQualityChange_', function(assert) {

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -34,6 +34,14 @@ const makeMockPlaylist = function(options) {
     playlist.excludeUntil = options.excludeUntil;
   }
 
+  if ('uri' in options) {
+    playlist.uri = options.uri;
+  }
+
+  if ('disabled' in options) {
+    playlist.disabled = options.disabled;
+  }
+
   return playlist;
 };
 
@@ -55,7 +63,13 @@ const makeMockHlsHandler = function(playlistOptions) {
     }
   };
 
-  hlsHandler.playlists.master.playlists = playlistOptions.map(makeMockPlaylist);
+  playlistOptions.forEach((playlist, i) => {
+    hlsHandler.playlists.master.playlists[i] = makeMockPlaylist(playlist);
+
+    if (playlist.uri) {
+      hlsHandler.playlists.master.playlists[playlist.uri] = hlsHandler.playlists.master.playlists[i];
+    }
+  });
 
   return hlsHandler;
 };
@@ -139,11 +153,13 @@ QUnit.test('representations are disabled if their excludeUntil is after Date.now
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: Infinity
+      excludeUntil: Infinity,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media1.m3u8'
     }
   ]);
 
@@ -155,15 +171,17 @@ QUnit.test('representations are disabled if their excludeUntil is after Date.now
   assert.equal(renditions[1].enabled(), true, 'rendition is enabled');
 });
 
-QUnit.test('setting a representation to disabled sets excludeUntil to Infinity', function(assert) {
+QUnit.test('setting a representation to disabled sets disabled to true', function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      excludeUntil: 0,
+      uri: 'media1.m3u8'
     }
   ]);
   let playlists = hlsHandler.playlists.master.playlists;
@@ -174,19 +192,20 @@ QUnit.test('setting a representation to disabled sets excludeUntil to Infinity',
 
   renditions[0].enabled(false);
 
-  assert.equal(playlists[0].excludeUntil, Infinity, 'rendition has an infinite excludeUntil');
-  assert.equal(playlists[1].excludeUntil, 0, 'rendition has an excludeUntil of zero');
+  assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
+  assert.equal(playlists[1].disabled, undefined, 'rendition has not been disabled');
 });
 
 QUnit.test('changing the enabled state of a representation calls fastQualityChange_', function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
-      excludeUntil: Infinity
+      disabled: true,
+      uri: 'media0.m3u8'
     },
     {
       bandwidth: 0,
-      excludeUntil: 0
+      uri: 'media1.m3u8'
     }
   ]);
   let mpc = hlsHandler.masterPlaylistController_;
@@ -199,9 +218,37 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 
   renditions[0].enabled(true);
 
-  assert.equal(mpc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
+  assert.equal(mpc.fastQualityChange_.calls, 1,'fastQualityChange_ was called once');
 
   renditions[1].enabled(false);
 
   assert.equal(mpc.fastQualityChange_.calls, 2, 'fastQualityChange_ was called twice');
 });
+
+QUnit.test('changing the enabled state of a blacklisted representation still (un)sets disabled',
+  function() {
+    let hlsHandler = makeMockHlsHandler([
+      {
+        bandwidth: 0,
+        excludeUntil: Infinity,
+        uri: 'media0.m3u8'
+      },
+      {
+        bandwidth: 0,
+        disabled: true,
+        excludeUntil: Date.now() + 99999,
+        uri: 'media1.m3u8'
+      }
+    ]);
+    let playlists = hlsHandler.playlists.master.playlists;
+
+    RenditionMixin(hlsHandler);
+
+    let renditions = hlsHandler.representations();
+
+    renditions[0].enabled(false);
+    renditions[1].enabled(true);
+
+    QUnit.equal(playlists[0].disabled, true, 'rendition has been disabled');
+    QUnit.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
+  });

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -160,6 +160,11 @@ QUnit.test('blacklisted playlists are not included in the representations list',
       bandwidth: 0,
       excludeUntil: 0,
       uri: 'media1.m3u8'
+    },
+    {
+      bandwidth: 0,
+      excludeUntil: Date.now() + 999999,
+      uri: 'media1.m3u8'
     }
   ]);
 
@@ -167,7 +172,7 @@ QUnit.test('blacklisted playlists are not included in the representations list',
 
   let renditions = hlsHandler.representations();
 
-  assert.equal(renditions.length, 1, 'rblacklisted rendition not added');
+  assert.equal(renditions.length, 1, 'blacklisted rendition not added');
   assert.equal(renditions[0].id, 'media1.m3u8', 'rendition is enabled');
 });
 

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -149,7 +149,7 @@ QUnit.test('returns representations with width and height if present', function(
   assert.equal(renditions[2].height, undefined, 'rendition has a height of undefined');
 });
 
-QUnit.test('representations are disabled if their excludeUntil is after Date.now', function(assert) {
+QUnit.test('blacklisted playlists are not included in the representations list', function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
@@ -167,8 +167,8 @@ QUnit.test('representations are disabled if their excludeUntil is after Date.now
 
   let renditions = hlsHandler.representations();
 
-  assert.equal(renditions[0].enabled(), false, 'rendition is not enabled');
-  assert.equal(renditions[1].enabled(), true, 'rendition is enabled');
+  assert.equal(renditions.length, 1, 'rblacklisted rendition not added');
+  assert.equal(renditions[0].id, 'media1.m3u8', 'rendition is enabled');
 });
 
 QUnit.test('setting a representation to disabled sets disabled to true', function(assert) {
@@ -226,31 +226,3 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 
   assert.equal(mpc.fastQualityChange_.calls, 2, 'fastQualityChange_ was called twice');
 });
-
-QUnit.test('changing the enabled state of a blacklisted representation still (un)sets disabled',
-  function(assert) {
-    let hlsHandler = makeMockHlsHandler([
-      {
-        bandwidth: 0,
-        excludeUntil: Infinity,
-        uri: 'media0.m3u8'
-      },
-      {
-        bandwidth: 0,
-        disabled: true,
-        excludeUntil: Date.now() + 99999,
-        uri: 'media1.m3u8'
-      }
-    ]);
-    let playlists = hlsHandler.playlists.master.playlists;
-
-    RenditionMixin(hlsHandler);
-
-    let renditions = hlsHandler.representations();
-
-    renditions[0].enabled(false);
-    renditions[1].enabled(true);
-
-    assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
-    assert.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
-  });

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -164,7 +164,16 @@ QUnit.test('blacklisted playlists are not included in the representations list',
     {
       bandwidth: 0,
       excludeUntil: Date.now() + 999999,
-      uri: 'media1.m3u8'
+      uri: 'media2.m3u8'
+    },
+    {
+      bandwidth: 0,
+      excludeUntil: 1,
+      uri: 'media3.m3u8'
+    },
+    {
+      bandwidth: 0,
+      uri: 'media4.m3u8'
     }
   ]);
 
@@ -172,8 +181,10 @@ QUnit.test('blacklisted playlists are not included in the representations list',
 
   let renditions = hlsHandler.representations();
 
-  assert.equal(renditions.length, 1, 'blacklisted rendition not added');
+  assert.equal(renditions.length, 3, 'blacklisted rendition not added');
   assert.equal(renditions[0].id, 'media1.m3u8', 'rendition is enabled');
+  assert.equal(renditions[1].id, 'media3.m3u8', 'rendition is enabled');
+  assert.equal(renditions[2].id, 'media4.m3u8', 'rendition is enabled');
 });
 
 QUnit.test('setting a representation to disabled sets disabled to true', function(assert) {

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -218,7 +218,7 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 
   renditions[0].enabled(true);
 
-  assert.equal(mpc.fastQualityChange_.calls, 1,'fastQualityChange_ was called once');
+  assert.equal(mpc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
 
   renditions[1].enabled(false);
 
@@ -226,7 +226,7 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
 });
 
 QUnit.test('changing the enabled state of a blacklisted representation still (un)sets disabled',
-  function() {
+  function(assert) {
     let hlsHandler = makeMockHlsHandler([
       {
         bandwidth: 0,
@@ -249,6 +249,6 @@ QUnit.test('changing the enabled state of a blacklisted representation still (un
     renditions[0].enabled(false);
     renditions[1].enabled(true);
 
-    QUnit.equal(playlists[0].disabled, true, 'rendition has been disabled');
-    QUnit.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
+    assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
+    assert.equal(playlists[1].disabled, undefined, 'rendition has been enabled');
   });

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -18,10 +18,12 @@ import {
 import {HlsSourceHandler, HlsHandler, Hls} from '../src/videojs-contrib-hls';
 import HlsAudioTrack from '../src/hls-audio-track';
 import window from 'global/window';
+// we need this so the plugin registers itself
+import 'videojs-contrib-quality-levels';
 /* eslint-enable no-unused-vars */
 
 const Flash = videojs.getComponent('Flash');
-const ogHlsHandlerSetupQualityLevels = videojs.HlsHandler.setupQualityLevels_;
+const ogHlsHandlerSetupQualityLevels = videojs.HlsHandler.prototype.setupQualityLevels_;
 let nextId = 0;
 
 // do a shallow copy of the properties of source onto the target object

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -21,6 +21,7 @@ import window from 'global/window';
 /* eslint-enable no-unused-vars */
 
 const Flash = videojs.getComponent('Flash');
+const ogHlsHandlerSetupQualityLevels = videojs.HlsHandler.setupQualityLevels_;
 let nextId = 0;
 
 // do a shallow copy of the properties of source onto the target object
@@ -1455,6 +1456,7 @@ QUnit.test('the source handler supports HLS mime types', function(assert) {
 });
 
 QUnit.test('fires loadstart manually if Flash is used', function(assert) {
+  videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   let tech = new (videojs.getTech('Flash'))({});
   let loadstarts = 0;
 
@@ -1469,6 +1471,7 @@ QUnit.test('fires loadstart manually if Flash is used', function(assert) {
   assert.equal(loadstarts, 0, 'loadstart is not synchronous');
   this.clock.tick(1);
   assert.equal(loadstarts, 1, 'fired loadstart');
+  videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
 });
 
 QUnit.test('has no effect if native HLS is available', function(assert) {
@@ -2314,6 +2317,36 @@ QUnit.test('passes useCueTags hls option to master playlist controller', functio
   videojs.options.hls = origHlsOptions;
 });
 
+QUnit.test('populates quality levels list when available', function(assert) {
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  assert.ok(this.player.tech_.hls.qualityLevels_, 'added quality levels');
+
+  let qualityLevels = this.player.qualityLevels();
+  let addCount = 0;
+  let changeCount = 0;
+
+  qualityLevels.on('addqualitylevel', () => {
+    addCount++;
+  });
+
+  qualityLevels.on('change', () => {
+    changeCount++;
+  });
+
+  openMediaSource(this.player, this.clock);
+  // master
+  standardXHRResponse(this.requests.shift());
+  // media
+  standardXHRResponse(this.requests.shift());
+
+  assert.equal(addCount, 4, 'four levels added from master');
+  assert.equal(changeCount, 1, 'selected initial quality level');
+});
+
 QUnit.module('HLS Integration', {
   beforeEach(assert) {
     this.env = useFakeEnvironment(assert);
@@ -2321,10 +2354,12 @@ QUnit.module('HLS Integration', {
     this.mse = useFakeMediaSource();
     this.tech = new (videojs.getTech('Html5'))({});
     this.clock = this.env.clock;
+    videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   },
   afterEach() {
     this.env.restore();
     this.mse.restore();
+    videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
   }
 });
 
@@ -2585,10 +2620,12 @@ QUnit.module('HLS - Encryption', {
     this.requests = this.env.requests;
     this.mse = useFakeMediaSource();
     this.tech = new (videojs.getTech('Html5'))({});
+    videojs.HlsHandler.prototype.setupQualityLevels_ = () => {};
   },
   afterEach() {
     this.env.restore();
     this.mse.restore();
+    videojs.HlsHandler.prototype.setupQualityLevels_ = ogHlsHandlerSetupQualityLevels;
   }
 });
 


### PR DESCRIPTION
## Description
This PR introduces QualityLevels to contrib-hls.

The first part of this addition is to fix the representations mixin to create closure on the playlist loader instead of the playlist object, since the playlist loader creates a new object reference when loading a new playlist. This would cause outdated references to the representations enabled functions. 

The next change is separating the notion of disabled and blacklisted. We disable playlists for a multitude of reasons. Sometimes we want to blacklist a playlist permanently, for a short time, or to manually have a choice of which playlist is loaded. Since blacklisting and disabling/enabling use the same state variable, there is no way to know the difference between enabling a playlist that was disabled manually or blacklisted permanently.

Lastly, this change brings in videojs-contrib-quality-levels to expose the qualityLevels api on the player and populate the list of quality levels with the available representations in the source. This requires [these changes](https://github.com/videojs/videojs-contrib-quality-levels/pull/4) in contrib-quality-levels.

## Specific Changes proposed
- make representation references persist on new playlist loads
- separate disabling from blacklisting
- bring in the qualityLevels api

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
