### PR TITLE
Processing segment reachable even after playlist update removes it

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -526,7 +526,9 @@ export default class SegmentLoader extends videojs.EventTarget {
       // The timeline that the segment is in
       timeline: segment.timeline,
       // The expected duration of the segment in seconds
-      duration: segment.duration
+      duration: segment.duration,
+      // retain the segment in case the playlist updates while doing an async process
+      segment
     };
   }
 
@@ -674,7 +676,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.sourceUpdater_.remove(0, removeToTime);
     }
 
-    segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    segment = segmentInfo.segment;
 
     // optionally, request the decryption key
     if (segment.key) {
@@ -756,7 +758,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     segmentInfo = this.pendingSegment_;
-    segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    segment = segmentInfo.segment;
 
     // if a request times out, reset bandwidth tracking
     if (request.timedout) {
@@ -909,7 +911,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.state = 'DECRYPTING';
 
     let segmentInfo = this.pendingSegment_;
-    let segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
 
     if (segment.key) {
       // this is an encrypted segment
@@ -943,7 +945,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.state = 'APPENDING';
 
     let segmentInfo = this.pendingSegment_;
-    let segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
 
     this.syncController_.probeSegmentInfo(segmentInfo);
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -278,6 +278,13 @@ export default class SegmentLoader extends videojs.EventTarget {
 
         if (segmentInfo && !segmentInfo.isSyncRequest) {
           segmentInfo.mediaIndex -= mediaSequenceDiff;
+
+          // we need to update the referenced segment so that timing information is
+          // saved for the new playlist's segment, however, if the segment fell off the
+          // playlist, we can leave the old reference and just lose the timing info
+          if (segmentInfo.mediaIndex >= 0) {
+            segmentInfo.segment = newPlaylist.segments[segmentInfo.mediaIndex];
+          }
         }
 
         this.syncController_.saveExpiredSegmentInfo(oldPlaylist, newPlaylist);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -276,7 +276,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
         this.mediaIndex -= mediaSequenceDiff;
 
-        if (segmentInfo && !segmentInfo.isSyncRequest) {
+        if (segmentInfo) {
           segmentInfo.mediaIndex -= mediaSequenceDiff;
 
           // we need to update the referenced segment so that timing information is

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -214,7 +214,7 @@ export default class SyncController extends videojs.EventTarget {
    * @param {SegmentInfo} segmentInfo - The current active request information
    */
   probeSegmentInfo(segmentInfo) {
-    let segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
     let timingInfo;
 
     if (segment.map) {
@@ -239,7 +239,7 @@ export default class SyncController extends videojs.EventTarget {
    * @return {object} The start and end time of the current segment in "media time"
    */
   probeMp4Segment_(segmentInfo) {
-    let segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
     let timescales = mp4probe.timescale(segment.map.bytes);
     let startTime = mp4probe.startTime(timescales, segmentInfo.bytes);
 
@@ -295,7 +295,7 @@ export default class SyncController extends videojs.EventTarget {
    * @param {object} timingInfo - The start and end time of the current segment in "media time"
    */
   calculateSegmentTimeMapping_(segmentInfo, timingInfo) {
-    let segment = segmentInfo.playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
     let mappingObj = this.timelines[segmentInfo.timeline];
 
     if (segmentInfo.timestampOffset !== null) {
@@ -329,7 +329,7 @@ export default class SyncController extends videojs.EventTarget {
    */
   saveDiscontinuitySyncInfo_(segmentInfo) {
     let playlist = segmentInfo.playlist;
-    let segment = playlist.segments[segmentInfo.mediaIndex];
+    let segment = segmentInfo.segment;
 
     // If the current segment is a discontinuity then we know exactly where
     // the start of the range and it's accuracy is 0 (greater accuracy values

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1093,6 +1093,7 @@ function(assert) {
   loader.playlist(playlist);
   loader.mimeType(this.mimeType);
   loader.load();
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
@@ -1103,6 +1104,7 @@ function(assert) {
   this.requests.shift().respond(200, null, '');
   mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
   mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
@@ -1139,6 +1141,7 @@ function(assert) {
   loader.playlist(playlist);
   loader.mimeType(this.mimeType);
   loader.load();
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
@@ -1149,6 +1152,7 @@ function(assert) {
   this.requests.shift().respond(200, null, '');
   mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
   mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
@@ -1193,6 +1197,7 @@ function(assert) {
   loader.playlist(playlist);
   loader.mimeType(this.mimeType);
   loader.load();
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
@@ -1203,6 +1208,7 @@ function(assert) {
   this.requests.shift().respond(200, null, '');
   mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
   mediaSource.sourceBuffers[0].trigger('updateend');
+  this.clock.tick(1);
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1063,6 +1063,7 @@ function(assert) {
   this.clock.tick(1);
 
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'retrieving first segment');
+  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
   assert.equal(loader.state, 'WAITING', 'waiting for response');
 
   this.requests[0].response = new Uint8Array(10).buffer;
@@ -1079,6 +1080,7 @@ function(assert) {
   this.clock.tick(1);
 
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'retrieving second segment');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
   assert.equal(loader.state, 'WAITING', 'waiting for response');
 });
 
@@ -1094,6 +1096,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
 
   // wrap up the first request to set mediaIndex and start normal live streaming
   this.requests[0].response = new Uint8Array(10).buffer;
@@ -1103,6 +1106,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   // playlist updated during waiting
   let playlistUpdated = playlistWithDuration(40);
@@ -1113,6 +1117,7 @@ function(assert) {
   loader.playlist(playlistUpdated);
 
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   this.requests[0].response = new Uint8Array(10).buffer;
   this.requests.shift().respond(200, null, '');
@@ -1122,6 +1127,7 @@ function(assert) {
   // response
   assert.equal(loader.state, 'APPENDING', 'moved to appending state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'still using second segment');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 });
 
 QUnit.test('saves segment info to new segment after playlist refresh',
@@ -1136,6 +1142,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
 
   // wrap up the first request to set mediaIndex and start normal live streaming
   this.requests[0].response = new Uint8Array(10).buffer;
@@ -1145,6 +1152,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   // playlist updated during waiting
   let playlistUpdated = playlistWithDuration(40);
@@ -1154,6 +1162,7 @@ function(assert) {
   loader.playlist(playlistUpdated);
 
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
   // time info)
@@ -1187,6 +1196,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
 
   // wrap up the first request to set mediaIndex and start normal live streaming
   this.requests[0].response = new Uint8Array(10).buffer;
@@ -1196,6 +1206,7 @@ function(assert) {
 
   assert.equal(loader.state, 'WAITING', 'in waiting state');
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   // playlist updated during waiting
   let playlistUpdated = playlistWithDuration(40);
@@ -1206,6 +1217,7 @@ function(assert) {
   loader.playlist(playlistUpdated);
 
   assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
 
   // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
   // time info)

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -182,13 +182,14 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
       };
     };
 
+    let segment = playlist.segments[0];
     let segmentInfo = {
       mediaIndex: 0,
       playlist,
       timeline: 0,
-      timestampOffset: 0
+      timestampOffset: 0,
+      segment
     };
-    let segment = playlist.segments[0];
 
     syncCon.probeSegmentInfo(segmentInfo);
     assert.ok(syncCon.timelines[0], 'created mapping object for timeline 0');
@@ -203,6 +204,7 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
     segmentInfo.timestampOffset = null;
     segmentInfo.mediaIndex = 1;
     segment = playlist.segments[1];
+    segmentInfo.segment = segment;
 
     syncCon.probeSegmentInfo(segmentInfo);
     assert.equal(segment.start, 10, 'correctly calculated segment start');
@@ -214,6 +216,7 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
     segmentInfo.mediaIndex = 3;
     segmentInfo.timeline = 1;
     segment = playlist.segments[3];
+    segmentInfo.segment = segment;
 
     syncCon.probeSegmentInfo(segmentInfo);
     assert.ok(syncCon.timelines[1], 'created mapping object for timeline 1');


### PR DESCRIPTION
## Description
In live scenarios, a refresh may render a processing segment unreachable. This attaches the segment to the segmentInfo object so the segment will always be around.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
