### PR TITLE
Bubble progress events

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -707,6 +707,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     });
 
     segmentXhr = this.hls_.xhr(segmentRequestOptions, this.handleResponse_.bind(this));
+    segmentXhr.addEventListener('progress', (event) => {
+      this.trigger(event);
+    });
 
     this.xhr_ = {
       keyXhr,

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -258,6 +258,21 @@ QUnit.test('segment request timeouts reset bandwidth', function(assert) {
   assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
 });
 
+QUnit.test('progress on segment requests are redispatched', function(assert) {
+  let progressEvents = 0;
+
+  loader.on('progress', function() {
+    progressEvents++;
+  });
+  loader.playlist(playlistWithDuration(10));
+  loader.mimeType(this.mimeType);
+  loader.load();
+  this.clock.tick(1);
+
+  this.requests[0].dispatchEvent({ type: 'progress' });
+  assert.equal(progressEvents, 1, 'triggered progress');
+});
+
 QUnit.test('updates timestamps when segments do not start at zero', function(assert) {
   let playlist = playlistWithDuration(10);
 


### PR DESCRIPTION
If the segment request triggers progress events (that is, XHR2 is supported), bubble those up to the tech. This makes it clearer that buffering is happening even on very slow connections.