### PR TITLE
run decryption in a webworker

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,9 @@ and most CDNs should have no trouble turning CORS on for your account.
 Issues that are currenty know about with workarounds. If you want to
 help find a solution that would be appreciated!
 
+### IE10 and Below
+As of version 5.0.0, IE10 and below are no longer supported.
+
 ### IE11
 In some IE11 setups there are issues working with its native HTML
 SourceBuffers functionality. This leads to various issues, such as

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Maintenance Status: Stable
   - [In-Band Metadata](#in-band-metadata)
 - [Hosting Considerations](#hosting-considerations)
 - [Known Issues](#known-issues)
+  - [IE10 and Below](#ie10-and-below)
   - [IE11](#ie11)
   - [Fragmented MP4 Support](#fragmented-mp4-support)
   - [Testing](#testing)

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "url-toolkit": "^1.0.4",
     "video.js": "^5.15.1",
     "videojs-contrib-media-sources": "^4.1.4",
-    "videojs-swf": "^5.0.2"
+    "videojs-swf": "^5.0.2",
+    "webworkify": "1.0.2"
   },
   "devDependencies": {
     "babel": "^5.8.0",

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -31,6 +31,37 @@ const formatAsciiString = function(e) {
 };
 
 /**
+ * Creates an object for sending to a web worker modifying properties that are TypedArrays
+ * into seperated properties for the buffer, byteOffset, and byteLength.
+ *
+ * @param {Object} message
+ *        Object of properties and values to send to the web worker
+ * @return {Object}
+ *         Modified message with TypedArray values expanded
+ * @function transferableMessage
+ */
+const transferableMessage = function(message) {
+  const transferable = {};
+  const keys = Object.keys(message);
+
+  keys.forEach((key) => {
+    const value = message[key];
+
+    if (ArrayBuffer.isView(value)) {
+      transferable[key] = {
+        bytes: value.buffer,
+        byteOffset: value.byteOffset,
+        byteLength: value.byteLength
+      };
+    } else {
+      transferable[key] = value;
+    }
+  });
+
+  return transferable;
+};
+
+/**
  * utils to help dump binary data to the console
  */
 const utils = {
@@ -59,7 +90,8 @@ const utils = {
       result += textRange(ranges, i) + ' ';
     }
     return result;
-  }
+  },
+  transferableMessage
 };
 
 export default utils;

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -32,19 +32,18 @@ const formatAsciiString = function(e) {
 
 /**
  * Creates an object for sending to a web worker modifying properties that are TypedArrays
- * into seperated properties for the buffer, byteOffset, and byteLength.
+ * into a new object with seperated properties for the buffer, byteOffset, and byteLength.
  *
  * @param {Object} message
  *        Object of properties and values to send to the web worker
  * @return {Object}
  *         Modified message with TypedArray values expanded
- * @function transferableMessage
+ * @function createTransferableMessage
  */
-const transferableMessage = function(message) {
+const createTransferableMessage = function(message) {
   const transferable = {};
-  const keys = Object.keys(message);
 
-  keys.forEach((key) => {
+  Object.keys(message).forEach((key) => {
     const value = message[key];
 
     if (ArrayBuffer.isView(value)) {
@@ -91,7 +90,7 @@ const utils = {
     }
     return result;
   },
-  transferableMessage
+  createTransferableMessage
 };
 
 export default utils;

--- a/src/decrypter-worker.js
+++ b/src/decrypter-worker.js
@@ -1,0 +1,58 @@
+import window from 'global/window';
+import {Decrypter} from 'aes-decrypter';
+
+/**
+ * Callback method to send the decrypted segment bytes back to the main thread
+ *
+ * @param {Object} err
+ *        Decryption error. Will always be null with aes-decrypter ^1.0.3
+ * @param {Uint8Array} bytes
+ *        Decrypted byte array
+ * @function postDecrypted
+ */
+const postDecrypted = function(err, bytes) {
+  window.postMessage({
+    action: 'done',
+    source: this.source,
+    bytes: bytes.buffer,
+    byteOffset: bytes.byteOffset,
+    byteLength: bytes.byteLength
+  }, [bytes.buffer]);
+};
+
+/**
+ * Our web wroker interface so that things can talk to aes-decrypter
+ * that will be running in a web worker. the scope is passed to this by
+ * webworkify.
+ *
+ * @param {Object} self
+ *        the scope for the web worker
+ */
+const Worker = function(self) {
+  self.onmessage = function(event) {
+    const data = event.data;
+    if (data.action === 'decrypt') {
+      const encrypted = new Uint8Array(data.encrypted.bytes,
+                                     data.encrypted.byteOffset,
+                                     data.encrypted.byteLength);
+      const key = new Uint32Array(data.key.bytes,
+                                data.key.byteOffset,
+                                data.key.byteLength / 4);
+      const iv = new Uint32Array(data.iv.bytes,
+                               data.iv.byteOffset,
+                               data.iv.byteLength / 4);
+      const context = {
+        source: data.source
+      };
+
+      new Decrypter(encrypted,
+                    key,
+                    iv,
+                    postDecrypted.bind(context));
+    }
+  };
+};
+
+export default (self) => {
+  return new Worker(self);
+};

--- a/src/decrypter-worker.js
+++ b/src/decrypter-worker.js
@@ -2,7 +2,7 @@ import window from 'global/window';
 import {Decrypter} from 'aes-decrypter';
 
 /**
- * Our web wroker interface so that things can talk to aes-decrypter
+ * Our web worker interface so that things can talk to aes-decrypter
  * that will be running in a web worker. the scope is passed to this by
  * webworkify.
  *

--- a/src/decrypter-worker.js
+++ b/src/decrypter-worker.js
@@ -1,6 +1,6 @@
 import window from 'global/window';
 import {Decrypter} from 'aes-decrypter';
-import { transferableMessage } from './bin-utils';
+import { createTransferableMessage } from './bin-utils';
 
 /**
  * Our web worker interface so that things can talk to aes-decrypter
@@ -28,7 +28,7 @@ const Worker = function(self) {
                   key,
                   iv,
                   function(err, bytes) {
-                    window.postMessage(transferableMessage({
+                    window.postMessage(createTransferableMessage({
                       source: data.source,
                       decrypted: bytes
                     }), [bytes.buffer]);

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -268,7 +268,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.decrypter_.onmessage = (event) => {
       if (event.data.source === 'main') {
         this.mainSegmentLoader_.handleDecrypted_(event.data);
-      } else {
+      } else if (event.data.source === 'audio') {
         this.audiosegmentloader_.handleDecrypted_(event.data);
       }
     };

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -267,14 +267,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.decrypter_.onmessage = (event) => {
       switch (event.data.source) {
-        case 'main':
-          this.mainSegmentLoader_.handleDecrypted_(event.data);
-          break;
-        case 'audio':
-          this.audiosegmentloader_.handleDecrypted_(event.data);
-          break;
-        default:
-          break;
+      case 'main':
+        this.mainSegmentLoader_.handleDecrypted_(event.data);
+        break;
+      case 'audio':
+        this.audiosegmentloader_.handleDecrypted_(event.data);
+        break;
+      default:
+        break;
       }
     };
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -8,7 +8,7 @@ import videojs from 'video.js';
 import AdCueTags from './ad-cue-tags';
 import SyncController from './sync-controller';
 import { translateLegacyCodecs } from 'videojs-contrib-media-sources/es5/codec-utils';
-import work from 'webworkify';
+import worker from 'webworkify';
 import Decrypter from './decrypter-worker';
 
 // 5 minute blacklist
@@ -237,7 +237,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.syncController_ = new SyncController();
 
-    this.decrypter_ = work(Decrypter);
+    this.decrypter_ = worker(Decrypter);
 
     let segmentLoaderOptions = {
       hls: this.hls_,
@@ -266,15 +266,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.audioSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
 
     this.decrypter_.onmessage = (event) => {
-      switch (event.data.source) {
-      case 'main':
+      if (event.data.source === 'main') {
         this.mainSegmentLoader_.handleDecrypted_(event.data);
-        break;
-      case 'audio':
+      } else {
         this.audiosegmentloader_.handleDecrypted_(event.data);
-        break;
-      default:
-        break;
       }
     };
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -942,9 +942,8 @@ export default class SegmentLoader extends videojs.EventTarget {
           bytes: segment.key.iv.buffer,
           byteOffset: segment.key.iv.byteOffset,
           byteLength: segment.key.iv.byteLength
-        },
-      },
-      [
+        }
+      }, [
         segmentInfo.encryptedBytes.buffer,
         segment.key.bytes.buffer
       ]);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -4,7 +4,6 @@
 import {getMediaInfoForTime_ as getMediaInfoForTime} from './playlist';
 import videojs from 'video.js';
 import SourceUpdater from './source-updater';
-import {Decrypter} from 'aes-decrypter';
 import Config from './config';
 import window from 'global/window';
 
@@ -130,6 +129,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.setCurrentTime_ = settings.setCurrentTime;
     this.mediaSource_ = settings.mediaSource;
     this.hls_ = settings.hls;
+    this.loaderType_ = settings.loaderType;
 
     // private instance variables
     this.checkBufferTimeout_ = null;
@@ -144,6 +144,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // Fragmented mp4 playback
     this.activeInitSegmentId_ = null;
     this.initSegments_ = {};
+
+    this.decrypter_ = settings.decrypter;
 
     // Manages the tracking and generation of sync-points, mappings
     // between a time in the display time and a segment index within
@@ -923,19 +925,51 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (segment.key) {
       // this is an encrypted segment
       // incrementally decrypt the segment
-      /* eslint-disable no-new, handle-callback-err */
-      new Decrypter(segmentInfo.encryptedBytes,
-                    segment.key.bytes,
-                    segment.key.iv,
-                    (function(err, bytes) {
-                      // err always null
-                      segmentInfo.bytes = bytes;
-                      this.handleSegment_();
-                    }).bind(this));
-      /* eslint-enable */
+      this.decrypter_.postMessage({
+        action: 'decrypt',
+        source: this.loaderType_,
+        encrypted: {
+          bytes: segmentInfo.encryptedBytes.buffer,
+          byteOffset: segmentInfo.encryptedBytes.byteOffset,
+          byteLength: segmentInfo.encryptedBytes.byteLength
+        },
+        key: {
+          bytes: segment.key.bytes.buffer,
+          byteOffset: segment.key.bytes.byteOffset,
+          byteLength: segment.key.bytes.byteLength
+        },
+        iv: {
+          bytes: segment.key.iv.buffer,
+          byteOffset: segment.key.iv.byteOffset,
+          byteLength: segment.key.iv.byteLength
+        },
+      },
+      [
+        segmentInfo.encryptedBytes.buffer,
+        segment.key.bytes.buffer
+      ]);
     } else {
       this.handleSegment_();
     }
+  }
+
+  /**
+   * Handles response from the decrypter and attaches the decrypted bytes to the pending
+   * segment
+   *
+   * @param {Object} data
+   *        Response from decrypter
+   * @method handleDecrypted_
+   */
+  handleDecrypted_(data) {
+    if (data.action === 'done') {
+      const segmentInfo = this.pendingSegment_;
+
+      if (segmentInfo) {
+        segmentInfo.bytes = new Uint8Array(data.bytes, data.byteOffset, data.byteLength);
+      }
+    }
+    this.handleSegment_();
   }
 
   /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -6,7 +6,7 @@ import videojs from 'video.js';
 import SourceUpdater from './source-updater';
 import Config from './config';
 import window from 'global/window';
-import { transferableMessage } from './bin-utils';
+import { createTransferableMessage } from './bin-utils';
 
 // in ms
 const CHECK_BUFFER_DELAY = 500;
@@ -926,7 +926,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (segment.key) {
       // this is an encrypted segment
       // incrementally decrypt the segment
-      this.decrypter_.postMessage(transferableMessage({
+      this.decrypter_.postMessage(createTransferableMessage({
         source: this.loaderType_,
         encrypted: segmentInfo.encryptedBytes,
         key: segment.key.bytes,

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -753,6 +753,11 @@ Hls.comparePlaylistResolution = function(left, right) {
 };
 
 HlsSourceHandler.canPlayType = function(type) {
+  // No support for IE 10 or below
+  if (videojs.browser.IE_VERSION && videojs.browser.IE_VERSION <= 10) {
+    return false;
+  }
+
   let mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
 
   // favor native HLS support if it's available

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -12,7 +12,7 @@ import {
 import sinon from 'sinon';
 import SyncController from '../src/sync-controller';
 import Decrypter from '../src/decrypter-worker';
-import work from 'webworkify';
+import worker from 'webworkify';
 
 let currentTime;
 let mediaSource;
@@ -41,7 +41,7 @@ QUnit.module('Segment Loader', {
     mediaSource = new videojs.MediaSource();
     mediaSource.trigger('sourceopen');
     syncController = new SyncController();
-    decrypter = work(Decrypter);
+    decrypter = worker(Decrypter);
     loader = new SegmentLoader({
       hls: this.fakeHls,
       currentTime() {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -11,11 +11,14 @@ import {
 } from './test-helpers.js';
 import sinon from 'sinon';
 import SyncController from '../src/sync-controller';
+import Decrypter from '../src/decrypter-worker';
+import work from 'webworkify';
 
 let currentTime;
 let mediaSource;
 let loader;
 let syncController;
+let decrypter;
 
 QUnit.module('Segment Loader', {
   beforeEach(assert) {
@@ -38,6 +41,7 @@ QUnit.module('Segment Loader', {
     mediaSource = new videojs.MediaSource();
     mediaSource.trigger('sourceopen');
     syncController = new SyncController();
+    decrypter = work(Decrypter);
     loader = new SegmentLoader({
       hls: this.fakeHls,
       currentTime() {
@@ -47,14 +51,20 @@ QUnit.module('Segment Loader', {
       seeking: () => false,
       hasPlayed: () => true,
       mediaSource,
-      syncController
+      syncController,
+      decrypter,
+      loaderType: 'main'
     });
+    decrypter.onmessage = (event) => {
+      loader.handleDecrypted_(event.data);
+    };
   },
   afterEach() {
     this.env.restore();
     this.mse.restore();
     this.timescale.restore();
     this.startTime.restore();
+    decrypter.terminate();
   }
 });
 
@@ -955,9 +965,13 @@ function(assert) {
 QUnit.test('segment with key has decrypted bytes appended during processing', function(assert) {
   let keyRequest;
   let segmentRequest;
+  let done = assert.async();
 
   // stop processing so we can examine segment info
-  loader.handleSegment_ = function() {};
+  loader.handleSegment_ = function() {
+    assert.ok(loader.pendingSegment_.bytes, 'decrypted bytes in segment');
+    done();
+  };
 
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
   loader.mimeType(this.mimeType);
@@ -978,7 +992,6 @@ QUnit.test('segment with key has decrypted bytes appended during processing', fu
   this.clock.tick(1);
   // Allow the decrypter's async stream to run the callback
   this.clock.tick(1);
-  assert.ok(loader.pendingSegment_.bytes, 'decrypted bytes in segment');
 
   // verify stats
   assert.equal(loader.mediaBytesTransferred, 8, '8 bytes');

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -95,7 +95,7 @@ QUnit.module('HLS', {
 
     // save and restore browser detection for the Firefox-specific tests
     this.old.IS_FIREFOX = videojs.browser.IS_FIREFOX;
-    this.old.IE_VERSION = videojs.browser.IE_VERSION
+    this.old.IE_VERSION = videojs.browser.IE_VERSION;
 
     this.standardXHRResponse = (request, data) => {
       standardXHRResponse(request, data);

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -95,6 +95,7 @@ QUnit.module('HLS', {
 
     // save and restore browser detection for the Firefox-specific tests
     this.old.IS_FIREFOX = videojs.browser.IS_FIREFOX;
+    this.old.IE_VERSION = videojs.browser.IE_VERSION
 
     this.standardXHRResponse = (request, data) => {
       standardXHRResponse(request, data);
@@ -120,6 +121,7 @@ QUnit.module('HLS', {
     videojs.Hls.supportsNativeHls = this.old.NativeHlsSupport;
     videojs.Hls.Decrypter = this.old.Decrypt;
     videojs.browser.IS_FIREFOX = this.old.IS_FIREFOX;
+    videojs.browser.IE_VERSION = this.old.IE_VERSION;
 
     this.player.dispose();
   }
@@ -1464,6 +1466,18 @@ QUnit.test('the source handler supports HLS mime types', function(assert) {
     assert.ok(!(HlsSourceHandler(techName).canPlayType('video/x-flv')),
              'does not support flv');
   });
+});
+
+QUnit.test('source handler does not support sources when IE 10 or below', function(assert) {
+  videojs.browser.IE_VERSION = 10;
+
+  ['html5', 'flash'].forEach(function(techName) {
+    assert.ok(!HlsSourceHandler(techName).canHandleSource({
+      type: 'aPplicatiOn/x-MPegUrl'
+    }), 'does not support when browser is IE10');
+  });
+
+  videojs.browser.IE_VERSION = this.old.IE_VERSION;
 });
 
 QUnit.test('fires loadstart manually if Flash is used', function(assert) {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1473,11 +1473,9 @@ QUnit.test('source handler does not support sources when IE 10 or below', functi
 
   ['html5', 'flash'].forEach(function(techName) {
     assert.ok(!HlsSourceHandler(techName).canHandleSource({
-      type: 'aPplicatiOn/x-MPegUrl'
+      type: 'application/x-mpegURL'
     }), 'does not support when browser is IE10');
   });
-
-  videojs.browser.IE_VERSION = this.old.IE_VERSION;
 });
 
 QUnit.test('fires loadstart manually if Flash is used', function(assert) {


### PR DESCRIPTION
## Description
Currently trying to play an encrypted source in a background tab causes the player to crash. This seems to be due to browsers throttling setTimeouts to 1000ms delays while in a background tab. Since our decryption uses a lot of timeouts, it cannot preform fast enough in a background tab. This change moves the decryption work into a web worker since timeouts are not throttled while in a worker.

## Specific Changes proposed
* Move decryption to a web worker for the segment loaders to use

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
