### PR TITLE
reset segment loaders on all flash seeks

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
     "m3u8-parser": "2.0.1",
-    "mux.js": "4.0.1",
+    "mux.js": "4.1.0",
     "url-toolkit": "^1.0.4",
     "video.js": "^5.17.0",
-    "videojs-contrib-media-sources": "4.3.0",
+    "videojs-contrib-media-sources": "4.4.0",
     "webworkify": "1.0.2"
   },
   "devDependencies": {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -861,7 +861,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // In flash playback, the segment loaders should be reset on every seek, even
     // in buffer seeks
     const isFlash = (this.mode_ === 'flash') ||
-                    (this.mode_ === 'auto' && !Hls.supportsNativeHls);
+                    (this.mode_ === 'auto' && !videojs.MediaSource.supportsNativeMediaSources());
 
     // if the seek location is already buffered, continue buffering as
     // usual

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -858,9 +858,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return 0;
     }
 
+    // In flash playback, the segment loaders should be reset on every seek, even
+    // in buffer seeks
+    const isFlash = (this.mode_ === 'flash') ||
+                    (this.mode_ === 'auto' && !Hls.supportsNativeHls);
+
     // if the seek location is already buffered, continue buffering as
     // usual
-    if (buffered && buffered.length) {
+    if (buffered && buffered.length && !isFlash) {
       return currentTime;
     }
 


### PR DESCRIPTION
## Description
seeking into a buffered region while using flash playback can cause the player to stall since flash seeks clear the buffer but the segment loader still acts as if it is just in `mediaIndex++` walk forward mode when it should resync to fetch the correct segment
