### PR TITLE
Add events for underflow and live resync

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -135,6 +135,8 @@ export default class PlaybackWatcher {
       this.cancelTimer_();
       this.tech_.setCurrentTime(livePoint);
 
+      // live window resyncs may be useful for monitoring QoS
+      this.tech_.trigger('liveresync');
       return;
     }
 
@@ -148,6 +150,9 @@ export default class PlaybackWatcher {
       // (only suffering ~3 seconds of frozen video and a pause in audio playback).
       this.cancelTimer_();
       this.tech_.setCurrentTime(currentTime);
+
+      // video underflow may be useful for monitoring QoS
+      this.tech_.trigger('videounderflow');
       return;
     }
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -223,10 +223,10 @@ QUnit.test('fires notifications when activated', function(assert) {
 
   currentTime = 12;
   seekable[0] = [0, 100];
-  buffered[0] = [0, 9];
-  buffered.push([10, 20]);
+  buffered = [[0, 9], [10, 20]];
   playbackWatcher.waiting_();
   assert.equal(videounderflow, 1, 'triggered a videounderflow event');
+  assert.equal(liveresync, 1, 'did not trigger an additional liveresync event');
 });
 
 QUnit.module('PlaybackWatcher isolated functions', {


### PR DESCRIPTION
For QoS measurement purposes, it may be useful to know how often the playback watcher is activating. Add new events for when the player falls off the back of the live window or stalls due to a video buffer gap.
