### PR TITLE
feature: Support for Akamai-style Redundant HLS

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -136,6 +136,12 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   let width;
   let height;
 
+  // In Chrome, the Array#sort function is not stable so add a
+  // presortIndex that we can use to ensure we get a stable-sort
+  sortedPlaylists.forEach(function(elem, idx) {
+    elem.presortIndex = idx;
+  });
+
   sortedPlaylists.sort(Hls.comparePlaylistBandwidth);
 
   // filter out any playlists that have been excluded due to
@@ -161,6 +167,10 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
       // since the playlists are sorted in ascending order by
       // bandwidth, the first viable variant is the best
       if (!bandwidthBestVariant) {
+        if (i !== 0 &&
+            sortedPlaylists[i - 1].attributes.BANDWIDTH === variant.attributes.BANDWIDTH) {
+          continue;
+        }
         bandwidthBestVariant = variant;
       }
     }
@@ -710,6 +720,9 @@ Hls.comparePlaylistBandwidth = function(left, right) {
   }
   rightBandwidth = rightBandwidth || window.Number.MAX_VALUE;
 
+  if (leftBandwidth === rightBandwidth) {
+    return left.presortIndex - right.presortIndex;
+  }
   return leftBandwidth - rightBandwidth;
 };
 
@@ -747,6 +760,9 @@ Hls.comparePlaylistResolution = function(left, right) {
   if (leftWidth === rightWidth &&
       left.attributes.BANDWIDTH &&
       right.attributes.BANDWIDTH) {
+    if (left.attributes.BANDWIDTH === right.attributes.BANDWIDTH) {
+      return right.presortIndex - left.presortIndex;
+    }
     return left.attributes.BANDWIDTH - right.attributes.BANDWIDTH;
   }
   return leftWidth - rightWidth;

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -167,6 +167,7 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
       // since the playlists are sorted in ascending order by
       // bandwidth, the first viable variant is the best
       if (!bandwidthBestVariant) {
+        // make sure the first playlist is chosen
         if (i !== 0 &&
             sortedPlaylists[i - 1].attributes.BANDWIDTH === variant.attributes.BANDWIDTH) {
           continue;

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -119,18 +119,18 @@ const handleHlsLoadedMetadata = function(qualityLevels, hls) {
 /**
  * Resuable stable sort function
  *
- * @param {Playlists} playlists
- * @param {Function} different comparators
+ * @param {Playlists} array
+ * @param {Function} sortFn Different comparators
  * @function stableSort
  */
 const stableSort = function(array, sortFn) {
-  let cmp;
+  let newArray = array.slice();
 
   array.sort(function(left, right) {
-    cmp = sortFn(left, right);
+    let cmp = sortFn(left, right);
 
     if (cmp === 0) {
-      return array.indexOf(left) - array.indexOf(right);
+      return newArray.indexOf(left) - newArray.indexOf(right);
     }
     return cmp;
   });
@@ -198,7 +198,7 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
   });
   // ensure that we pick the highest bandwidth variant that have exact resolution
   resolutionBestVariant = resolutionBestVariantList.filter(function(elem) {
-    return elem.attributes.BANDWIDTH === resolutionBestVariantList.slice(-1)[0].attributes.BANDWIDTH;
+    return elem.attributes.BANDWIDTH === resolutionBestVariantList[resolutionBestVariantList.length - 1].attributes.BANDWIDTH;
   })[0];
 
   // find the smallest variant that is larger than the player
@@ -216,7 +216,7 @@ Hls.STANDARD_PLAYLIST_SELECTOR = function() {
     // ensure that we also pick the highest bandwidth variant that
     // is just-larger-than the video player
     resolutionPlusOne = resolutionPlusOneSmallest.filter(function(elem) {
-      return elem.attributes.BANDWIDTH === resolutionPlusOneSmallest.slice(-1)[0].attributes.BANDWIDTH;
+      return elem.attributes.BANDWIDTH === resolutionPlusOneSmallest[resolutionPlusOneSmallest.length - 1].attributes.BANDWIDTH;
     })[0];
   }
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -662,6 +662,7 @@ QUnit.test('selects a primary rendtion when there are multiple rendtions share s
   openMediaSource(this.player, this.clock);
   standardXHRResponse(this.requests[0]);
 
+  // covers playlists with same bandwidth but different resolution and different bandwidth but same resolution
   this.player.tech_.hls.playlists.master.playlists[0].attributes.BANDWIDTH = 528;
   this.player.tech_.hls.playlists.master.playlists[1].attributes.BANDWIDTH = 528;
   this.player.tech_.hls.playlists.master.playlists[2].attributes.BANDWIDTH = 728;
@@ -672,10 +673,27 @@ QUnit.test('selects a primary rendtion when there are multiple rendtions share s
   playlist = this.player.tech_.hls.selectPlaylist();
   assert.strictEqual(playlist,
                      this.player.tech_.hls.playlists.master.playlists[2],
-                     'the primary rendition is selected');
+                     'select the rendition with largest bandwidth and just-larger-than video player');
 
   // verify stats
   assert.equal(this.player.tech_.hls.stats.bandwidth, 1000, 'bandwidth set above');
+
+  // covers playlists share same bandwidth and resolutions
+  this.player.tech_.hls.playlists.master.playlists[0].attributes.BANDWIDTH = 728;
+  this.player.tech_.hls.playlists.master.playlists[0].attributes.RESOLUTION.width = 960;
+  this.player.tech_.hls.playlists.master.playlists[0].attributes.RESOLUTION.height = 540;
+  this.player.tech_.hls.playlists.master.playlists[1].attributes.BANDWIDTH = 728;
+  this.player.tech_.hls.playlists.master.playlists[2].attributes.BANDWIDTH = 728;
+  this.player.tech_.hls.playlists.master.playlists[2].attributes.RESOLUTION.width = 960;
+  this.player.tech_.hls.playlists.master.playlists[2].attributes.RESOLUTION.height = 540;
+  this.player.tech_.hls.playlists.master.playlists[3].attributes.BANDWIDTH = 728;
+
+  this.player.tech_.hls.bandwidth = 1000;
+
+  playlist = this.player.tech_.hls.selectPlaylist();
+  assert.strictEqual(playlist,
+                     this.player.tech_.hls.playlists.master.playlists[0],
+                     'the primary rendition is selected');
 });
 
 QUnit.test('allows initial bandwidth to be provided', function(assert) {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -652,6 +652,32 @@ QUnit.test('selects a playlist below the current bandwidth', function(assert) {
   assert.equal(this.player.tech_.hls.stats.bandwidth, 10, 'bandwidth set above');
 });
 
+QUnit.test('selects a primary rendtion when there are multiple rendtions share same attributes', function(assert) {
+  let playlist;
+
+  this.player.src({
+    src: 'manifest/master.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  openMediaSource(this.player, this.clock);
+  standardXHRResponse(this.requests[0]);
+
+  this.player.tech_.hls.playlists.master.playlists[0].attributes.BANDWIDTH = 528;
+  this.player.tech_.hls.playlists.master.playlists[1].attributes.BANDWIDTH = 528;
+  this.player.tech_.hls.playlists.master.playlists[2].attributes.BANDWIDTH = 728;
+  this.player.tech_.hls.playlists.master.playlists[3].attributes.BANDWIDTH = 728;
+
+  this.player.tech_.hls.bandwidth = 1000;
+
+  playlist = this.player.tech_.hls.selectPlaylist();
+  assert.strictEqual(playlist,
+                     this.player.tech_.hls.playlists.master.playlists[2],
+                     'the primary rendition is selected');
+
+  // verify stats
+  assert.equal(this.player.tech_.hls.stats.bandwidth, 1000, 'bandwidth set above');
+});
+
 QUnit.test('allows initial bandwidth to be provided', function(assert) {
   this.player.src({
     src: 'manifest/master.m3u8',


### PR DESCRIPTION
## Description
Only play backup streams when the primary have failed to support for Akamai-style Redundant HLS

## Specific Changes proposed
Implement a stable sort for renditions
Change the way of select bandwidthBestVariants in selectPlaylist algorithm