### PR TITLE
update deps for 4.3.0 mediasources

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,14 +89,13 @@
     "test/"
   ],
   "dependencies": {
-    "aes-decrypter": "^1.0.3",
+    "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
-    "m3u8-parser": "^2.0.1",
-    "mux.js": "^3.0.0",
+    "m3u8-parser": "2.0.1",
+    "mux.js": "4.0.1",
     "url-toolkit": "^1.0.4",
-    "video.js": "^5.15.1",
-    "videojs-contrib-media-sources": "^4.1.4",
-    "videojs-swf": "^5.0.2",
+    "video.js": "^5.17.0",
+    "videojs-contrib-media-sources": "4.3.0",
     "webworkify": "1.0.2"
   },
   "devDependencies": {
@@ -137,6 +136,7 @@
     "videojs-standard": "^4.0.3",
     "videojs-contrib-quality-levels": "^2.0.2",
     "watchify": "^3.6.0",
-    "webpack": "^1.13.2"
+    "webpack": "^1.13.2",
+    "videojs-swf": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Description
contrib-media-sources includes a number of flash performance enhancements. This updates the version to 4.3.0

Also updated a few other dependencies so that the versions across projects are in line with each other. Also removed a few wildcards in dependencies so it is easier to know what version of media-sources and mux.js is included in the dist of contrib-hls