### PR TITLE
isLowestEnabledRendition returns true when there are redundant streams

### DIFF
--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -245,7 +245,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       return false;
     }
 
-    let currentBandwidth = loader.media().attributes.BANDWIDTH || 0;
+    let currentBandwidth = media.attributes.BANDWIDTH || 0;
 
     return !(loader.master.playlists.filter((playlist) => {
       const enabled = isEnabled(playlist);
@@ -259,9 +259,9 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       if (playlist && playlist.attributes) {
         bandwidth = playlist.attributes.BANDWIDTH;
       }
-      return bandwidth <= currentBandwidth;
+      return bandwidth < currentBandwidth;
 
-    }).length > 1);
+    }).length >= 1);
   };
 
    /**

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -247,7 +247,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     let currentBandwidth = media.attributes.BANDWIDTH || 0;
 
-    return !(loader.master.playlists.filter((playlist) => {
+    return (loader.master.playlists.filter((playlist) => {
       const enabled = isEnabled(playlist);
 
       if (!enabled) {
@@ -261,7 +261,7 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       }
       return bandwidth < currentBandwidth;
 
-    }).length >= 1);
+    }).length === 0);
   };
 
    /**

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -143,10 +143,18 @@ QUnit.test('playlist loader detects if we are on lowest rendition', function(ass
                               {attributes: {BANDWIDTH: 20}}];
   assert.ok(loader.isLowestEnabledRendition_(), 'Detected on lowest rendition');
 
+  loader.master.playlists = [{attributes: {BANDWIDTH: 10}},
+                              {attributes: {BANDWIDTH: 10}},
+                              {attributes: {BANDWIDTH: 10}},
+                              {attributes: {BANDWIDTH: 20}}];
+  assert.ok(loader.isLowestEnabledRendition_(), 'Detected on lowest rendition');
+
   loader.media = function() {
     return {attributes: {BANDWIDTH: 20}};
   };
 
+  loader.master.playlists = [{attributes: {BANDWIDTH: 10}},
+                              {attributes: {BANDWIDTH: 20}}];
   assert.ok(!loader.isLowestEnabledRendition_(), 'Detected not on lowest rendition');
 });
 


### PR DESCRIPTION
## Description
PlaylistLoader#isLowestEnabledRendition_ never returns true when there are redundant streams

## Specific Changes proposed
return true when the lowest "rendition set" (all renditions sharing the same bandwidth) is selected.
