### PR TITLE
Fix #1030

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -426,7 +426,24 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('error', () => {
-      this.blacklistCurrentPlaylist(this.mainSegmentLoader_.error());
+      var segmentLoader = this;
+      var error = this.mainSegmentLoader_.error();
+      if(error.code == 2){//If lost connection, try again later
+          //pause the media
+          segmentLoader.mainSegmentLoader_.pause();
+          if (segmentLoader.audioPlaylistLoader_) {
+              segmentLoader.audioSegmentLoader_.pause();
+          }
+          //setTimeout to try again in 5 seconds
+          setTimeout(function(){
+              segmentLoader.mainSegmentLoader_.load();
+              if (segmentLoader.audioPlaylistLoader_) {
+                  segmentLoader.audioSegmentLoader_.load();
+              }
+          }, 5000);
+      }else{
+          segmentLoader.blacklistCurrentPlaylist(error);
+      }
     });
 
     this.mainSegmentLoader_.on('syncinfoupdate', () => {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -426,23 +426,26 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('error', () => {
-      var segmentLoader = this;
-      var error = this.mainSegmentLoader_.error();
-      if(error.code == 2){//If lost connection, try again later
-          //pause the media
-          segmentLoader.mainSegmentLoader_.pause();
+      let segmentLoader = this;
+      let error = this.mainSegmentLoader_.error();
+
+      // If lost connection (status = 0) , try again later
+      if (error.status === 0) {
+        // pause the media
+        segmentLoader.mainSegmentLoader_.pause();
+        if (segmentLoader.audioPlaylistLoader_) {
+          segmentLoader.audioSegmentLoader_.pause();
+        }
+        videojs.log.warn('Connection lost. Trying again in 5 seconds.');
+        // setTimeout to try again in 5 seconds
+        setTimeout(function() {
+          segmentLoader.mainSegmentLoader_.load();
           if (segmentLoader.audioPlaylistLoader_) {
-              segmentLoader.audioSegmentLoader_.pause();
+            segmentLoader.audioSegmentLoader_.load();
           }
-          //setTimeout to try again in 5 seconds
-          setTimeout(function(){
-              segmentLoader.mainSegmentLoader_.load();
-              if (segmentLoader.audioPlaylistLoader_) {
-                  segmentLoader.audioSegmentLoader_.load();
-              }
-          }, 5000);
-      }else{
-          segmentLoader.blacklistCurrentPlaylist(error);
+        }, 5000);
+      } else {
+        segmentLoader.blacklistCurrentPlaylist(error);
       }
     });
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -847,10 +847,12 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (!request.aborted && error) {
       // abort will clear xhr_
       let keyXhrRequest = this.xhr_.keyXhr;
+      // Get the request error status before aborting
+      let s = request.status;
 
       this.abort_();
       this.error({
-        status: request.status,
+        status: s,
         message: request === keyXhrRequest ?
           'HLS key request error at URL: ' + segment.key.uri :
           'HLS segment request error at URL: ' + segmentInfo.uri,

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2789,6 +2789,38 @@ QUnit.test('blacklists playlist if key requests fail', function(assert) {
   assert.equal(this.env.log.warn.calls, 1, 'logged warning for blacklist');
 });
 
+QUnit.test('does not blacklist playlist if connection is lost', function(assert) {
+  let hls = HlsSourceHandler('html5').handleSource({
+    src: 'manifest/encrypted-media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  }, this.tech);
+
+  hls.mediaSource.trigger('sourceopen');
+  this.requests.shift()
+    .respond(200, null,
+      '#EXTM3U\n' +
+      '#EXT-X-KEY:METHOD=AES-128,URI="htts://priv.example.com/key.php?r=52"\n' +
+      '#EXTINF:2.833,\n' +
+      'http://media.example.com/fileSequence52-A.ts\n' +
+      '#EXT-X-KEY:METHOD=AES-128,URI="htts://priv.example.com/key.php?r=53"\n' +
+      '#EXTINF:15.0,\n' +
+      'http://media.example.com/fileSequence53-A.ts\n' +
+      '#EXT-X-ENDLIST\n');
+  this.clock.tick(1);
+
+  // segment 1
+  if (/key\.php/i.test(this.requests[0].url)) {
+    this.standardXHRResponse(this.requests.pop());
+  } else {
+    this.standardXHRResponse(this.requests.shift());
+  }
+  // Lost connection
+  this.requests.shift().respond(0);
+  assert.notOk(hls.playlists.media().excludeUntil,
+    'playlist was not blacklisted');
+  assert.equal(this.env.log.warn.calls, 1, 'logged warning for connection loss');
+});
+
 QUnit.test('treats invalid keys as a key request failure and blacklists playlist', function(assert) {
   let hls = HlsSourceHandler('html5').handleSource({
     src: 'manifest/encrypted-media.m3u8',


### PR DESCRIPTION
## Description
If the connection is lost, videojs-contrib-hls will try to load the media every five seconds until the connection is back.

## Specific Changes proposed
Change the error handling of mainSegmentLoader.
Case the error is a connection lost error it will try to load the segment again from five to five seconds.
Case the error is any other else it will blacklist the playlist 

## Requirements Checklist
- [X] Bug fixed
- [ ] Reviewed by Two Core Contributors
