### PR TITLE
Rename Worker to DecrypterWorker

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "videojs-contrib-hls",
   "version": "5.2.0",
   "description": "Play back HLS with video.js, even where it's not natively supported",
-  "main": "es5/videojs-contrib-hls.js",
+  "main": "src/videojs-contrib-hls.js",
   "engines": {
     "node": ">= 0.10.12"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "videojs-contrib-hls",
   "version": "5.2.0",
   "description": "Play back HLS with video.js, even where it's not natively supported",
-  "main": "src/videojs-contrib-hls.js",
+  "main": "es5/videojs-contrib-hls.js",
   "engines": {
     "node": ">= 0.10.12"
   },

--- a/src/decrypter-worker.js
+++ b/src/decrypter-worker.js
@@ -10,7 +10,7 @@ import { createTransferableMessage } from './bin-utils';
  * @param {Object} self
  *        the scope for the web worker
  */
-const Worker = function(self) {
+const DecrypterWorker = function(self) {
   self.onmessage = function(event) {
     const data = event.data;
     const encrypted = new Uint8Array(data.encrypted.bytes,
@@ -38,5 +38,5 @@ const Worker = function(self) {
 };
 
 export default (self) => {
-  return new Worker(self);
+  return new DecrypterWorker(self);
 };


### PR DESCRIPTION
## Description
problem that using webpack and webworkify-webpack-dropin
and videojs-contrib-media-sources
we have same Worker(self) name 

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
