### PR TITLE
Locking url-toolkit to 1.0.9 to support relative urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "global": "^4.3.0",
     "m3u8-parser": "2.0.1",
     "mux.js": "4.1.0",
-    "url-toolkit": "^1.0.4",
+    "url-toolkit": "1.0.9",
     "video.js": "^5.17.0",
     "videojs-contrib-media-sources": "4.4.0",
     "webworkify": "1.0.2"


### PR DESCRIPTION
Downgrading and locking url-toolkit because of https://github.com/tjenkinson/url-toolkit/issues/4