### PR TITLE
Fix for EXT-X-MAP assumption of fragmented mp4s

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -122,10 +122,9 @@ export const mimeTypesForPlaylist_ = function(master, media) {
   // An initialization segment means the media playlists is an iframe
   // playlist or is using the mp4 container. We don't currently
   // support iframe playlists, so assume this is signalling mp4
-  // fragments.
-  // the existence check for segments can be removed once
-  // https://github.com/videojs/m3u8-parser/issues/8 is closed
-  if (media.segments && media.segments.length && media.segments[0].map) {
+  // fragments if the uri doesn't end in .ts (which indicates mpeg2ts 
+  // segments).
+  if (media.segments.length && media.segments[0].map && !media.segments[0].uri.endsWith('.ts')) {
     container = 'mp4';
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1011,8 +1011,9 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     // if the media initialization segment is changing, append it
-    // before the content segment
-    if (segment.map) {
+    // before the content segment.  only append to media source buffer
+    // if the segment is part of a fragmented mp4
+    if (segment.map && !segment.uri.endsWith('.ts')) {
       let initId = initSegmentId(segment.map);
 
       if (!this.activeInitSegmentId_ ||

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -217,7 +217,8 @@ export default class SyncController extends videojs.EventTarget {
     let segment = segmentInfo.segment;
     let timingInfo;
 
-    if (segment.map) {
+    // Assume fragmented mp4 if map exists and segment uri doesn't end in .ts
+    if (segment.map && !segment.uri.endsWith('.ts')) {
       timingInfo = this.probeMp4Segment_(segmentInfo);
     } else {
       timingInfo = this.probeTsSegment_(segmentInfo);


### PR DESCRIPTION
## Description
When using the EXT-X-MAP tag to specify the location of initialization metadata, it is currently assumed that a fragmented mp4 is being specified.  However, an MPEG-TS file can also utilize the EXT-X-MAP tag to specify the location of the first PAT and PMT packets in a byte stream.  This branch and pull request merely add a check in 3 different locations to ensure that a transport stream can be specified by EXT-X-MAP and still load.

## Testing performed
I've only been able to test this on the limited data that we have available.  To generate m3u8 files that index into our single .ts files, we used:

`fmpeg -i input.ts -codec copy -hls_flags single_file out.m3u8`

and then ran `tsinfo` on the original mpeg-ts file to get the packets of the first PAT and PMT packets, allowing us to fill in the EXT-X-MAP tag in the m3u8 file.

## Remaining question

I'm fairly new to javascript development and HTML MediaSources, so I was wondering if my change in `segment-loader.js` was appropriate.  If we append the ts fragment directly to the MediaSources buffer, video playing fails, because it isn't data in an mp4 container.

Is there other information in the PAT and PMT packets that isn't already extracted at that point?  Would the proper change be to append to the sourcebuffer either `initSegment.bytes` if using a fragmented mp4, or something like `mux_mpegts_to_mp4(initSegment.bytes)` if using a transport stream?

We haven't got a lot of variety of data for testing, so while the suggested change works for our data, I would be open to suggestions about a more proper conversion of mpeg-ts into mp4 that would be more future-proof.