### PR TITLE
Fixed mediaIndex tracking so that it is consistent when the playlist updates during a live stream

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -270,8 +270,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.playlist_ = newPlaylist;
     this.xhrOptions_ = options;
 
-    // when we haven't started playing yet, the start of the playlist is always
-    // our zero-time so force a sync update each time we get a new playlist
+    // when we haven't started playing yet, the start of a live playlist
+    // is always our zero-time so force a sync update each time the playlist
+    // is refreshed from the server
     if (!this.hasPlayed_()) {
       newPlaylist.syncInfo = {
         mediaSequence: newPlaylist.mediaSequence,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -606,6 +606,104 @@ QUnit.test('abort does not cancel segment processing in progress', function(asse
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
+QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
+  loader.playlist(playlistWithDuration(50, {
+    mediaSequence: 0,
+    endList: false
+  }));
+  loader.mimeType(this.mimeType);
+  loader.load();
+  // Start at mediaIndex 2 which means that the next segment we request
+  // should mediaIndex 3
+  loader.mediaIndex = 2;
+  this.clock.tick(1);
+
+  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex starts at 2');
+  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+  this.clock.tick(1);
+  mediaSource.sourceBuffers[0].trigger('updateend');
+
+  assert.equal(loader.mediaIndex, 3, 'mediaIndex ends at 3');
+
+  this.clock.tick(1);
+
+  assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex starts at 3');
+  assert.equal(this.requests[0].url, '4.ts', 'requesting the segment at mediaIndex 4');
+
+  // Update the playlist shifting the mediaSequence by 2 which will result
+  // in a decrement of the mediaIndex by 2 to 1
+  loader.playlist(playlistWithDuration(50, {
+    mediaSequence: 2,
+    endList: false
+  }));
+
+  assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex is updated to 1');
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+  this.clock.tick(1);
+  mediaSource.sourceBuffers[0].trigger('updateend');
+
+  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex ends at 2');
+});
+
+QUnit.test('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
+  currentTime = 31;
+  loader.playlist(playlistWithDuration(50, {
+    mediaSequence: 0,
+    endList: false
+  }));
+  loader.mimeType(this.mimeType);
+  loader.load();
+  // Start at mediaIndex 2 which means that the next segment we request
+  // should mediaIndex 3
+  loader.mediaIndex = null;
+  loader.syncPoint_ = {
+    segmentIndex: 0,
+    time: 0
+  };
+  this.clock.tick(1);
+
+  let segmentInfo = loader.pendingSegment_;
+
+  assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
+  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+  this.clock.tick(1);
+  mediaSource.sourceBuffers[0].trigger('updateend');
+
+  assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex ends at 3');
+
+  loader.mediaIndex = null;
+  loader.fetchAtBuffer_ = false;
+  this.clock.tick(1);
+  segmentInfo = loader.pendingSegment_;
+
+  assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
+  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+  // Update the playlist shifting the mediaSequence by 2 which will result
+  // in a decrement of the mediaIndex by 2 to 1
+  loader.playlist(playlistWithDuration(50, {
+    mediaSequence: 2,
+    endList: false
+  }));
+
+  assert.equal(segmentInfo.mediaIndex, 1, 'segmentInfo.mediaIndex is updated to 1');
+
+  this.requests[0].response = new Uint8Array(10).buffer;
+  this.requests.shift().respond(200, null, '');
+  this.clock.tick(1);
+  mediaSource.sourceBuffers[0].trigger('updateend');
+
+  assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex ends at 1');
+});
+
 QUnit.test('sets the timestampOffset on timeline change', function(assert) {
   let playlist = playlistWithDuration(40);
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -651,6 +651,7 @@ QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated',
 });
 
 QUnit.test('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
+  // Setting currentTime to 31 so that we start requesting at segment #3
   currentTime = 31;
   loader.playlist(playlistWithDuration(50, {
     mediaSequence: 0,
@@ -658,8 +659,8 @@ QUnit.test('segmentInfo.mediaIndex is adjusted when live playlist is updated', f
   }));
   loader.mimeType(this.mimeType);
   loader.load();
-  // Start at mediaIndex 2 which means that the next segment we request
-  // should mediaIndex 3
+  // Start at mediaIndex null which means that the next segment we request
+  // should be based on currentTime (mediaIndex 3)
   loader.mediaIndex = null;
   loader.syncPoint_ = {
     segmentIndex: 0,

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -313,7 +313,7 @@ export const playlistWithDuration = function(time, conf) {
     mediaSequence: conf && conf.mediaSequence ? conf.mediaSequence : 0,
     discontinuityStarts: [],
     segments: [],
-    endList: true
+    endList: conf && typeof conf.endList !== 'undefined' ? !!conf.endList : true
   };
   let count = Math.floor(time / 10);
   let remainder = time % 10;


### PR DESCRIPTION
## What
During low-bandwidth conditions, segment requests can take long enough that the playlist reloads while we are fetching segments. This confused our handling of `mediaIndex` forcing the player to load the same segment that it loaded previously.

If network conditions are bad enough (and we are on the lowest rendition) then we can get into a situation where we refresh the playlist during each segment's request. The end result is that we will fetch the same segment over and over again without making progress. In extreme cases (when two playlist loads happened while fetching a segment) we can actually go backwards!!

## Why
There was code in `SegmentLoader#handleUpdateEnd_` that would adjust `segmentInfo.mediaIndex` before setting `this.mediaIndex`. The change was based on the difference between the saved playlist object and the current playlist's `mediaSequence`.

This action by `handleUpdateEnd_` was ONLY required when `this.mediaIndex` was `null` but we didn't have a check. When `this.mediaIndex` was not `null`, `SegmentLoader#playlist` was responsible for adjusting `mediaIndex`. 

For this PR, I decided to remove the code in `handleUpdateEnd_` and move all the responsibility of tracking `mediaIndex` to one place - `SegmentLoader#playlist`.

## Changes
1. Removed any code in `SegmentLoader#handleUpdateEnd_` that modified the `mediaIndex`
2. Reordered `SegmentLoader#playlist` to make it easier to follow and less deeply nested
3. All changes to both `mediaIndex`-es (SegmentLoader's and segmentInfo's) now happen solely in `SegmentLoader#playlist`

