### PR TITLE
If beforeRequest is set, reuse it on source changes

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -691,7 +691,7 @@ const HlsSourceHandler = function(mode) {
 
       let previousBeforeRequest;
 
-      if (tech.hls && tech.hls.xhr && tech.hls.xhr.beforeRequest) {
+      if (tech.hls && tech.hls.xhr) {
         previousBeforeRequest = tech.hls.xhr.beforeRequest;
       }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -703,10 +703,6 @@ const HlsSourceHandler = function(mode) {
         // The player had a beforeRequest set prior to the source change.
         // Use it for the new source.
         tech.hls.xhr.beforeRequest = previousBeforeRequest;
-      } else if (videojs.Hls.xhr.beforeRequest) {
-        // Use a global `before` function if specified on videojs.Hls.xhr
-        // but still allow for a per-player override
-        tech.hls.xhr.beforeRequest = videojs.Hls.xhr.beforeRequest;
       }
 
       tech.hls.src(source.src);

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -689,21 +689,8 @@ const HlsSourceHandler = function(mode) {
 
       let settings = videojs.mergeOptions(options, {hls: {mode}});
 
-      let previousBeforeRequest;
-
-      if (tech.hls && tech.hls.xhr) {
-        previousBeforeRequest = tech.hls.xhr.beforeRequest;
-      }
-
       tech.hls = new HlsHandler(source, tech, settings);
-
       tech.hls.xhr = xhrFactory();
-
-      if (previousBeforeRequest) {
-        // The player had a beforeRequest set prior to the source change.
-        // Use it for the new source.
-        tech.hls.xhr.beforeRequest = previousBeforeRequest;
-      }
 
       tech.hls.src(source.src);
       return tech.hls;

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -689,12 +689,23 @@ const HlsSourceHandler = function(mode) {
 
       let settings = videojs.mergeOptions(options, {hls: {mode}});
 
+      let previousBeforeRequest;
+
+      if (tech.hls && tech.hls.xhr && tech.hls.xhr.beforeRequest) {
+        previousBeforeRequest = tech.hls.xhr.beforeRequest;
+      }
+
       tech.hls = new HlsHandler(source, tech, settings);
 
       tech.hls.xhr = xhrFactory();
-      // Use a global `before` function if specified on videojs.Hls.xhr
-      // but still allow for a per-player override
-      if (videojs.Hls.xhr.beforeRequest) {
+
+      if (previousBeforeRequest) {
+        // The player had a beforeRequest set prior to the source change.
+        // Use it for the new source.
+        tech.hls.xhr.beforeRequest = previousBeforeRequest;
+      } else if (videojs.Hls.xhr.beforeRequest) {
+        // Use a global `before` function if specified on videojs.Hls.xhr
+        // but still allow for a per-player override
         tech.hls.xhr.beforeRequest = videojs.Hls.xhr.beforeRequest;
       }
 

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -9,7 +9,11 @@
  * @param {Function} callback the callback to call when done
  * @return {Request} the xhr request that is going to be made
  */
-import {xhr as videojsXHR, mergeOptions} from 'video.js';
+import {
+  xhr as videojsXHR,
+  mergeOptions,
+  default as videojs
+} from 'video.js';
 
 const xhrFactory = function() {
   const xhr = function XhrFunction(options, callback) {
@@ -20,9 +24,10 @@ const xhrFactory = function() {
 
     // Allow an optional user-specified function to modify the option
     // object before we construct the xhr request
-    if (XhrFunction.beforeRequest &&
-        typeof XhrFunction.beforeRequest === 'function') {
-      let newOptions = XhrFunction.beforeRequest(options);
+    let beforeRequest = XhrFunction.beforeRequest || videojs.Hls.xhr.beforeRequest;
+
+    if (beforeRequest && typeof beforeRequest === 'function') {
+      let newOptions = beforeRequest(options);
 
       if (newOptions) {
         options = newOptions;

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2456,34 +2456,6 @@ QUnit.test('Allows specifying the beforeRequest function on the player', functio
   assert.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
 });
 
-QUnit.test('player specified beforeRequest survives src changes', function(assert) {
-  let beforeRequestCalled = false;
-
-  HlsSourceHandler('html5').handleSource({
-    src: 'manifest/encrypted-media.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  }, this.player.tech_);
-
-  this.player.tech_.hls.xhr.beforeRequest = () => {
-    beforeRequestCalled = true;
-  };
-
-  this.player.src({
-    src: 'master.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-  openMediaSource(this.player, this.clock);
-  // master
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  assert.ok(beforeRequestCalled, 'beforeRequest was called');
-
-  // verify stats
-  assert.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
-});
-
 QUnit.test('Allows specifying the beforeRequest function globally', function(assert) {
   let beforeRequestCalled = false;
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2456,6 +2456,34 @@ QUnit.test('Allows specifying the beforeRequest function on the player', functio
   assert.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
 });
 
+QUnit.test('player specified beforeRequest survives src changes', function(assert) {
+  let beforeRequestCalled = false;
+
+  HlsSourceHandler('html5').handleSource({
+    src: 'manifest/encrypted-media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  }, this.player.tech_);
+
+  this.player.tech_.hls.xhr.beforeRequest = () => {
+    beforeRequestCalled = true;
+  };
+
+  this.player.src({
+    src: 'master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  openMediaSource(this.player, this.clock);
+  // master
+  this.standardXHRResponse(this.requests.shift());
+  // media
+  this.standardXHRResponse(this.requests.shift());
+
+  assert.ok(beforeRequestCalled, 'beforeRequest was called');
+
+  // verify stats
+  assert.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default');
+});
+
 QUnit.test('Allows specifying the beforeRequest function globally', function(assert) {
   let beforeRequestCalled = false;
 

--- a/test/xhr.test.js
+++ b/test/xhr.test.js
@@ -1,0 +1,46 @@
+import QUnit from 'qunit';
+import xhrFactory from '../src/xhr';
+import { useFakeEnvironment } from './test-helpers.js';
+import videojs from 'video.js';
+
+QUnit.module('xhr', {
+  beforeEach(assert) {
+    this.env = useFakeEnvironment(assert);
+    this.clock = this.env.clock;
+    this.requests = this.env.requests;
+    this.xhr = xhrFactory();
+  },
+  afterEach() {
+    this.env.restore();
+  }
+});
+
+QUnit.test('xhr respects beforeRequest', function(assert) {
+  let defaultOptions = {
+    url: 'default'
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'default', 'url the same without override');
+
+  this.xhr.beforeRequest = (options) => {
+    options.url = 'player';
+    return options;
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'player', 'url changed with player override');
+
+  videojs.Hls.xhr.beforeRequest = (options) => {
+    options.url = 'global';
+    return options;
+  };
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'player', 'prioritizes player override');
+
+  delete this.xhr.beforeRequest;
+
+  this.xhr(defaultOptions);
+  assert.equal(this.requests.shift().url, 'global', 'url changed with global override');
+});


### PR DESCRIPTION
## Description
handleSource would replace any preexisting beforeRequest. 
Reported in https://github.com/videojs/videojs-contrib-hls/issues/665
Example of bug: http://jsbin.com/qijehan/2/edit?html,console,output

## Specific Changes proposed
Now handleSource checks for a preexisting beforeRequest, and reuses it if it is there.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [X] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
