### PR TITLE
Fix qualityLevels setup for video with source

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -547,7 +547,7 @@ class HlsHandler extends Component {
       this.ignoreNextSeekingEvent_ = true;
     });
 
-    this.setupQualityLevels_();
+    this.tech_.ready(this.setupQualityLevels_.bind(this));
 
     // do nothing if the tech has been disposed already
     // this can occur if someone sets the src in player.ready(), for instance

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -566,7 +566,7 @@ class HlsHandler extends Component {
    * @private
    */
   setupQualityLevels_() {
-    let player = videojs(this.tech_.options_.playerId);
+    let player = videojs.players[this.tech_.options_.playerId];
 
     if (player && player.qualityLevels) {
       this.qualityLevels_ = player.qualityLevels();

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -566,7 +566,7 @@ class HlsHandler extends Component {
    * @private
    */
   setupQualityLevels_() {
-    let player = videojs.players[this.tech_.options_.playerId];
+    let player = videojs(this.tech_.options_.playerId);
 
     if (player && player.qualityLevels) {
       this.qualityLevels_ = player.qualityLevels();

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -547,7 +547,7 @@ class HlsHandler extends Component {
       this.ignoreNextSeekingEvent_ = true;
     });
 
-    this.tech_.ready(this.setupQualityLevels_.bind(this));
+    this.tech_.ready(() => this.setupQualityLevels_());
 
     // do nothing if the tech has been disposed already
     // this can occur if someone sets the src in player.ready(), for instance

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -227,12 +227,25 @@ export const mockTech = function(tech) {
   };
 };
 
-export const createPlayer = function(options) {
+export const createPlayer = function(options, src) {
   let video;
   let player;
 
   video = document.createElement('video');
   video.className = 'video-js';
+  if (src) {
+    if (typeof src === 'string') {
+      video.src = src;
+    } else if (src.src) {
+      let source = document.createElement('source');
+
+      source.src = src.src;
+      if (src.type) {
+        source.type = src.type;
+      }
+      video.appendChild(source);
+    }
+  }
   document.querySelector('#qunit-fixture').appendChild(video);
   player = videojs(video, options || {
     flash: {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2373,6 +2373,14 @@ QUnit.test('populates quality levels list when available', function(assert) {
 
   assert.equal(addCount, 4, 'four levels added from master');
   assert.equal(changeCount, 1, 'selected initial quality level');
+
+  this.player.dispose();
+  this.player = createPlayer({}, {
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  assert.ok(this.player.tech_.hls.qualityLevels_, 'added quality levels from video with source');
 });
 
 QUnit.module('HLS Integration', {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2350,6 +2350,7 @@ QUnit.test('populates quality levels list when available', function(assert) {
     src: 'manifest/master.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
+  openMediaSource(this.player, this.clock);
 
   assert.ok(this.player.tech_.hls.qualityLevels_, 'added quality levels');
 
@@ -2365,7 +2366,6 @@ QUnit.test('populates quality levels list when available', function(assert) {
     changeCount++;
   });
 
-  openMediaSource(this.player, this.clock);
   // master
   this.standardXHRResponse(this.requests.shift());
   // media
@@ -2379,6 +2379,7 @@ QUnit.test('populates quality levels list when available', function(assert) {
     src: 'http://example.com/media.m3u8',
     type: 'application/vnd.apple.mpegurl'
   });
+  openMediaSource(this.player, this.clock);
 
   assert.ok(this.player.tech_.hls.qualityLevels_, 'added quality levels from video with source');
 });


### PR DESCRIPTION
## Description
If a player is created from a `<video>` with a `<source>`, qualityLevels integration is not set up.

## Specific Changes proposed
`videojs.players[playerId]` is not set yet when `setupQualityLevels_` is called, but the player is already associated with the tag. Use the `videojs` function to get the player instead.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
