### PR TITLE
Add a segment-metadata TextTrack that contains cues for the segments currently in the buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,16 +451,16 @@ the web](http://www.html5rocks.com/en/tutorials/track/basics/).
 ### Segment Metadata
 You can get metadata about the segments currently in the buffer by using the `segment-metadata`
 text track. You can get the metadata of the currently rendered segment by looking at the
-tracks `activeCues` array. The metadata will be attached to the `cue.value` property and
+track's `activeCues` array. The metadata will be attached to the `cue.value` property and
 will have this structure
 
 ```javascript
 cue.value = {
-  uri: The Segment uri,
-  timeline: Timeline of the segment,
-  playlist: The Playlist uri,
-  start: Segment start time,
-  end: Segment end time
+  uri, // The Segment uri
+  timeline, // Timeline of the segment for detecting discontinuities
+  playlist, // The Playlist uri
+  start, // Segment start time
+  end // Segment end time
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,50 @@ cue.value.data
 There are lots of guides and references to using text tracks [around
 the web](http://www.html5rocks.com/en/tutorials/track/basics/).
 
+### Segment Metadata
+You can get metadata about the segments currently in the buffer by using the `segment-metadata`
+text track. You can get the metadata of the currently rendered segment by looking at the
+tracks `activeCues` array. The metadata will be attached to the `cue.value` property and
+will have this structure
+
+```javascript
+cue.value = {
+  uri: The Segment uri,
+  timeline: Timeline of the segment,
+  playlist: The Playlist uri,
+  start: Segment start time,
+  end: Segment end time
+};
+```
+
+Example:
+Detect when a change in quality is rendered on screen
+```javascript
+let tracks = player.textTracks();
+let segmentMetadataTrack;
+
+for (let i = 0; i < tracks.length; i++) {
+  if (tracks[i].label === 'segment-metadata') {
+    segmentMetadataTrack = tracks[i];
+  }
+}
+
+let previousPlaylist;
+
+if (segmentMetadataTrack) {
+  segmentMetadataTrack.on('cuechange', function() {
+    let activeCue = segmentMetadataTrack.activeCues[0];
+
+    if (activeCue) {
+      if (previousPlaylist !== activeCue.playlist) {
+        console.log('Switched from rendition' + previousPlaylist + 'to rendition' + activeCue.playlist);
+      }
+      previousPlaylist = activeCue.playlist;
+    }
+  });
+}
+```
+
 ## Hosting Considerations
 Unlike a native HLS implementation, the HLS tech has to comply with
 the browser's security policies. That means that all the files that

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -252,9 +252,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       hasPlayed: () => this.hasPlayed_(),
       bandwidth,
       syncController: this.syncController_,
-      decrypter: this.decrypter_,
-      loaderType: 'main',
-      segmentMetadataTrack: this.segmentMetadataTrack_
+      decrypter: this.decrypter_
     };
 
     // setup playlist loaders
@@ -264,15 +262,15 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     // setup segment loaders
     // combined audio/video or just video when alternate audio track is selected
-    this.mainSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
-
-    // for now we don't want the audio segment loader to also add cues to the segment
-    // metadata track
-    delete segmentLoaderOptions.segmentMetadataTrack;
+    this.mainSegmentLoader_ = new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
+      segmentMetadataTrack: this.segmentMetadataTrack_,
+      loaderType: 'main'
+    }));
 
     // alternate audio track
-    segmentLoaderOptions.loaderType = 'audio';
-    this.audioSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
+    this.audioSegmentLoader_ = new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
+      loaderType: 'audio'
+    }));
 
     this.decrypter_.onmessage = (event) => {
       if (event.data.source === 'main') {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -235,6 +235,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.hasPlayed_ = () => false;
 
     this.syncController_ = new SyncController();
+    this.segmentMetadataTrack_ = tech.addRemoteTextTrack({
+      kind: 'metadata',
+      label: 'segment-metadata'
+    }, true).track;
 
     this.decrypter_ = worker(Decrypter);
 
@@ -249,7 +253,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       bandwidth,
       syncController: this.syncController_,
       decrypter: this.decrypter_,
-      loaderType: 'main'
+      loaderType: 'main',
+      segmentMetadataTrack: this.segmentMetadataTrack_
     };
 
     // setup playlist loaders
@@ -260,6 +265,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // setup segment loaders
     // combined audio/video or just video when alternate audio track is selected
     this.mainSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);
+
+    // for now we don't want the audio segment loader to also add cues to the segment
+    // metadata track
+    delete segmentLoaderOptions.segmentMetadataTrack;
+
     // alternate audio track
     segmentLoaderOptions.loaderType = 'audio';
     this.audioSegmentLoader_ = new SegmentLoader(segmentLoaderOptions);

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1155,7 +1155,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     const playlist = segmentInfo.playlist;
-    const segment = playlist.segments[segmentInfo.mediaIndex];
+    const segment = segmentInfo.segment;
     const start = segment.start;
     const end = segment.end;
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -7,6 +7,7 @@ import SourceUpdater from './source-updater';
 import Config from './config';
 import window from 'global/window';
 import { createTransferableMessage } from './bin-utils';
+import removeCuesFromTrack from 'videojs-contrib-media-sources/es5/remove-cues-from-track.js';
 
 // in ms
 const CHECK_BUFFER_DELAY = 500;
@@ -121,6 +122,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.mediaSource_ = settings.mediaSource;
     this.hls_ = settings.hls;
     this.loaderType_ = settings.loaderType;
+    this.segmentMetadataTrack_ = settings.segmentMetadataTrack;
 
     // private instance variables
     this.checkBufferTimeout_ = null;
@@ -437,6 +439,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.sourceUpdater_) {
       this.sourceUpdater_.remove(start, end);
     }
+    removeCuesFromTrack(start, end, this.segmentMetadataTrack_);
   }
 
   /**
@@ -712,7 +715,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     removeToTime = this.trimBuffer_(segmentInfo);
 
     if (removeToTime > 0) {
-      this.sourceUpdater_.remove(0, removeToTime);
+      this.remove(0, removeToTime);
     }
 
     segment = segmentInfo.segment;
@@ -1066,6 +1069,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     this.pendingSegment_ = null;
     this.recordThroughput_(segmentInfo);
+    this.addSegmentMetadataCue_(segmentInfo);
 
     this.state = 'READY';
 
@@ -1085,6 +1089,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (isWalkingForward) {
       this.trigger('progress');
     }
+
 
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will
@@ -1134,4 +1139,42 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @private
    */
   logger_() {}
+
+  /**
+   * Adds a cue to the segment-metadata track with some metadata information about the
+   * segment
+   *
+   * @private
+   * @param {Object} segmentInfo
+   *        the object returned by loadSegment
+   * @method addSegmentMetadataCue_
+   */
+  addSegmentMetadataCue_(segmentInfo) {
+    if (!this.segmentMetadataTrack_ || !segmentInfo) {
+      return;
+    }
+
+    const playlist = segmentInfo.playlist;
+    const segment = playlist.segments[segmentInfo.mediaIndex];
+    const start = segment.start;
+    const end = segment.end;
+
+    removeCuesFromTrack(start, end, this.segmentMetadataTrack_);
+
+    const value = {
+      uri: segmentInfo.uri,
+      timeline: segmentInfo.timeline,
+      playlist: playlist.uri,
+      start,
+      end
+    };
+    const Cue = window.WebKitDataCue || window.VTTCue;
+    const data = JSON.stringify(value);
+    const cue = new Cue(start, end, data);
+
+    value.data = data;
+    cue.value = value;
+
+    this.segmentMetadataTrack_.addCue(cue);
+  }
 }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1090,7 +1090,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.trigger('progress');
     }
 
-
     // any time an update finishes and the last segment is in the
     // buffer, end the stream. this ensures the "ended" event will
     // fire if playback reaches that point.
@@ -1154,7 +1153,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    const playlist = segmentInfo.playlist;
     const segment = segmentInfo.segment;
     const start = segment.start;
     const end = segment.end;
@@ -1165,7 +1163,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     const value = {
       uri: segmentInfo.uri,
       timeline: segmentInfo.timeline,
-      playlist: playlist.uri,
+      playlist: segmentInfo.playlist.uri,
       start,
       end
     };

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1150,7 +1150,7 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @method addSegmentMetadataCue_
    */
   addSegmentMetadataCue_(segmentInfo) {
-    if (!this.segmentMetadataTrack_ || !segmentInfo) {
+    if (!this.segmentMetadataTrack_) {
       return;
     }
 
@@ -1161,6 +1161,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     removeCuesFromTrack(start, end, this.segmentMetadataTrack_);
 
+    const Cue = window.WebKitDataCue || window.VTTCue;
     const value = {
       uri: segmentInfo.uri,
       timeline: segmentInfo.timeline,
@@ -1168,11 +1169,11 @@ export default class SegmentLoader extends videojs.EventTarget {
       start,
       end
     };
-    const Cue = window.WebKitDataCue || window.VTTCue;
     const data = JSON.stringify(value);
     const cue = new Cue(start, end, data);
 
-    value.data = data;
+    // Attach the metadata to the value property of the cue to keep consistency between
+    // the differences of WebKitDataCue in safari and VTTCue in other browsers
     cue.value = value;
 
     this.segmentMetadataTrack_.addCue(cue);

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -46,6 +46,9 @@ QUnit.module('MasterPlaylistController', {
     };
 
     this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+    // Make segment metadata noop since most test segments dont have real data
+    this.masterPlaylistController.mainSegmentLoader_.addSegmentMetadataCue_ = () => {};
   },
   afterEach() {
     this.env.restore();
@@ -218,6 +221,8 @@ QUnit.test('if buffered, will request second segment byte range', function(asser
     type: 'application/vnd.apple.mpegurl'
   });
   this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+  // Make segment metadata noop since most test segments dont have real data
+  this.masterPlaylistController.mainSegmentLoader_.addSegmentMetadataCue_ = () => {};
 
   // mock that the user has played the video before
   this.player.tech_.triggerReady();
@@ -240,6 +245,7 @@ QUnit.test('if buffered, will request second segment byte range', function(asser
   this.masterPlaylistController.mainSegmentLoader_.fetchAtBuffer_ = true;
   this.masterPlaylistController.mediaSource.sourceBuffers[0].trigger('updateend');
   this.clock.tick(10 * 1000);
+  this.clock.tick(1);
   assert.equal(this.requests[2].headers.Range, 'bytes=522828-1110327');
 
   // verify stats
@@ -265,6 +271,9 @@ function(assert) {
     type: 'application/vnd.apple.mpegurl'
   });
   this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+  // Make segment metadata noop since most test segments dont have real data
+  this.masterPlaylistController.mainSegmentLoader_.addSegmentMetadataCue_ = () => {};
+
   // maybe not needed if https://github.com/videojs/video.js/issues/2326 gets fixed
   this.clock.tick(1);
   assert.ok(!this.masterPlaylistController.masterPlaylistLoader_.media(),

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -35,6 +35,7 @@ class MockTextTrack {
 // save the original function to a variable to patch it back in for the metadata cue
 // specific tests
 const ogAddSegmentMetadataCue_ = SegmentLoader.prototype.addSegmentMetadataCue_;
+
 SegmentLoader.prototype.addSegmentMetadataCue_ = function() {};
 
 let currentTime;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -855,7 +855,7 @@ QUnit.test('adds cues with segment information to the segment-metadata track as 
     };
 
     assert.equal(track.cues.length, 1, 'one cue added for segment');
-    assert.deepEqual(JSON.parse(track.cues[0].value.data), expectedCue,
+    assert.deepEqual(track.cues[0].value, expectedCue,
       'added correct segment info to cue');
 
     probeResponse = { start: 9.56, end: 19.2 };
@@ -872,7 +872,7 @@ QUnit.test('adds cues with segment information to the segment-metadata track as 
     };
 
     assert.equal(track.cues.length, 2, 'one cue added for segment');
-    assert.deepEqual(JSON.parse(track.cues[1].value.data), expectedCue,
+    assert.deepEqual(track.cues[1].value, expectedCue,
       'added correct segment info to cue');
 
     probeResponse = { start: 19.24, end: 28.99 };
@@ -889,12 +889,30 @@ QUnit.test('adds cues with segment information to the segment-metadata track as 
     };
 
     assert.equal(track.cues.length, 3, 'one cue added for segment');
-    assert.deepEqual(JSON.parse(track.cues[2].value.data), expectedCue,
+    assert.deepEqual(track.cues[2].value, expectedCue,
+      'added correct segment info to cue');
+
+    // append overlapping segment, emmulating segment-loader fetching behavior on
+    // rendtion switch
+    probeResponse = { start: 19.21, end: 28.98 };
+    this.requests[0].response = new Uint8Array(10).buffer;
+    this.requests.shift().respond(200, null, '');
+    mediaSource.sourceBuffers[0].trigger('updateend');
+    expectedCue = {
+      uri: '3.ts',
+      timeline: 0,
+      playlist: 'playlist.m3u8',
+      start: 19.21,
+      end: 28.98
+    };
+
+    assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');
+    assert.deepEqual(track.cues[2].value, expectedCue,
       'added correct segment info to cue');
 
     // verify stats
-    assert.equal(loader.mediaBytesTransferred, 30, '10 bytes');
-    assert.equal(loader.mediaRequests, 3, '1 request');
+    assert.equal(loader.mediaBytesTransferred, 40, '40 bytes');
+    assert.equal(loader.mediaRequests, 4, '4 requests');
   });
 
 QUnit.test('segment 404s should trigger an error', function(assert) {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -31,6 +31,12 @@ class MockTextTrack {
   }
 }
 
+// noop addSegmentMetadataCue_ since most test segments dont have real timing information
+// save the original function to a variable to patch it back in for the metadata cue
+// specific tests
+const ogAddSegmentMetadataCue_ = SegmentLoader.prototype.addSegmentMetadataCue_;
+SegmentLoader.prototype.addSegmentMetadataCue_ = function() {};
+
 let currentTime;
 let mediaSource;
 let loader;
@@ -821,6 +827,7 @@ QUnit.test('adds cues with segment information to the segment-metadata track as 
     let probeResponse;
     let expectedCue;
 
+    loader.addSegmentMetadataCue_ = ogAddSegmentMetadataCue_;
     loader.syncController_.probeTsSegment_ = function(segmentInfo) {
       return probeResponse;
     };

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -326,7 +326,8 @@ export const playlistWithDuration = function(time, conf) {
     mediaSequence: conf && conf.mediaSequence ? conf.mediaSequence : 0,
     discontinuityStarts: [],
     segments: [],
-    endList: conf && typeof conf.endList !== 'undefined' ? !!conf.endList : true
+    endList: conf && typeof conf.endList !== 'undefined' ? !!conf.endList : true,
+    uri: conf && typeof conf.uri !== 'undefined' ? conf.uri : 'playlist.m3u8'
   };
   let count = Math.floor(time / 10);
   let remainder = time % 10;
@@ -337,7 +338,8 @@ export const playlistWithDuration = function(time, conf) {
     result.segments.push({
       uri: i + '.ts',
       resolvedUri: i + '.ts',
-      duration: 10
+      duration: 10,
+      timeline: 0
     });
     if (isEncrypted) {
       result.segments[i].key = {
@@ -349,7 +351,8 @@ export const playlistWithDuration = function(time, conf) {
   if (remainder) {
     result.segments.push({
       uri: i + '.ts',
-      duration: remainder
+      duration: remainder,
+      timeline: 0
     });
   }
   return result;

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2576,6 +2576,9 @@ QUnit.test('downloads additional playlists if required', function(assert) {
     type: 'application/vnd.apple.mpegurl'
   }, this.tech);
 
+  // Make segment metadata noop since most test segments dont have real data
+  hls.masterPlaylistController_.mainSegmentLoader_.addSegmentMetadataCue_ = () => {};
+
   hls.mediaSource.trigger('sourceopen');
   hls.bandwidth = 1;
   // master
@@ -2613,6 +2616,8 @@ QUnit.test('waits to download new segments until the media playlist is stable', 
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'
   }, this.tech);
+
+  hls.masterPlaylistController_.mainSegmentLoader_.addSegmentMetadataCue_ = () => {};
 
   hls.mediaSource.trigger('sourceopen');
 


### PR DESCRIPTION
## Description
Currently, we do not expose or track segment information for the segments that are currently in the actual buffer. Being able to know which segment or rendition is currently being rendered on screen has been a much requested feature. This addition allows users to listen to `cuechange` events on the track and see the segment information for the currently rendered segment in the active cues list.

## Specific Changes proposed
* Adds a new TextTrack to the tech with the label `segment-metadata`
* The Cues in the track directly correspond to the current state of the buffer at a segment level
* As segments are appended to the buffer, a new cue is added to the track that has start and end times equal to the segment. If the segment being appended overlaps already buffered content, we remove any overlapping cues from the track so that the cues in the track are always the most up to date.
* whenever data is removed from the buffer, we remove any cues that also fall inside the removed area

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
