### PR TITLE
do not timeout segment requests for non-master playlist source

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -288,7 +288,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
       let media = this.masterPlaylistLoader_.media();
       let requestTimeout = (this.masterPlaylistLoader_.targetDuration * 1.5) * 1000;
 
-      this.requestOptions_.timeout = requestTimeout;
+      // If we don't have any more available playlists, we don't want to
+      // timeout the request.
+      if (this.masterPlaylistLoader_.isLowestEnabledRendition_()) {
+        this.requestOptions_.timeout = 0;
+      } else {
+        this.requestOptions_.timeout = requestTimeout;
+      }
 
       // if this isn't a live video and preload permits, start
       // downloading segments

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -239,21 +239,13 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
    * @return {Boolean} true if on lowest rendition
    */
   loader.isLowestEnabledRendition_ = function() {
-    let media = loader.media();
-
-    if (!media) {
-      return false;
-    }
-
-    if (!media.attributes) {
-      // The spec says that every rendition MUST have a BANDWITH attribute. If our media
-      // object does not have an attributes field, that means we loaded this media as our
-      // source, not from a master playlist. This means it is our only rendition, so it
-      // must be the lowest enabled rendition
+    if (loader.master.playlists.length === 1) {
       return true;
     }
 
-    let currentBandwidth = media.attributes.BANDWIDTH || 0;
+    let media = loader.media();
+
+    let currentBandwidth = media.attributes.BANDWIDTH || Number.MAX_VALUE;
 
     return (loader.master.playlists.filter((playlist) => {
       const enabled = isEnabled(playlist);

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -241,8 +241,16 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
   loader.isLowestEnabledRendition_ = function() {
     let media = loader.media();
 
-    if (!media || !media.attributes) {
+    if (!media) {
       return false;
+    }
+
+    if (!media.attributes) {
+      // The spec says that every rendition MUST have a BANDWITH attribute. If our media
+      // object does not have an attributes field, that means we loaded this media as our
+      // source, not from a master playlist. This means it is our only rendition, so it
+      // must be the lowest enabled rendition
+      return true;
     }
 
     let currentBandwidth = media.attributes.BANDWIDTH || 0;

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -688,6 +688,23 @@ function(assert) {
               'request timeout 0');
 });
 
+QUnit.test('removes request timeout when the source is a media playlist and not master',
+  function(assert) {
+    this.requests.length = 0;
+
+    this.player.src({
+      src: 'manifest/media.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+    this.masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
+
+    // media
+    this.standardXHRResponse(this.requests.shift());
+
+    assert.equal(this.masterPlaylistController.requestOptions_.timeout, 0,
+              'request timeout set to 0 when loading a non master playlist');
+  });
+
 QUnit.test('seekable uses the intersection of alternate audio and combined tracks',
 function(assert) {
   let origSeekable = Playlist.seekable;


### PR DESCRIPTION
## Description
If the source loaded into the player is just a media playlist and not a master playlist, segments will still timeout after `1.5 * targetDuration` even though it is playing the lowest enabled rendition (seeing how its the only rendition)

Addresses #1022 

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
