### PR TITLE
feat: use an existing id3 cue track if it is available

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -211,9 +211,23 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.mode_ = mode;
     this.useCueTags_ = useCueTags;
     if (this.useCueTags_) {
-      this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
-        'ad-cues');
-      this.cueTagsTrack_.inBandMetadataTrackDispatchType = '';
+      let track;
+      const tracks = this.tech_.textTracks();
+      let i = tracks.length;
+
+      // check if an track already exists for id3 cue tags
+      while (i-- && !track) {
+        if (typeof tracks[i].inBandMetadataTrackDispatchType !== 'undefined') {
+          track = tracks[i];
+        }
+      }
+
+      if (!track) {
+        track = this.tech_.addTextTrack('metadata', 'ad-cues');
+        track.inBandMetadataTrackDispatchType = '';
+      }
+
+      this.cueTagsTrack_ = track;
     }
 
     this.audioTracks_ = [];

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -916,6 +916,30 @@ QUnit.test('respects useCueTags option', function(assert) {
   videojs.options.hls = origHlsOptions;
 });
 
+QUnit.test('respects useCueTags and uses existing cue tags track', function(assert) {
+  let origHlsOptions = videojs.options.hls;
+
+  videojs.options.hls = {
+    useCueTags: true
+  };
+
+  this.player = createPlayer();
+  const track = this.player.addTextTrack('metadata', 'ad-cues');
+
+  track.inBandMetadataTrackDispatchType = '';
+
+  this.player.src({
+    src: 'manifest/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+  this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+  assert.ok(this.masterPlaylistController.cueTagsTrack_, 'creates cueTagsTrack_ if useCueTags is truthy');
+  assert.equal(this.masterPlaylistController.cueTagsTrack_.id, track.id, 'uses existing track');
+
+  videojs.options.hls = origHlsOptions;
+});
+
 QUnit.test('sends decrypter messages to correct segment loader', function(assert) {
   this.player = createPlayer();
   this.player.src({


### PR DESCRIPTION
## Description
Use an existing id3 cue track if it exists, before creating a new one

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
