### PR TITLE
Fix resuming live playback after long pauses

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -966,7 +966,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
     let seekableEnd = this.seekable_.end(this.seekable_.length - 1);
 
     if (currentTime < this.seekable_.start(0) ||
-        currentTime > seekableEnd) {
+        // provide a buffer of 1 second to handle rounding/imprecise numbers (prevent us
+        // from seeking too many times)
+        currentTime > seekableEnd + 1) {
       // sync to live point (if VOD, our seekable was updated and we're simply adjusting)
       this.tech_.setCurrentTime(seekableEnd);
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -953,23 +953,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
                                                        mainSeekable.end(0)
       ]]);
     }
-
-    // now that seekable is updated, handle any cases where we've fallen off, but only
-    // in the case where we are seeking (let fall off be handled by playback watcher)
-    if (!this.tech_.seeking()) {
-      return;
-    }
-
-    let currentTime = this.tech_.currentTime();
-    let seekableEnd = this.seekable_.end(this.seekable_.length - 1);
-
-    if (currentTime < this.seekable_.start(0) ||
-        // provide a buffer of 1 second to handle rounding/imprecise numbers (prevent us
-        // from seeking too many times)
-        currentTime > seekableEnd + 1) {
-      // sync to live point (if VOD, our seekable was updated and we're simply adjusting)
-      this.tech_.setCurrentTime(seekableEnd);
-    }
   }
 
   /**

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -333,12 +333,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // on `mediachange`
       this.mainSegmentLoader_.playlist(updatedPlaylist, this.requestOptions_);
       this.updateDuration();
-      // although we may have already updated due to sync info via the segment loader,
-      // it isn't always fired (cases where we've fallen far enough off the back of the
-      // live playlist while paused)
-      if (!updatedPlaylist.endList && this.tech_.paused()) {
-        this.onSyncInfoUpdate_();
-      }
 
       if (!updatedPlaylist.endList) {
         let addSeekableRange = () => {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -947,6 +947,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
       // seekable has been calculated based on buffering video data so it
       // can be returned directly
       this.seekable_ = mainSeekable;
+    } else if (audioSeekable.start(0) > mainSeekable.end(0) ||
+               mainSeekable.start(0) > audioSeekable.end(0)) {
+      // seekables are pretty far off, rely on main
+      this.seekable_ = mainSeekable;
     } else {
       this.seekable_ = videojs.createTimeRanges([[
         (audioSeekable.start(0) > mainSeekable.start(0)) ? audioSeekable.start(0) :

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -79,7 +79,7 @@ export default class PlaybackWatcher {
    * @private
    */
   checkCurrentTime_() {
-    if (this.tech_.seeking() && this.fixBadSeeks_()) {
+    if (this.tech_.seeking() && this.fixesBadSeeks_()) {
       this.consecutiveUpdates = 0;
       this.lastRecordedTime = this.tech_.currentTime();
       return;
@@ -126,7 +126,7 @@ export default class PlaybackWatcher {
    * @return {Boolean} whether an action was taken to fix the seek
    * @private
    */
-  fixBadSeeks_() {
+  fixesBadSeeks_() {
     let seekable = this.seekable();
     let currentTime = this.tech_.currentTime();
 
@@ -154,7 +154,7 @@ export default class PlaybackWatcher {
     let seekable = this.seekable();
     let currentTime = this.tech_.currentTime();
 
-    if (this.tech_.seeking() && this.fixBadSeeks_()) {
+    if (this.tech_.seeking() && this.fixesBadSeeks_()) {
       return;
     }
 

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -91,8 +91,8 @@ export default class PlaybackWatcher {
 
       // handle any cases where we're trying to seek outside of the seekable range
       // provide a buffer of .1 seconds to handle rounding/imprecise numbers
-      if (currentTime < seekable.start(0) - .1 ||
-          currentTime > seekableEnd + .1) {
+      if (currentTime < seekable.start(0) - 0.1 ||
+          currentTime > seekableEnd + 0.1) {
         // sync to live point (if VOD, our seekable was updated and we're
         // simply adjusting)
         this.logger_(`Trying to seek outside of seekable at time ${currentTime} with ` +

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -85,7 +85,7 @@ export default class PlaybackWatcher {
       return;
     }
 
-    if (this.tech_.paused()) {
+    if (this.tech_.paused() || this.tech_.seeking()) {
       return;
     }
 

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -325,20 +325,17 @@ const getSegmentBufferedPercent = function(startOfSegment,
  * @returns {String} a human readable string
  */
 const printableRange = (range) => {
-  let str = '';
+  let strArr = [];
 
   if (!range || !range.length) {
-    return str;
+    return '';
   }
 
   for (let i = 0; i < range.length; i++) {
-    if (i > 0) {
-      str += ', ';
-    }
-    str += range.start(i) + ' => ' + range.end(i);
+    strArr.push(range.start(i) + ' => ' + range.end(i));
   }
 
-  return str;
+  return strArr.join(', ');
 };
 
 export default {

--- a/src/ranges.js
+++ b/src/ranges.js
@@ -318,11 +318,35 @@ const getSegmentBufferedPercent = function(startOfSegment,
   return percent;
 };
 
+/**
+ * Gets a human readable string for a TimeRange
+ *
+ * @param {TimeRange} range
+ * @returns {String} a human readable string
+ */
+const printableRange = (range) => {
+  let str = '';
+
+  if (!range || !range.length) {
+    return str;
+  }
+
+  for (let i = 0; i < range.length; i++) {
+    if (i > 0) {
+      str += ', ';
+    }
+    str += range.start(i) + ' => ' + range.end(i);
+  }
+
+  return str;
+};
+
 export default {
   findRange,
   findNextRange,
   findGaps,
   findSoleUncommonTimeRangesEnd,
   getSegmentBufferedPercent,
-  TIME_FUDGE_FACTOR
+  TIME_FUDGE_FACTOR,
+  printableRange
 };

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -281,8 +281,11 @@ export default class SegmentLoader extends videojs.EventTarget {
         mediaSequence: newPlaylist.mediaSequence,
         time: 0
       };
-      this.trigger('syncinfoupdate');
     }
+
+    // in VOD, this is always a rendition switch (or we updated our syncInfo above)
+    // in LIVE, we always want to update with new playlists (including refreshes)
+    this.trigger('syncinfoupdate');
 
     // if we were unpaused but waiting for a playlist, start
     // buffering now

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -764,6 +764,20 @@ function(assert) {
   assertTimeRangesEqual(mpc.seekable(),
                         videojs.createTimeRanges([[2, 9]]),
                         'audio later start, audio earlier end');
+  mainTimeRanges = [[1, 10]];
+  audioTimeRanges = [[11, 20]];
+  mpc.seekable_ = videojs.createTimeRanges();
+  mpc.onSyncInfoUpdate_();
+  assertTimeRangesEqual(mpc.seekable(),
+                        videojs.createTimeRanges([[1, 10]]),
+                        'no intersection, audio later');
+  mainTimeRanges = [[11, 20]];
+  audioTimeRanges = [[1, 10]];
+  mpc.seekable_ = videojs.createTimeRanges();
+  mpc.onSyncInfoUpdate_();
+  assertTimeRangesEqual(mpc.seekable(),
+                        videojs.createTimeRanges([[11, 20]]),
+                        'no intersection, main later');
 
   Playlist.seekable = origSeekable;
 });

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -340,7 +340,7 @@ QUnit.test('seeks to live point if we try to seek outside of seekable', function
   this.player.tech_.trigger('waiting');
   assert.equal(seeks.length, 2, 'did not seek');
 
-  // no check for 0 with seekable false because that should be handled by live falloff
+  // no check for 0 with seeking false because that should be handled by live falloff
 
   // checkCurrentTime
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -229,6 +229,146 @@ QUnit.test('fires notifications when activated', function(assert) {
   assert.equal(liveresync, 1, 'did not trigger an additional liveresync event');
 });
 
+QUnit.test('fixes bad seeks', function(assert) {
+  // set an arbitrary live source
+  this.player.src({
+    src: 'liveStart30sBefore.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  // start playback normally
+  this.player.tech_.triggerReady();
+  this.clock.tick(1);
+  standardXHRResponse(this.requests.shift());
+  openMediaSource(this.player, this.clock);
+  this.player.tech_.trigger('play');
+  this.player.tech_.trigger('playing');
+  this.clock.tick(1);
+
+  let playbackWatcher = this.player.tech_.hls.playbackWatcher_;
+  let seeks = [];
+  let seekable;
+  let seeking;
+  let currentTime;
+
+  playbackWatcher.seekable = () => seekable;
+  playbackWatcher.tech_ = {
+    seeking: () => seeking,
+    setCurrentTime: (time) => {
+      seeks.push(time);
+    },
+    currentTime: () => currentTime
+  };
+
+  currentTime = 50;
+  seekable = videojs.createTimeRanges([[1, 45]]);
+  seeking = false;
+  assert.ok(!playbackWatcher.fixBadSeeks_(), 'does nothing when not seeking');
+  assert.equal(seeks.length, 0, 'did not seek');
+
+  seeking = true;
+  assert.ok(playbackWatcher.fixBadSeeks_(), 'acts when seek past seekable range');
+  assert.equal(seeks.length, 1, 'seeked');
+  assert.equal(seeks[0], 45, 'player seeked to live point');
+
+  currentTime = 0;
+  assert.ok(playbackWatcher.fixBadSeeks_(), 'acts when seek before seekable range');
+  assert.equal(seeks.length, 2, 'seeked');
+  assert.equal(seeks[1], 45, 'player seeked to live point');
+
+  currentTime = 30;
+  assert.ok(!playbackWatcher.fixBadSeeks_(), 'does nothing when time within range');
+  assert.equal(seeks.length, 2, 'did not seek');
+});
+
+QUnit.test('seeks to live point if we try to seek outside of seekable', function(assert) {
+  // set an arbitrary live source
+  this.player.src({
+    src: 'liveStart30sBefore.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  // start playback normally
+  this.player.tech_.triggerReady();
+  this.clock.tick(1);
+  standardXHRResponse(this.requests.shift());
+  openMediaSource(this.player, this.clock);
+  this.player.tech_.trigger('play');
+  this.player.tech_.trigger('playing');
+  this.clock.tick(1);
+
+  let playbackWatcher = this.player.tech_.hls.playbackWatcher_;
+  let seeks = [];
+  let seekable;
+  let seeking;
+  let currentTime;
+
+  playbackWatcher.seekable = () => seekable;
+  playbackWatcher.tech_ = {
+    seeking: () => seeking,
+    setCurrentTime: (time) => {
+      seeks.push(time);
+    },
+    currentTime: () => currentTime,
+    // mocked out
+    paused: () => false,
+    buffered: () => videojs.createTimeRanges()
+  };
+
+  // waiting
+
+  currentTime = 50;
+  seekable = videojs.createTimeRanges([[1, 45]]);
+  seeking = true;
+  this.player.tech_.trigger('waiting');
+  assert.equal(seeks.length, 1, 'seeked');
+  assert.equal(seeks[0], 45, 'player seeked to live point');
+
+  currentTime = 0;
+  this.player.tech_.trigger('waiting');
+  assert.equal(seeks.length, 2, 'seeked');
+  assert.equal(seeks[1], 45, 'player seeked to live point');
+
+  // inside of seekable range
+  currentTime = 10;
+  this.player.tech_.trigger('waiting');
+  assert.equal(seeks.length, 2, 'did not seek');
+
+  currentTime = 50;
+  // if we're not seeking, the case shouldn't be handled here
+  seeking = false;
+  this.player.tech_.trigger('waiting');
+  assert.equal(seeks.length, 2, 'did not seek');
+
+  // no check for 0 with seekable false because that should be handled by live falloff
+
+  // checkCurrentTime
+
+  seeking = true;
+  currentTime = 50;
+  playbackWatcher.checkCurrentTime_();
+  assert.equal(seeks.length, 3, 'seeked');
+  assert.equal(seeks[2], 45, 'player seeked to live point');
+
+  currentTime = 0;
+  playbackWatcher.checkCurrentTime_();
+  assert.equal(seeks.length, 4, 'seeked');
+  assert.equal(seeks[3], 45, 'player seeked to live point');
+
+  currentTime = 10;
+  playbackWatcher.checkCurrentTime_();
+  assert.equal(seeks.length, 4, 'did not seek');
+
+  seeking = false;
+  currentTime = 50;
+  playbackWatcher.checkCurrentTime_();
+  assert.equal(seeks.length, 4, 'did not seek');
+
+  currentTime = 0;
+  playbackWatcher.checkCurrentTime_();
+  assert.equal(seeks.length, 4, 'did not seek');
+});
+
 QUnit.module('PlaybackWatcher isolated functions', {
   beforeEach() {
     monitorCurrentTime_ = PlaybackWatcher.prototype.monitorCurrentTime_;
@@ -328,4 +468,38 @@ QUnit.test('detects live window falloff', function(assert) {
   assert.ok(
     fellOutOfLiveWindow_(videojs.createTimeRanges([[11, 20]]), 0),
     'true if current time is 0 and earlier than seekable range');
+});
+
+QUnit.test('detects outside of seekable window', function(assert) {
+  let outsideOfSeekableWindow =
+    this.playbackWatcher.outsideOfSeekableWindow_.bind(this.playbackWatcher);
+
+  assert.ok(
+    outsideOfSeekableWindow(videojs.createTimeRanges([[11, 20]]), 10.8),
+    'true if before seekable range');
+  assert.ok(
+    outsideOfSeekableWindow(videojs.createTimeRanges([[11, 20]]), 20.2),
+    'true if after seekable range');
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges([[11, 20]]), 10.9),
+    'false if within starting seekable range buffer');
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges([[11, 20]]), 20.1),
+    'false if within ending seekable range buffer');
+
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges(), 10),
+    'false if no seekable range');
+  assert.ok(
+    outsideOfSeekableWindow(videojs.createTimeRanges([[0, 10]]), -0.2),
+    'true even if current time is negative');
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges([[0, 10]]), 5),
+    'false if within seekable range');
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges([[0, 10]]), 0),
+    'false if within seekable range');
+  assert.ok(
+    !outsideOfSeekableWindow(videojs.createTimeRanges([[0, 10]]), 10),
+    'false if within seekable range');
 });

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -263,21 +263,21 @@ QUnit.test('fixes bad seeks', function(assert) {
   currentTime = 50;
   seekable = videojs.createTimeRanges([[1, 45]]);
   seeking = false;
-  assert.ok(!playbackWatcher.fixBadSeeks_(), 'does nothing when not seeking');
+  assert.ok(!playbackWatcher.fixesBadSeeks_(), 'does nothing when not seeking');
   assert.equal(seeks.length, 0, 'did not seek');
 
   seeking = true;
-  assert.ok(playbackWatcher.fixBadSeeks_(), 'acts when seek past seekable range');
+  assert.ok(playbackWatcher.fixesBadSeeks_(), 'acts when seek past seekable range');
   assert.equal(seeks.length, 1, 'seeked');
   assert.equal(seeks[0], 45, 'player seeked to live point');
 
   currentTime = 0;
-  assert.ok(playbackWatcher.fixBadSeeks_(), 'acts when seek before seekable range');
+  assert.ok(playbackWatcher.fixesBadSeeks_(), 'acts when seek before seekable range');
   assert.equal(seeks.length, 2, 'seeked');
   assert.equal(seeks[1], 45, 'player seeked to live point');
 
   currentTime = 30;
-  assert.ok(!playbackWatcher.fixBadSeeks_(), 'does nothing when time within range');
+  assert.ok(!playbackWatcher.fixesBadSeeks_(), 'does nothing when time within range');
   assert.equal(seeks.length, 2, 'did not seek');
 });
 

--- a/test/ranges.test.js
+++ b/test/ranges.test.js
@@ -280,3 +280,25 @@ QUnit.test('finds gaps within ranges', function(assert) {
            createTimeRanges([[10, 11], [20, 22]])),
            'finds multiple gaps');
 });
+
+QUnit.test('creates printable ranges', function(assert) {
+  assert.equal(Ranges.printableRange(createTimeRanges()), '', 'empty range empty string');
+  assert.equal(Ranges.printableRange(createTimeRanges([[0, 0]])),
+               '0 => 0',
+               'formats range correctly');
+  assert.equal(Ranges.printableRange(createTimeRanges([[0, 1]])),
+               '0 => 1',
+               'formats range correctly');
+  assert.equal(Ranges.printableRange(createTimeRanges([[1, -1]])),
+               '1 => -1',
+               'formats range correctly');
+  assert.equal(Ranges.printableRange(createTimeRanges([[10.2, 25.2]])),
+               '10.2 => 25.2',
+               'formats range correctly');
+  assert.equal(Ranges.printableRange(createTimeRanges([[10, 20], [30, 40]])),
+               '10 => 20, 30 => 40',
+               'formats ranges correctly');
+  assert.equal(Ranges.printableRange(createTimeRanges([[10, 25], [20, 40], [-1, -2]])),
+               '10 => 25, 20 => 40, -1 => -2',
+               'formats ranges correctly');
+});

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1374,6 +1374,30 @@ function(assert) {
             'no end info for first segment of new playlist');
 });
 
+QUnit.test('new playlist always triggers syncinfoupdate', function(assert) {
+  let playlist = playlistWithDuration(100, { endList: false });
+  let syncInfoUpdates = 0;
+
+  loader.on('syncinfoupdate', () => syncInfoUpdates++);
+
+  loader.playlist(playlist);
+  loader.mimeType('video/mp4');
+  loader.load();
+
+  assert.equal(syncInfoUpdates, 1, 'first playlist triggers an update');
+  loader.playlist(playlist);
+  assert.equal(syncInfoUpdates, 2, 'same playlist triggers an update');
+  playlist = playlistWithDuration(100, { endList: false });
+  loader.playlist(playlist);
+  assert.equal(syncInfoUpdates, 3, 'new playlist with same info triggers an update');
+  playlist.segments[0].start = 10;
+  playlist = playlistWithDuration(100, { endList: false, mediaSequence: 1 });
+  loader.playlist(playlist);
+  assert.equal(syncInfoUpdates,
+               5,
+               'new playlist after expiring segment triggers two updates');
+});
+
 QUnit.module('Segment Loading Calculation', {
   beforeEach(assert) {
     this.env = useFakeEnvironment(assert);

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1170,8 +1170,8 @@ QUnit.test('estimates seekable ranges for live streams that have been paused for
                'offset the seekable start');
 });
 
-QUnit.test('resets the time to a seekable position when resuming a live stream ' +
-           'after a long break', function(assert) {
+QUnit.test('resets the time to the live point when resuming a live stream after a ' +
+           'long break', function(assert) {
   let seekTarget;
 
   this.player.src({
@@ -1199,10 +1199,10 @@ QUnit.test('resets the time to a seekable position when resuming a live stream '
   };
   this.player.tech_.trigger('playing');
 
+  let seekable = this.player.seekable();
+
   this.player.tech_.trigger('play');
-  assert.equal(seekTarget,
-              this.player.seekable().start(0),
-              'seeked to the start of seekable');
+  assert.equal(seekTarget, seekable.end(seekable.length - 1), 'seeked to live point');
   this.player.tech_.trigger('seeked');
 });
 


### PR DESCRIPTION
## Description
After a live video is paused long enough that the playlist no longer contains any segments previously requested, our seekable range is off and we often can't resume playback. This was for two primary reasons: (1) we were not updating seekable after the playlist updated enough that we no longer had any known segments and (2) if the segment times did not match up perfectly with the specified durations in the playlist, our seekable range would be off and we'd never try to adjust after seeking.

## Specific Changes proposed
This _seeks_ to resolve resuming live playback by keeping the seekable range updated, and checking to see if we are outside of a seekable range when we resume (after getting new sync info).

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
