### PR TITLE
Fix a bug with the combination of seek-to-live and resync-on-a-poor-guess behaviors

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -957,6 +957,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
                                                        mainSeekable.end(0)
       ]]);
     }
+
+    this.tech_.trigger('seekablechanged');
   }
 
   /**

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -38,7 +38,9 @@ export default class PlaybackWatcher {
 
     let waitingHandler = () => this.waiting_();
     let cancelTimerHandler = () => this.cancelTimer_();
+    let fixesBadSeeksHandler = () => this.fixesBadSeeks_();
 
+    this.tech_.on('seekablechanged', fixesBadSeeksHandler);
     this.tech_.on('waiting', waitingHandler);
     this.tech_.on(timerCancelEvents, cancelTimerHandler);
     this.monitorCurrentTime_();

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -48,6 +48,7 @@ export default class PlaybackWatcher {
     // Define the dispose function to clean up our events
     this.dispose = () => {
       this.logger_('dispose');
+      this.tech_.off('seekablechanged', fixesBadSeeksHandler);
       this.tech_.off('waiting', waitingHandler);
       this.tech_.off(timerCancelEvents, cancelTimerHandler);
       if (this.checkCurrentTimeTimeout_) {

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -368,7 +368,7 @@ export default class SyncController extends videojs.EventTarget {
     } else {
       return false;
     }
-    this.trigger('syncinfoupdate');
+
     return true;
   }
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -831,6 +831,29 @@ function(assert) {
   Playlist.seekable = origSeekable;
 });
 
+QUnit.test('syncInfoUpdate triggers seekablechanged when seekable is updated',
+function(assert) {
+  let origSeekable = Playlist.seekable;
+  let mpc = this.masterPlaylistController;
+  let tech = this.player.tech_;
+  let mainTimeRanges = [];
+  let media = {};
+  let seekablechanged = 0;
+  tech.on('seekablechanged', () => seekablechanged++);
+
+  Playlist.seekable = (media) => {
+    return videojs.createTimeRanges(mainTimeRanges);
+  };
+  this.masterPlaylistController.masterPlaylistLoader_.media = () => media;
+
+  mainTimeRanges = [[0, 10]];
+  mpc.seekable_ = videojs.createTimeRanges();
+  mpc.onSyncInfoUpdate_();
+  assert.equal(seekablechanged, 1, 'seekablechanged triggered');
+
+  Playlist.seekable = origSeekable;
+});
+
 QUnit.test('calls to update cues on new media', function(assert) {
   let origHlsOptions = videojs.options.hls;
 

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -839,9 +839,10 @@ function(assert) {
   let mainTimeRanges = [];
   let media = {};
   let seekablechanged = 0;
+
   tech.on('seekablechanged', () => seekablechanged++);
 
-  Playlist.seekable = (media) => {
+  Playlist.seekable = () => {
     return videojs.createTimeRanges(mainTimeRanges);
   };
   this.masterPlaylistController.masterPlaylistLoader_.media = () => media;

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -369,6 +369,32 @@ QUnit.test('seeks to live point if we try to seek outside of seekable', function
   assert.equal(seeks.length, 4, 'did not seek');
 });
 
+QUnit.test('calls fixesBadSeeks_ on seekablechanged', function(assert) {
+  // set an arbitrary live source
+  this.player.src({
+    src: 'liveStart30sBefore.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  // start playback normally
+  this.player.tech_.triggerReady();
+  this.clock.tick(1);
+  standardXHRResponse(this.requests.shift());
+  openMediaSource(this.player, this.clock);
+  this.player.tech_.trigger('play');
+  this.player.tech_.trigger('playing');
+  this.clock.tick(1);
+
+  let playbackWatcher = this.player.tech_.hls.playbackWatcher_;
+  let fixesBadSeeks_ = 0;
+
+  playbackWatcher.fixesBadSeeks_ = () => fixesBadSeeks_++;
+
+  this.player.tech_.trigger('seekablechanged');
+
+  assert.equal(fixesBadSeeks_, 1, 'fixesBadSeeks_ was called');
+});
+
 QUnit.module('PlaybackWatcher isolated functions', {
   beforeEach() {
     monitorCurrentTime_ = PlaybackWatcher.prototype.monitorCurrentTime_;


### PR DESCRIPTION
## Description
1. When the seekable window gets far out of sync from being pretty far in the future from the last known sync-point, we can set currentTime to a value that is unreachable
2. Once the segment is loaded, we have enough information to adjust seekable to the correct value
3. The original segment fetched from the “very wrong” currentTime is actually the right segment (it was based on the same, poor information)
4. Doing a seek-to-live again after we adjust the seekable window will put the currentTime at the end of the segment we just fetched
5. If we perform these operations in the right order we can avoid any spurious segment requests (ie. not trigger the resync-on-a-poor-guess behavior)

## Specific Changes proposed
1. Stop emitting `syncinfoupdate` from SyncController after probing a segment
   * Do that manually later in SegmentLoader
2. In `handleUpdateEnd_` use `resetEverything` to delete any portion of the segment that might be buffered when we re-sync
3. Add a new event `seekablechanged` to PlaybackWatcher so that it can immediately perform a seek-to-live when the seekable window has changed

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
