### PR TITLE
fix: introduce videojs 6 forward compatibility while maintaining backward compatibilty

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -212,14 +212,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
         'ad-cues');
       this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
-
-      const textTracks = this.tech_.textTracks();
-
-      if (textTracks.addTrack) {
-        textTracks.addTrack(this.cueTagsTrack_);
-      } else {
-        textTracks.addTrack_(this.cueTagsTrack_);
-      }
     }
 
     this.audioTracks_ = [];

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -212,7 +212,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
         'ad-cues');
       this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
-      this.tech_.textTracks().addTrack_(this.cueTagsTrack_);
+
+      const textTracks = this.tech_.textTracks();
+
+      if (textTracks.addTrack) {
+        textTracks.addTrack(this.cueTagsTrack_);
+      } else {
+        textTracks.addTrack_(this.cueTagsTrack_);
+      }
     }
 
     this.audioTracks_ = [];

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -781,8 +781,10 @@ if (window.Uint8Array && flashTech) {
 videojs.HlsHandler = HlsHandler;
 videojs.HlsSourceHandler = HlsSourceHandler;
 videojs.Hls = Hls;
+if (!videojs.use) {
+  videojs.registerComponent('Hls', Hls);
+}
 videojs.m3u8 = m3u8;
-videojs.registerComponent('Hls', Hls);
 videojs.options.hls = videojs.options.hls || {};
 videojs.plugin('reloadSourceOnError', reloadSourceOnError);
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -786,7 +786,12 @@ if (!videojs.use) {
 }
 videojs.m3u8 = m3u8;
 videojs.options.hls = videojs.options.hls || {};
-videojs.plugin('reloadSourceOnError', reloadSourceOnError);
+
+if (videojs.registerPlugin) {
+  videojs.registerPlugin('reloadSourceOnError', reloadSourceOnError);
+} else {
+  videojs.plugin('reloadSourceOnError', reloadSourceOnError);
+}
 
 module.exports = {
   Hls,

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -244,7 +244,7 @@ Hls.supportsNativeHls = (function() {
   let video = document.createElement('video');
 
   // native HLS is definitely not supported if HTML5 video isn't
-  if (!videojs.getComponent('Html5').isSupported()) {
+  if (!videojs.getTech('Html5').isSupported()) {
     return false;
   }
 
@@ -768,12 +768,14 @@ if (typeof videojs.MediaSource === 'undefined' ||
   videojs.URL = URL;
 }
 
+const flashTech = videojs.getTech('Flash');
+
 // register source handlers with the appropriate techs
 if (MediaSource.supportsNativeMediaSources()) {
-  videojs.getComponent('Html5').registerSourceHandler(HlsSourceHandler('html5'), 0);
+  videojs.getTech('Html5').registerSourceHandler(HlsSourceHandler('html5'), 0);
 }
-if (window.Uint8Array) {
-  videojs.getComponent('Flash').registerSourceHandler(HlsSourceHandler('flash'));
+if (window.Uint8Array && flashTech) {
+  flashTech.registerSourceHandler(HlsSourceHandler('flash'));
 }
 
 videojs.HlsHandler = HlsHandler;


### PR DESCRIPTION
This makes it backwards and forwards compatible to videojs 6 and as far back as [5.2](https://github.com/videojs/video.js/blob/master/CHANGELOG.md#520-2015-11-10) when the tech registry was added.

Fix #968