### PR TITLE
WebVTT Cleanup

### DIFF
--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -61,6 +61,21 @@ const createTransferableMessage = function(message) {
 };
 
 /**
+ * Returns a unique string identifier for a media initialization
+ * segment.
+ */
+const initSegmentId = function(initSegment) {
+  let byterange = initSegment.byterange || {
+    length: Infinity,
+    offset: 0
+  };
+
+  return [
+    byterange.length, byterange.offset, initSegment.resolvedUri
+  ].join(',');
+};
+
+/**
  * utils to help dump binary data to the console
  */
 const utils = {
@@ -90,7 +105,8 @@ const utils = {
     }
     return result;
   },
-  createTransferableMessage
+  createTransferableMessage,
+  initSegmentId
 };
 
 export default utils;

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -264,7 +264,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),
       seeking: () => this.tech_.seeking(),
-      setCurrentTime: (a) => this.tech_.setCurrentTime(a),
+      duration: () => this.mediaSource.duration,
       hasPlayed: () => this.hasPlayed_(),
       bandwidth,
       syncController: this.syncController_,

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -244,14 +244,14 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @return {Boolean} True if the all configuration is ready for loading
    * @private
    */
-   couldBeginLoading_() {
+  couldBeginLoading_() {
     return this.playlist_ &&
            // the source updater is created when init_ is called, so either having a
            // source updater or being in the INIT state with a mimeType is enough
            // to say we have all the needed configuration to start loading.
            (this.sourceUpdater_ || (this.mimeType_ && this.state === 'INIT')) &&
            !this.paused();
-   }
+  }
 
   /**
    * load a playlist and start to fill the buffer

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -7,6 +7,7 @@ import SourceUpdater from './source-updater';
 import Config from './config';
 import window from 'global/window';
 import removeCuesFromTrack from 'videojs-contrib-media-sources/es5/remove-cues-from-track.js';
+import { initSegmentId } from './bin-utils';
 import {mediaSegmentRequest, REQUEST_ERRORS} from './media-segment-request';
 
 // in ms
@@ -23,7 +24,7 @@ const CHECK_BUFFER_DELAY = 500;
  * @returns {Boolean} do we need to call endOfStream on the MediaSource
  */
 const detectEndOfStream = function(playlist, mediaSource, segmentIndex) {
-  if (!playlist) {
+  if (!playlist || !mediaSource) {
     return false;
   }
 
@@ -39,21 +40,6 @@ const detectEndOfStream = function(playlist, mediaSource, segmentIndex) {
   return playlist.endList &&
     mediaSource.readyState === 'open' &&
     appendedLastSegment;
-};
-
-/**
- * Returns a unique string identifier for a media initialization
- * segment.
- */
-const initSegmentId = function(initSegment) {
-  let byterange = initSegment.byterange || {
-    length: Infinity,
-    offset: 0
-  };
-
-  return [
-    byterange.length, byterange.offset, initSegment.resolvedUri
-  ].join(',');
 };
 
 /**
@@ -91,7 +77,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.currentTime_ = settings.currentTime;
     this.seekable_ = settings.seekable;
     this.seeking_ = settings.seeking;
-    this.setCurrentTime_ = settings.setCurrentTime;
+    this.duration_ = settings.duration;
     this.mediaSource_ = settings.mediaSource;
     this.hls_ = settings.hls;
     this.loaderType_ = settings.loaderType;
@@ -210,6 +196,64 @@ export default class SegmentLoader extends videojs.EventTarget {
   }
 
   /**
+   * Indicates which time ranges are buffered
+   *
+   * @return {TimeRange}
+   *         TimeRange object representing the current buffered ranges
+   */
+  buffered_() {
+    if (!this.sourceUpdater_) {
+      return videojs.createTimeRanges();
+    }
+
+    return this.sourceUpdater_.buffered();
+  }
+
+  /**
+   * Gets and sets init segment for the provided map
+   *
+   * @param {Object} map
+   *        The map object representing the init segment to get or set
+   * @param {Boolean=} set
+   *        If true, the init segment for the provided map should be saved
+   * @return {Object}
+   *         map object for desired init segment
+   */
+  initSegment(map, set = false) {
+    if (!map) {
+      return null;
+    }
+
+    const id = initSegmentId(map);
+    let storedMap = this.initSegments_[id];
+
+    if (set && !storedMap && map.bytes) {
+      this.initSegments_[id] = storedMap = {
+        resolvedUri: map.resolvedUri,
+        byterange: map.byterange,
+        bytes: map.bytes
+      };
+    }
+
+    return storedMap || map;
+  }
+
+  /**
+   * Returns true if all configuration required for loading is present, otherwise false.
+   *
+   * @return {Boolean} True if the all configuration is ready for loading
+   * @private
+   */
+   couldBeginLoading_() {
+    return this.playlist_ &&
+           // the source updater is created when init_ is called, so either having a
+           // source updater or being in the INIT state with a mimeType is enough
+           // to say we have all the needed configuration to start loading.
+           (this.sourceUpdater_ || (this.mimeType_ && this.state === 'INIT')) &&
+           !this.paused();
+   }
+
+  /**
    * load a playlist and start to fill the buffer
    */
   load() {
@@ -226,13 +270,13 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.syncController_.setDateTimeMapping(this.playlist_);
 
     // if all the configuration is ready, initialize and begin loading
-    if (this.state === 'INIT' && this.mimeType_) {
+    if (this.state === 'INIT' && this.couldBeginLoading_()) {
       return this.init_();
     }
 
     // if we're in the middle of processing a segment already, don't
     // kick off an additional segment request
-    if (!this.sourceUpdater_ ||
+    if (!this.couldBeginLoading_() ||
         (this.state !== 'READY' &&
         this.state !== 'INIT')) {
       return;
@@ -287,7 +331,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // if we were unpaused but waiting for a playlist, start
     // buffering now
-    if (this.mimeType_ && this.state === 'INIT' && !this.paused()) {
+    if (this.state === 'INIT' && this.couldBeginLoading_()) {
       return this.init_();
     }
 
@@ -369,9 +413,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     this.mimeType_ = mimeType;
     // if we were unpaused but waiting for a sourceUpdater, start
     // buffering now
-    if (this.playlist_ &&
-        this.state === 'INIT' &&
-        !this.paused()) {
+    if (this.state === 'INIT' && this.couldBeginLoading_()) {
       this.init_();
     }
   }
@@ -464,13 +506,13 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (!this.syncPoint_) {
       this.syncPoint_ = this.syncController_.getSyncPoint(this.playlist_,
-                                                          this.mediaSource_.duration,
+                                                          this.duration_(),
                                                           this.currentTimeline_,
                                                           this.currentTime_());
     }
 
     // see if we need to begin loading immediately
-    let segmentInfo = this.checkBuffer_(this.sourceUpdater_.buffered(),
+    let segmentInfo = this.checkBuffer_(this.buffered_(),
                                         this.playlist_,
                                         this.mediaIndex,
                                         this.hasPlayed_(),
@@ -764,16 +806,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (segment.map) {
-      const map = this.initSegments_[initSegmentId(segment.map)];
-
-      if (map) {
-        simpleSegment.map = map;
-      } else {
-        simpleSegment.map = {
-          resolvedUri: segment.map.resolvedUri,
-          byterange: segment.map.byterange
-        };
-      }
+      simpleSegment.map = this.initSegment(segment.map);
     }
 
     return simpleSegment;
@@ -851,7 +884,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // if this request included an initialization segment, save that data
     // to the initSegment cache
     if (simpleSegment.map) {
-      this.initSegments_[initSegmentId(simpleSegment.map)] = simpleSegment.map;
+      simpleSegment.map = this.initSegment(simpleSegment.map, true);
     }
 
     this.processSegmentResponse_(simpleSegment);
@@ -912,7 +945,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       if (!this.activeInitSegmentId_ ||
           this.activeInitSegmentId_ !== initId) {
-        const initSegment = this.initSegments_[initId];
+        const initSegment = this.initSegment(segment.map);
 
         this.sourceUpdater_.appendBuffer(initSegment.bytes, () => {
           this.activeInitSegmentId_ = initId;

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -194,9 +194,9 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * empty or not.
    *
    * @param {Object} segmentInfo
-   *        a segment request object that describes the segment to load
+   *        a segment info object that describes the current segment
    * @return {Object}
-   *         a segment request object that describes the segment to load
+   *         a segment info object that describes the current segment
    */
   skipEmptySegments_(segmentInfo) {
     while (segmentInfo && segmentInfo.segment.empty) {
@@ -283,6 +283,13 @@ export default class VTTSegmentLoader extends SegmentLoader {
     this.handleUpdateEnd_();
   }
 
+  /**
+   * Uses the WebVTT parser to parse the segment response
+   *
+   * @param {Object} segmentInfo
+   *        a segment info object that describes the current segment
+   * @private
+   */
   parseVTTCues_(segmentInfo) {
     let decoder;
     let decodeBytesToString = false;
@@ -327,6 +334,19 @@ export default class VTTSegmentLoader extends SegmentLoader {
     parser.flush();
   }
 
+  /**
+   * Updates the start and end times of any cues parsed by the WebVTT parser using
+   * the information parsed from the X-TIMESTAMP-MAP header and a TS to media time mapping
+   * from the SyncController
+   *
+   * @param {Object} segmentInfo
+   *        a segment info object that describes the current segment
+   * @param {Object} mappingObj
+   *        object containing a mapping from TS to media time
+   * @param {Object} playlist
+   *        the playlist object containing the segment
+   * @private
+   */
   updateTimeMapping_(segmentInfo, mappingObj, playlist) {
     const segment = segmentInfo.segment;
 

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -94,11 +94,11 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @return {Boolean} True if the all configuration is ready for loading
    * @private
    */
-   couldBeginLoading_() {
+  couldBeginLoading_() {
     return this.playlist_ &&
            this.subtitlesTrack_ &&
            !this.paused();
-   }
+  }
 
   /**
    * Once all the starting parameters have been specified, begin

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -1,31 +1,13 @@
 /**
  * @file vtt-segment-loader.js
  */
-import {getMediaInfoForTime_ as getMediaInfoForTime} from './playlist';
+import SegmentLoader from './segment-loader';
 import videojs from 'video.js';
-import Config from './config';
 import window from 'global/window';
 import removeCuesFromTrack from 'videojs-contrib-media-sources/es5/remove-cues-from-track.js';
-import {mediaSegmentRequest, REQUEST_ERRORS} from './media-segment-request';
+import { initSegmentId } from './bin-utils';
 
-// in ms
-const CHECK_BUFFER_DELAY = 500;
 const VTT_LINE_TERMINATORS = new Uint8Array('\n\n'.split('').map(char => char.charCodeAt(0)));
-
-/**
- * Returns a unique string identifier for a media initialization
- * segment.
- */
-const initSegmentId = function(initSegment) {
-  let byterange = initSegment.byterange || {
-    length: Infinity,
-    offset: 0
-  };
-
-  return [
-    byterange.length, byterange.offset, initSegment.resolvedUri
-  ].join(',');
-};
 
 const uintToString = function(uintArray) {
   return String.fromCharCode.apply(null, uintArray);
@@ -38,149 +20,24 @@ const uintToString = function(uintArray) {
  * @param {Object} options required and optional options
  * @extends videojs.EventTarget
  */
-export default class VTTSegmentLoader extends videojs.EventTarget {
+export default class VTTSegmentLoader extends SegmentLoader {
   constructor(options) {
-    super();
-    // check pre-conditions
-    if (!options) {
-      throw new TypeError('Initialization options are required');
-    }
-    if (typeof options.currentTime !== 'function') {
-      throw new TypeError('No currentTime getter specified');
-    }
-    let settings = videojs.mergeOptions(videojs.options.hls, options);
+    super(options);
 
-    // public properties
-    this.state = 'INIT';
-    this.bandwidth = settings.bandwidth;
-    this.throughput = {rate: 0, count: 0};
-    this.roundTrip = NaN;
-    this.resetStats_();
-    this.mediaIndex = null;
-
-    // private settings
-    this.hasPlayed_ = settings.hasPlayed;
-    this.currentTime_ = settings.currentTime;
-    this.seekable_ = settings.seekable;
-    this.seeking_ = settings.seeking;
-    this.setCurrentTime_ = settings.setCurrentTime;
-    this.mediaSource_ = settings.mediaSource;
-    this.hls_ = settings.hls;
-    this.loaderType_ = settings.loaderType;
-
-    // private instance variables
-    this.checkBufferTimeout_ = null;
-    this.error_ = void 0;
-    this.currentTimeline_ = -1;
-    this.pendingSegment_ = null;
-    this.sourceUpdater_ = null;
-    this.xhrOptions_ = null;
+    // SegmentLoader requires a MediaSource be specified or it will throw an error;
+    // however, VTTSegmentLoader has no need of a media source, so delete the reference
+    this.mediaSource_ = null;
 
     this.subtitlesTrack_ = null;
-
-    // Fragmented mp4 playback
-    this.initSegments_ = {};
-
-    this.decrypter_ = settings.decrypter;
-
-    // Manages the tracking and generation of sync-points, mappings
-    // between a time in the display time and a segment index within
-    // a playlist
-    this.syncController_ = settings.syncController;
-    this.syncPoint_ = {
-      segmentIndex: 0,
-      time: 0
-    };
-
-    this.syncController_.on('syncinfoupdate', () => this.trigger('syncinfoupdate'));
-
-    // ...for determining the fetch location
-    this.fetchAtBuffer_ = false;
-
-    if (settings.debug) {
-      this.logger_ = videojs.log.bind(videojs, 'segment-loader', this.loaderType_, '->');
-    }
-  }
-
-  /**
-   * reset all of our media stats
-   *
-   * @private
-   */
-  resetStats_() {
-    this.mediaBytesTransferred = 0;
-    this.mediaRequests = 0;
-    this.mediaRequestsAborted = 0;
-    this.mediaRequestsTimedout = 0;
-    this.mediaRequestsErrored = 0;
-    this.mediaTransferDuration = 0;
-    this.mediaSecondsLoaded = 0;
-  }
-
-  /**
-   * dispose of the SegmentLoader and reset to the default state
-   */
-  dispose() {
-    this.state = 'DISPOSED';
-    this.abort_();
-    this.resetStats_();
-  }
-
-  /**
-   * abort anything that is currently doing on with the SegmentLoader
-   * and reset to a default state
-   */
-  abort() {
-    if (this.state !== 'WAITING') {
-      if (this.pendingSegment_) {
-        this.pendingSegment_ = null;
-      }
-      return;
-    }
-
-    this.abort_();
-
-    // don't wait for buffer check timeouts to begin fetching the
-    // next segment
-    if (!this.paused()) {
-      this.state = 'READY';
-      this.monitorBuffer_();
-    }
-  }
-
-  /**
-   * abort all pending xhr requests and null any pending segements
-   *
-   * @private
-   */
-  abort_() {
-    if (this.pendingSegment_) {
-      this.pendingSegment_.abortRequests();
-    }
-
-    // clear out the segment being processed
-    this.pendingSegment_ = null;
-  }
-
-  /**
-   * set an error on the segment loader and null out any pending segements
-   *
-   * @param {Error} error the error to set on the SegmentLoader
-   * @return {Error} the error that was set or that is currently set
-   */
-  error(error) {
-    if (typeof error !== 'undefined') {
-      this.error_ = error;
-    }
-
-    this.pendingSegment_ = null;
-    return this.error_;
   }
 
   /**
    * Indicates which time ranges are buffered
+   *
+   * @return {TimeRange}
+   *         TimeRange object representing the current buffered ranges
    */
-  buffered() {
+  buffered_() {
     if (!this.subtitlesTrack_ || !this.subtitlesTrack_.cues.length) {
       return videojs.createTimeRanges();
     }
@@ -232,35 +89,16 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
   }
 
   /**
-   * load a playlist and start to fill the buffer
+   * Returns true if all configuration required for loading is present, otherwise false.
+   *
+   * @return {Boolean} True if the all configuration is ready for loading
+   * @private
    */
-  load() {
-    // un-pause
-    this.monitorBuffer_();
-
-    // if we don't have a playlist yet, keep waiting for one to be
-    // specified
-    if (!this.playlist_) {
-      return;
-    }
-
-    // not sure if this is the best place for this
-    this.syncController_.setDateTimeMapping(this.playlist_);
-
-    // if all the configuration is ready, initialize and begin loading
-    if (this.state === 'INIT' && this.subtitlesTrack_) {
-      return this.init_();
-    }
-
-    // if we're in the middle of processing a segment already, don't
-    // kick off an additional segment request
-    if (this.state !== 'READY' &&
-        this.state !== 'INIT') {
-      return;
-    }
-
-    this.state = 'READY';
-  }
+   couldBeginLoading_() {
+    return this.playlist_ &&
+           this.subtitlesTrack_ &&
+           !this.paused();
+   }
 
   /**
    * Once all the starting parameters have been specified, begin
@@ -286,140 +124,9 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
 
     // if we were unpaused but waiting for a sourceUpdater, start
     // buffering now
-    if (this.playlist_ &&
-        this.state === 'INIT' &&
-        !this.paused() &&
-        this.subtitlesTrack_) {
+    if (this.state === 'INIT' && this.couldBeginLoading_()) {
       this.init_();
     }
-  }
-
-  /**
-   * set a playlist on the segment loader
-   *
-   * @param {PlaylistLoader} media the playlist to set on the segment loader
-   */
-  playlist(newPlaylist, options = {}) {
-    if (!newPlaylist) {
-      return;
-    }
-
-    let oldPlaylist = this.playlist_;
-    let segmentInfo = this.pendingSegment_;
-
-    this.playlist_ = newPlaylist;
-    this.xhrOptions_ = options;
-
-    // when we haven't started playing yet, the start of a live playlist
-    // is always our zero-time so force a sync update each time the playlist
-    // is refreshed from the server
-    if (!this.hasPlayed_()) {
-      newPlaylist.syncInfo = {
-        mediaSequence: newPlaylist.mediaSequence,
-        time: 0
-      };
-    }
-
-    // in VOD, this is always a rendition switch (or we updated our syncInfo above)
-    // in LIVE, we always want to update with new playlists (including refreshes)
-    this.trigger('syncinfoupdate');
-
-    // if we were unpaused but waiting for a playlist, start
-    // buffering now
-    if (this.subtitlesTrack_ && this.state === 'INIT' && !this.paused()) {
-      return this.init_();
-    }
-
-    if (!oldPlaylist || oldPlaylist.uri !== newPlaylist.uri) {
-      if (this.mediaIndex !== null) {
-        // we must "resync" the segment loader when we switch renditions and
-        // the segment loader is already synced to the previous rendition
-        this.resyncLoader();
-      }
-
-      // the rest of this function depends on `oldPlaylist` being defined
-      return;
-    }
-
-    // we reloaded the same playlist so we are in a live scenario
-    // and we will likely need to adjust the mediaIndex
-    let mediaSequenceDiff = newPlaylist.mediaSequence - oldPlaylist.mediaSequence;
-
-    this.logger_('mediaSequenceDiff', mediaSequenceDiff);
-
-    // update the mediaIndex on the SegmentLoader
-    // this is important because we can abort a request and this value must be
-    // equal to the last appended mediaIndex
-    if (this.mediaIndex !== null) {
-      this.mediaIndex -= mediaSequenceDiff;
-    }
-
-    // update the mediaIndex on the SegmentInfo object
-    // this is important because we will update this.mediaIndex with this value
-    // in `handleUpdateEnd_` after the segment has been successfully appended
-    if (segmentInfo) {
-      segmentInfo.mediaIndex -= mediaSequenceDiff;
-
-      // we need to update the referenced segment so that timing information is
-      // saved for the new playlist's segment, however, if the segment fell off the
-      // playlist, we can leave the old reference and just lose the timing info
-      if (segmentInfo.mediaIndex >= 0) {
-        segmentInfo.segment = newPlaylist.segments[segmentInfo.mediaIndex];
-      }
-    }
-
-    this.syncController_.saveExpiredSegmentInfo(oldPlaylist, newPlaylist);
-  }
-
-  /**
-   * Prevent the loader from fetching additional segments. If there
-   * is a segment request outstanding, it will finish processing
-   * before the loader halts. A segment loader can be unpaused by
-   * calling load().
-   */
-  pause() {
-    if (this.checkBufferTimeout_) {
-      window.clearTimeout(this.checkBufferTimeout_);
-
-      this.checkBufferTimeout_ = null;
-    }
-  }
-
-  /**
-   * Returns whether the segment loader is fetching additional
-   * segments when given the opportunity. This property can be
-   * modified through calls to pause() and load().
-   */
-  paused() {
-    return this.checkBufferTimeout_ === null;
-  }
-
-  /**
-   * Delete all the buffered data and reset the SegmentLoader
-   */
-  resetEverything() {
-    this.resetLoader();
-    this.remove(0, Infinity);
-  }
-
-  /**
-   * Force the SegmentLoader to resync and start loading around the currentTime instead
-   * of starting at the end of the buffer
-   *
-   * Useful for fast quality changes
-   */
-  resetLoader() {
-    this.fetchAtBuffer_ = false;
-    this.resyncLoader();
-  }
-
-  /**
-   * Force the SegmentLoader to restart synchronization and make a conservative guess
-   * before returning to the simple walk-forward method
-   */
-  resyncLoader() {
-    this.mediaIndex = null;
-    this.syncPoint_ = null;
   }
 
   /**
@@ -429,38 +136,6 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
    */
   remove(start, end) {
     removeCuesFromTrack(start, end, this.subtitlesTrack_);
-  }
-
-  /**
-   * (re-)schedule monitorBufferTick_ to run as soon as possible
-   *
-   * @private
-   */
-  monitorBuffer_() {
-    if (this.checkBufferTimeout_) {
-      window.clearTimeout(this.checkBufferTimeout_);
-    }
-
-    this.checkBufferTimeout_ = window.setTimeout(this.monitorBufferTick_.bind(this), 1);
-  }
-
-  /**
-   * As long as the SegmentLoader is in the READY state, periodically
-   * invoke fillBuffer_().
-   *
-   * @private
-   */
-  monitorBufferTick_() {
-    if (this.state === 'READY') {
-      this.fillBuffer_();
-    }
-
-    if (this.checkBufferTimeout_) {
-      window.clearTimeout(this.checkBufferTimeout_);
-    }
-
-    this.checkBufferTimeout_ = window.setTimeout(this.monitorBufferTick_.bind(this),
-                                                 CHECK_BUFFER_DELAY);
   }
 
   /**
@@ -475,13 +150,13 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
   fillBuffer_() {
     if (!this.syncPoint_) {
       this.syncPoint_ = this.syncController_.getSyncPoint(this.playlist_,
-                                                          this.mediaSource_.duration,
+                                                          this.duration_(),
                                                           this.currentTimeline_,
                                                           this.currentTime_());
     }
 
     // see if we need to begin loading immediately
-    let segmentInfo = this.checkBuffer_(this.buffered(),
+    let segmentInfo = this.checkBuffer_(this.buffered_(),
                                         this.playlist_,
                                         this.mediaIndex,
                                         this.hasPlayed_(),
@@ -509,169 +184,8 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
       this.state = 'WAITING_ON_TIMELINE';
       return;
     }
+
     this.loadSegment_(segmentInfo);
-  }
-
-  /**
-   * Determines what segment request should be made, given current playback
-   * state.
-   *
-   * @param {TimeRanges} buffered - the state of the buffer
-   * @param {Object} playlist - the playlist object to fetch segments from
-   * @param {Number} mediaIndex - the previous mediaIndex fetched or null
-   * @param {Boolean} hasPlayed - a flag indicating whether we have played or not
-   * @param {Number} currentTime - the playback position in seconds
-   * @param {Object} syncPoint - a segment info object that describes the
-   * @returns {Object} a segment request object that describes the segment to load
-   */
-  checkBuffer_(buffered, playlist, mediaIndex, hasPlayed, currentTime, syncPoint) {
-    let lastBufferedEnd = 0;
-    let startOfSegment;
-
-    if (buffered.length) {
-      lastBufferedEnd = buffered.end(buffered.length - 1);
-    }
-
-    let bufferedTime = Math.max(0, lastBufferedEnd - currentTime);
-
-    if (!playlist.segments.length) {
-      return null;
-    }
-
-    // if there is plenty of content buffered, and the video has
-    // been played before relax for awhile
-    if (bufferedTime >= Config.GOAL_BUFFER_LENGTH) {
-      return null;
-    }
-
-    // if the video has not yet played once, and we already have
-    // one segment downloaded do nothing
-    if (!hasPlayed && bufferedTime >= 1) {
-      return null;
-    }
-
-    this.logger_('checkBuffer_',
-      'mediaIndex:', mediaIndex,
-      'hasPlayed:', hasPlayed,
-      'currentTime:', currentTime,
-      'syncPoint:', syncPoint,
-      'fetchAtBuffer:', this.fetchAtBuffer_,
-      'bufferedTime:', bufferedTime);
-
-    // When the syncPoint is null, there is no way of determining a good
-    // conservative segment index to fetch from
-    // The best thing to do here is to get the kind of sync-point data by
-    // making a request
-    if (syncPoint === null) {
-      mediaIndex = this.getSyncSegmentCandidate_(playlist);
-      this.logger_('getSync', 'mediaIndex:', mediaIndex);
-      return this.generateSegmentInfo_(playlist, mediaIndex, null, true);
-    }
-
-    // Under normal playback conditions fetching is a simple walk forward
-    if (mediaIndex !== null) {
-      this.logger_('walkForward', 'mediaIndex:', mediaIndex + 1);
-      let segment = playlist.segments[mediaIndex];
-
-      if (segment && segment.end) {
-        startOfSegment = segment.end;
-      } else {
-        startOfSegment = lastBufferedEnd;
-      }
-      return this.generateSegmentInfo_(playlist, mediaIndex + 1, startOfSegment, false);
-    }
-
-    // There is a sync-point but the lack of a mediaIndex indicates that
-    // we need to make a good conservative guess about which segment to
-    // fetch
-    if (this.fetchAtBuffer_) {
-      // Find the segment containing the end of the buffer
-      let mediaSourceInfo = getMediaInfoForTime(playlist,
-                                                lastBufferedEnd,
-                                                syncPoint.segmentIndex,
-                                                syncPoint.time);
-
-      mediaIndex = mediaSourceInfo.mediaIndex;
-      startOfSegment = mediaSourceInfo.startTime;
-    } else {
-      // Find the segment containing currentTime
-      let mediaSourceInfo = getMediaInfoForTime(playlist,
-                                                currentTime,
-                                                syncPoint.segmentIndex,
-                                                syncPoint.time);
-
-      mediaIndex = mediaSourceInfo.mediaIndex;
-      startOfSegment = mediaSourceInfo.startTime;
-    }
-    this.logger_('getMediaIndexForTime',
-      'mediaIndex:', mediaIndex,
-      'startOfSegment:', startOfSegment);
-
-    return this.generateSegmentInfo_(playlist, mediaIndex, startOfSegment, false);
-  }
-
-  /**
-   * The segment loader has no recourse except to fetch a segment in the
-   * current playlist and use the internal timestamps in that segment to
-   * generate a syncPoint. This function returns a good candidate index
-   * for that process.
-   *
-   * @param {Object} playlist - the playlist object to look for a
-   * @returns {Number} An index of a segment from the playlist to load
-   */
-  getSyncSegmentCandidate_(playlist) {
-    if (this.currentTimeline_ === -1) {
-      return 0;
-    }
-
-    let segmentIndexArray = playlist.segments
-      .map((s, i) => {
-        return {
-          timeline: s.timeline,
-          segmentIndex: i
-        };
-      }).filter(s => s.timeline === this.currentTimeline_);
-
-    if (segmentIndexArray.length) {
-      return segmentIndexArray[Math.min(segmentIndexArray.length - 1, 1)].segmentIndex;
-    }
-
-    return Math.max(playlist.segments.length - 1, 0);
-  }
-
-  generateSegmentInfo_(playlist, mediaIndex, startOfSegment, isSyncRequest) {
-    if (mediaIndex < 0 || mediaIndex >= playlist.segments.length) {
-      return null;
-    }
-
-    let segment = playlist.segments[mediaIndex];
-
-    return {
-      requestId: 'segment-loader-' + Math.random(),
-      // resolve the segment URL relative to the playlist
-      uri: segment.resolvedUri,
-      // the segment's mediaIndex at the time it was requested
-      mediaIndex,
-      // whether or not to update the SegmentLoader's state with this
-      // segment's mediaIndex
-      isSyncRequest,
-      startOfSegment,
-      // the segment's playlist
-      playlist,
-      // unencrypted bytes of the segment
-      bytes: null,
-      // when a key is defined for this segment, the encrypted bytes
-      encryptedBytes: null,
-      // The target timestampOffset for this segment when we append it
-      // to the source buffer
-      timestampOffset: null,
-      // The timeline that the segment is in
-      timeline: segment.timeline,
-      // The expected duration of the segment in seconds
-      duration: segment.duration,
-      // retain the segment in case the playlist updates while doing an async process
-      segment
-    };
   }
 
   /**
@@ -692,198 +206,6 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
                                               segmentInfo.isSyncRequest);
     }
     return segmentInfo;
-  }
-
-  /**
-   * load a specific segment from a request into the buffer
-   *
-   * @private
-   */
-  loadSegment_(segmentInfo) {
-    this.state = 'WAITING';
-    this.pendingSegment_ = segmentInfo;
-    this.trimBackBuffer_(segmentInfo);
-
-    segmentInfo.abortRequests = mediaSegmentRequest(this.hls_.xhr,
-      this.xhrOptions_,
-      this.decrypter_,
-      this.createSimplifiedSegmentObj_(segmentInfo),
-      // progress callback
-      (event, segment) => {
-        if (!this.pendingSegment_ || segment.requestId !== this.pendingSegment_.requestId) {
-          return;
-        }
-        // TODO: Use progress-based bandwidth to early abort low-bandwidth situations
-        this.trigger('progress');
-      },
-      this.segmentRequestFinished_.bind(this));
-  }
-
-  /**
-   * trim the back buffer so that we don't have too much data
-   * in the source buffer
-   *
-   * @private
-   *
-   * @param {Object} segmentInfo - the current segment
-   */
-  trimBackBuffer_(segmentInfo) {
-    const seekable = this.seekable_();
-    const currentTime = this.currentTime_();
-    let removeToTime = 0;
-
-    // Chrome has a hard limit of 150mb of
-    // buffer and a very conservative "garbage collector"
-    // We manually clear out the old buffer to ensure
-    // we don't trigger the QuotaExceeded error
-    // on the source buffer during subsequent appends
-
-    // If we have a seekable range use that as the limit for what can be removed safely
-    // otherwise remove anything older than 1 minute before the current play head
-    if (seekable.length &&
-        seekable.start(0) > 0 &&
-        seekable.start(0) < currentTime) {
-      removeToTime = seekable.start(0);
-    } else {
-      removeToTime = currentTime - 60;
-    }
-
-    if (removeToTime > 0) {
-      this.remove(0, removeToTime);
-    }
-  }
-
-  /**
-   * created a simplified copy of the segment object with just the
-   * information necessary to perform the XHR and decryption
-   *
-   * @private
-   *
-   * @param {Object} segmentInfo - the current segment
-   * @returns {Object} a simplified segment object copy
-   */
-  createSimplifiedSegmentObj_(segmentInfo) {
-    const segment = segmentInfo.segment;
-    const simpleSegment = {
-      resolvedUri: segment.resolvedUri,
-      byterange: segment.byterange,
-      requestId: segmentInfo.requestId
-    };
-
-    if (segment.key) {
-      // if the media sequence is greater than 2^32, the IV will be incorrect
-      // assuming 10s segments, that would be about 1300 years
-      const iv = segment.key.iv || new Uint32Array([
-        0, 0, 0, segmentInfo.mediaIndex + segmentInfo.playlist.mediaSequence
-      ]);
-
-      simpleSegment.key = {
-        resolvedUri: segment.key.resolvedUri,
-        iv
-      };
-    }
-
-    if (segment.map) {
-      simpleSegment.map = this.initSegment(segment.map);
-    }
-
-    return simpleSegment;
-  }
-
-  /**
-   * Handle the callback from the segmentRequest function and set the
-   * associated SegmentLoader state and errors if necessary
-   *
-   * @private
-   */
-  segmentRequestFinished_(error, simpleSegment) {
-    // every request counts as a media request even if it has been aborted
-    // or canceled due to a timeout
-    this.mediaRequests += 1;
-
-    if (simpleSegment.stats) {
-      this.mediaBytesTransferred += simpleSegment.stats.bytesReceived;
-      this.mediaTransferDuration += simpleSegment.stats.roundTripTime;
-    }
-
-    // The request was aborted and the SegmentLoader has already been reset
-    if (!this.pendingSegment_) {
-      this.mediaRequestsAborted += 1;
-      return;
-    }
-
-    // the request was aborted and the SegmentLoader has already started
-    // another request. this can happen when the timeout for an aborted
-    // request triggers due to a limitation in the XHR library
-    // do not count this as any sort of request or we risk double-counting
-    if (simpleSegment.requestId !== this.pendingSegment_.requestId) {
-      return;
-    }
-
-    // an error occurred from the active pendingSegment_ so reset everything
-    if (error) {
-      this.pendingSegment_ = null;
-
-      // the requests were aborted just record the aborted stat and exit
-      // this is not a true error condition and nothing corrective needs
-      // to be done
-      if (error.code === REQUEST_ERRORS.ABORTED) {
-        this.mediaRequestsAborted += 1;
-        return;
-      }
-
-      this.state = 'READY';
-      this.pause();
-
-      // the error is really just that at least one of the requests timed-out
-      // set the bandwidth to a very low value and trigger an ABR switch to
-      // take emergency action
-      if (error.code === REQUEST_ERRORS.TIMEOUT) {
-        this.mediaRequestsTimedout += 1;
-        this.bandwidth = 1;
-        this.roundTrip = NaN;
-        this.trigger('bandwidthupdate');
-        return;
-      }
-
-      // if control-flow has arrived here, then the error is real
-      // emit an error event to blacklist the current playlist
-      this.mediaRequestsErrored += 1;
-      this.error(error);
-      this.trigger('error');
-      return;
-    }
-
-    // the response was a success so set any bandwidth stats the request
-    // generated for ABR purposes
-    this.bandwidth = simpleSegment.stats.bandwidth;
-    this.roundTrip = simpleSegment.stats.roundTripTime;
-
-    // if this request included an initialization segment, save that data
-    // to the initSegment cache
-    if (simpleSegment.map) {
-      simpleSegment.map = this.initSegment(simpleSegment.map, true);
-    }
-
-    this.processSegmentResponse_(simpleSegment);
-  }
-
-  /**
-   * Move any important data from the simplified segment object
-   * back to the real segment object for future phases
-   *
-   * @private
-   */
-  processSegmentResponse_(simpleSegment) {
-    const segmentInfo = this.pendingSegment_;
-
-    segmentInfo.bytes = simpleSegment.bytes;
-    if (simpleSegment.map) {
-      segmentInfo.segment.map.bytes = simpleSegment.map.bytes;
-    }
-
-    segmentInfo.endOfAllRequests = simpleSegment.endOfAllRequests;
-    this.handleSegment_();
   }
 
   /**
@@ -1042,96 +364,4 @@ export default class VTTSegmentLoader extends videojs.EventTarget {
       };
     }
   }
-
-  /**
-   * callback to run when appendBuffer is finished. detects if we are
-   * in a good state to do things with the data we got, or if we need
-   * to wait for more
-   *
-   * @private
-   */
-  handleUpdateEnd_() {
-    this.logger_('handleUpdateEnd_', 'segmentInfo:', this.pendingSegment_);
-
-    if (!this.pendingSegment_) {
-      this.state = 'READY';
-      if (!this.paused()) {
-        this.monitorBuffer_();
-      }
-      return;
-    }
-
-    const segmentInfo = this.pendingSegment_;
-    const segment = segmentInfo.segment;
-    const isWalkingForward = this.mediaIndex !== null;
-
-    this.pendingSegment_ = null;
-    this.recordThroughput_(segmentInfo);
-
-    this.state = 'READY';
-
-    this.mediaIndex = segmentInfo.mediaIndex;
-    this.fetchAtBuffer_ = true;
-    this.currentTimeline_ = segmentInfo.timeline;
-
-    // We must update the syncinfo to recalculate the seekable range before
-    // the following conditional otherwise it may consider this a bad "guess"
-    // and attempt to resync when the post-update seekable window and live
-    // point would mean that this was the perfect segment to fetch
-    this.trigger('syncinfoupdate');
-
-    // If we previously appended a segment that ends more than 3 targetDurations before
-    // the currentTime_ that means that our conservative guess was too conservative.
-    // In that case, reset the loader state so that we try to use any information gained
-    // from the previous request to create a new, more accurate, sync-point.
-    if (segment.end &&
-        this.currentTime_() - segment.end > segmentInfo.playlist.targetDuration * 3) {
-      this.resetEverything();
-      return;
-    }
-
-    // Don't do a rendition switch unless we have enough time to get a sync segment
-    // and conservatively guess
-    if (isWalkingForward) {
-      this.trigger('bandwidthupdate');
-    }
-    this.trigger('progress');
-
-    if (!this.paused()) {
-      this.monitorBuffer_();
-    }
-  }
-
-  /**
-   * Records the current throughput of the decrypt, transmux, and append
-   * portion of the semgment pipeline. `throughput.rate` is a the cumulative
-   * moving average of the throughput. `throughput.count` is the number of
-   * data points in the average.
-   *
-   * @private
-   * @param {Object} segmentInfo the object returned by loadSegment
-   */
-  recordThroughput_(segmentInfo) {
-    const rate = this.throughput.rate;
-    // Add one to the time to ensure that we don't accidentally attempt to divide
-    // by zero in the case where the throughput is ridiculously high
-    const segmentProcessingTime =
-      Date.now() - segmentInfo.endOfAllRequests + 1;
-    // Multiply by 8000 to convert from bytes/millisecond to bits/second
-    const segmentProcessingThroughput =
-      Math.floor((segmentInfo.byteLength / segmentProcessingTime) * 8 * 1000);
-
-    // This is just a cumulative moving average calculation:
-    //   newAvg = oldAvg + (sample - oldAvg) / (sampleCount + 1)
-    this.throughput.rate +=
-      (segmentProcessingThroughput - rate) / (++this.throughput.count);
-  }
-
-  /**
-   * A debugging logger noop that is set to console.log only if debugging
-   * is enabled globally
-   *
-   * @private
-   */
-  logger_() {}
 }

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -1,0 +1,1043 @@
+import QUnit from 'qunit';
+import SegmentLoader from '../src/segment-loader';
+import videojs from 'video.js';
+import xhrFactory from '../src/xhr';
+import Config from '../src/config';
+import {
+  playlistWithDuration,
+  useFakeEnvironment,
+  useFakeMediaSource,
+  MockTextTrack
+} from './test-helpers.js';
+import sinon from 'sinon';
+import SyncController from '../src/sync-controller';
+import Decrypter from '../src/decrypter-worker';
+import worker from 'webworkify';
+
+export const CommonHooks = function() {
+  return {
+    beforeEach(assert) {
+      this.env = useFakeEnvironment(assert);
+      this.clock = this.env.clock;
+      this.requests = this.env.requests;
+      this.mse = useFakeMediaSource();
+      this.currentTime = 0;
+      this.seekable = {
+        length: 0
+      };
+      this.seeking = false;
+      this.hasPlayed = true;
+      this.fakeHls = {
+        xhr: xhrFactory()
+      };
+      this.mediaSource = new videojs.MediaSource();
+      this.mediaSource.trigger('sourceopen');
+      this.syncController = new SyncController();
+      this.decrypter = worker(Decrypter);
+    },
+    afterEach(assert) {
+      this.env.restore();
+      this.mse.restore();
+      decrypter.terminate();
+    }
+  };
+};
+
+export const CommonLoaderSettings = function(options) {
+  let settings = {
+    hls: this.fakeHls,
+    currentTime: () => this.currentTime,
+    seekable: () => this.seekable,
+    seeking: () => this.seeking,
+    hasPlayed: () => this.hasPlayed,
+    duration: () => this.mediaSource.duration,
+    mediaSource: this.mediaSource,
+    syncController: this.syncController,
+    decrypter: this.decrypter,
+    loaderType: 'main'
+  };
+
+  return videojs.mergeOptions(settings, options);
+}
+
+export const LoaderCommonFactory = (LoaderConstructor, loaderOptions, mimeTypeOrTrack, customHooks) => () => {
+  let loader;
+
+  QUnit.module('Loader Common', function(hooks) {
+    hooks.beforeEach(function(assert) {
+      // Assume this module is nested and the parent module uses CommonHooks.beforeEach
+
+      loader = new LoaderConstructor(CommonLoaderSettings.call(this, loaderOptions));
+
+      // shim updateend trigger to be a noop if the loader has no media source
+      this.updateend = function() {
+        if (loader.mediaSource_) {
+          loader.mediaSource_.sourceBuffers[0].trigger('updateend');
+        }
+      };
+
+      // shim a mimeTypeOrTrack method that calls the respective method for the given loader
+      // SegmentLoaders require a mimeType but not a track where VTTSegmentLoaders require
+      // a track but not a mimeType. This will let us test either type of loader without
+      // caring about the difference.
+      mimeTypeOrTrack = mimeTypeOrTrack;
+      mimeTypeOrTrack.value = mimeTypeOrTrack.init();
+    });
+
+    QUnit.test('fails without required initialization options', function(assert) {
+      /* eslint-disable no-new */
+      assert.throws(function() {
+        new LoaderConstructor();
+      }, 'requires options');
+      assert.throws(function() {
+        new LoaderConstructor({});
+      }, 'requires a currentTime callback');
+      assert.throws(function() {
+        new LoaderConstructor({
+          currentTime() {}
+        });
+      }, 'requires a media source');
+      /* eslint-enable */
+    });
+
+    QUnit.test(`load waits until a playlist and ${mimeTypeOrTrack.method} are specified to proceed`, function(assert) {
+      loader.load();
+
+      assert.equal(loader.state, 'INIT', 'waiting in init');
+      assert.equal(loader.paused(), false, 'not paused');
+
+      loader.playlist(playlistWithDuration(10));
+      assert.equal(this.requests.length, 0, 'have not made a request yet');
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      this.clock.tick(1);
+
+      assert.equal(this.requests.length, 1, 'made a request');
+      assert.equal(loader.state, 'WAITING', 'transitioned states');
+    });
+
+    QUnit.test(`calling ${mimeTypeOrTrack.method} and load begins buffering`, function(assert) {
+      assert.equal(loader.state, 'INIT', 'starts in the init state');
+      loader.playlist(playlistWithDuration(10));
+      assert.equal(loader.state, 'INIT', 'starts in the init state');
+      assert.ok(loader.paused(), 'starts paused');
+
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      assert.equal(loader.state, 'INIT', 'still in the init state');
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'moves to the ready state');
+      assert.ok(!loader.paused(), 'loading is not paused');
+      assert.equal(this.requests.length, 1, 'requested a segment');
+    });
+
+    QUnit.test('calling load is idempotent', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'moves to the ready state');
+      assert.equal(this.requests.length, 1, 'made one request');
+
+      loader.load();
+      assert.equal(loader.state, 'WAITING', 'still in the ready state');
+      assert.equal(this.requests.length, 1, 'still one request');
+
+      // some time passes and a response is received
+      this.clock.tick(100);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      loader.load();
+      assert.equal(this.requests.length, 0, 'load has no effect');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('calling load should unpause', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader.pause();
+
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+      loader.load();
+      this.clock.tick(1);
+      assert.equal(loader.paused(), false, 'loading unpauses');
+
+      loader.pause();
+      this.clock.tick(1);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(loader.paused(), true, 'stayed paused');
+      loader.load();
+      assert.equal(loader.paused(), false, 'unpaused during processing');
+
+      loader.pause();
+
+      this.updateend();
+
+      assert.equal(loader.state, 'READY', 'finished processing');
+      assert.ok(loader.paused(), 'stayed paused');
+
+      loader.load();
+      assert.equal(loader.paused(), false, 'unpaused');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('regularly checks the buffer while unpaused', function(assert) {
+      loader.playlist(playlistWithDuration(90));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      // fill the buffer
+      this.clock.tick(1);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      loader.buffered = () => videojs.createTimeRanges([[
+        0, Config.GOAL_BUFFER_LENGTH
+      ]]);
+
+      this.updateend();
+
+      assert.equal(this.requests.length, 0, 'no outstanding requests');
+
+      // play some video to drain the buffer
+      this.currentTime = Config.GOAL_BUFFER_LENGTH;
+      this.clock.tick(10 * 1000);
+      assert.equal(this.requests.length, 1, 'requested another segment');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('does not check the buffer while paused', function(assert) {
+      loader.playlist(playlistWithDuration(90));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.pause();
+      this.clock.tick(1);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.updateend();
+
+      this.clock.tick(10 * 1000);
+      assert.equal(this.requests.length, 0, 'did not make a request');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('calculates bandwidth after downloading a segment', function(assert) {
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      // some time passes and a response is received
+      this.clock.tick(100);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(loader.bandwidth, (10 / 100) * 8 * 1000, 'calculated bandwidth');
+      assert.equal(loader.roundTrip, 100, 'saves request round trip time');
+
+      // TODO: Bandwidth Stat will be stale??
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
+    });
+
+    QUnit.test('segment request timeouts reset bandwidth', function(assert) {
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      // a lot of time passes so the request times out
+      this.requests[0].timedout = true;
+      this.clock.tick(100 * 1000);
+
+      assert.equal(loader.bandwidth, 1, 'reset bandwidth');
+      assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
+    });
+
+    QUnit.test('progress on segment requests are redispatched', function(assert) {
+      let progressEvents = 0;
+
+      loader.on('progress', function() {
+        progressEvents++;
+      });
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      this.requests[0].dispatchEvent({ type: 'progress', target: this.requests[0] });
+      assert.equal(progressEvents, 1, 'triggered progress');
+    });
+
+    QUnit.test('appending a segment when loader is in walk-forward mode triggers bandwidthupdate', function(assert) {
+      let progresses = 0;
+
+      loader.on('bandwidthupdate', function() {
+        progresses++;
+      });
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      // some time passes and a response is received
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.updateend();
+
+      assert.equal(progresses, 0, 'no bandwidthupdate fired');
+
+      this.clock.tick(2);
+      // if mediaIndex is set, then the SegmentLoader is in walk-forward mode
+      loader.mediaIndex = 1;
+
+      // some time passes and a response is received
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.updateend();
+
+      assert.equal(progresses, 1, 'fired bandwidthupdate');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
+      assert.equal(loader.mediaRequests, 2, '2 request');
+    });
+
+    QUnit.test('only requests one segment at a time', function(assert) {
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      // a bunch of time passes without recieving a response
+      this.clock.tick(20 * 1000);
+      assert.equal(this.requests.length, 1, 'only one request was made');
+    });
+
+    QUnit.test('only appends one segment at a time', function(assert) {
+      loader.playlist(playlistWithDuration(10));
+      loader.mimeType(this.mimeType);
+      loader.load();
+      this.clock.tick(1);
+
+      // some time passes and a segment is received
+      this.clock.tick(100);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      // a lot of time goes by without "updateend"
+      this.clock.tick(20 * 1000);
+
+      assert.equal(mediaSource.sourceBuffers[0].updates_.filter(
+        update => update.append).length, 1, 'only one append');
+      assert.equal(this.requests.length, 0, 'only made one request');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('downloads init segments if specified', function(assert) {
+      let playlist = playlistWithDuration(20);
+      let map = {
+        resolvedUri: 'mainInitSegment',
+        byterange: {
+          length: 20,
+          offset: 0
+        }
+      };
+
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered = () => buffered;
+
+      playlist.segments[0].map = map;
+      playlist.segments[1].map = map;
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(this.requests.length, 2, 'made requests');
+
+      // init segment response
+      this.clock.tick(1);
+      assert.equal(this.requests[0].url, 'mainInitSegment', 'requested the init segment');
+      this.requests[0].response = new Uint8Array(20).buffer;
+      this.requests.shift().respond(200, null, '');
+      // 0.ts response
+      this.clock.tick(1);
+      assert.equal(this.requests[0].url, '0.ts',
+                  'requested the segment');
+      this.requests[0].response = new Uint8Array(20).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      // append the init segment
+      buffered = videojs.createTimeRanges([]);
+      this.updateend();
+
+      // append the segment
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(this.requests.length, 1, 'made a request');
+      assert.equal(this.requests[0].url, '1.ts',
+                  'did not re-request the init segment');
+    });
+
+    QUnit.test('detects init segment changes and downloads it', function(assert) {
+      let playlist = playlistWithDuration(20);
+      let buffered = videojs.createTimeRanges();
+
+      playlist.segments[0].map = {
+        resolvedUri: 'init0',
+        byterange: {
+          length: 20,
+          offset: 0
+        }
+      };
+      playlist.segments[1].map = {
+        resolvedUri: 'init0',
+        byterange: {
+          length: 20,
+          offset: 20
+        }
+      };
+
+      loader.buffered = () => buffered;
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(this.requests.length, 2, 'made requests');
+
+      // init segment response
+      this.clock.tick(1);
+      assert.equal(this.requests[0].url, 'init0.mp4', 'requested the init segment');
+      assert.equal(this.requests[0].headers.Range, 'bytes=0-19',
+                  'requested the init segment byte range');
+      this.requests[0].response = new Uint8Array(20).buffer;
+      this.requests.shift().respond(200, null, '');
+      // 0.ts response
+      this.clock.tick(1);
+      assert.equal(this.requests[0].url, '0.ts',
+                  'requested the segment');
+      this.requests[0].response = new Uint8Array(20).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      // append the init segment
+      buffered = videojs.createTimeRanges([]);
+      this.updateend();
+      // append the segment
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(this.requests.length, 2, 'made requests');
+      assert.equal(this.requests[0].url, 'init0.mp4', 'requested the init segment');
+      assert.equal(this.requests[0].headers.Range, 'bytes=20-39',
+                  'requested the init segment byte range');
+      assert.equal(this.requests[1].url, '1.ts',
+                  'did not re-request the init segment');
+    });
+
+    QUnit.test('request error increments mediaRequestsErrored stat', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      this.requests.shift().respond(404, null, '');
+
+      // verify stats
+      assert.equal(loader.mediaRequests, 1, '1 request');
+      assert.equal(loader.mediaRequestsErrored, 1, '1 errored request');
+    });
+
+    QUnit.test('request timeout increments mediaRequestsTimedout stat', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+      this.requests[0].timedout = true;
+      this.clock.tick(100 * 1000);
+
+      // verify stats
+      assert.equal(loader.mediaRequests, 1, '1 request');
+      assert.equal(loader.mediaRequestsTimedout, 1, '1 timed-out request');
+    });
+
+    QUnit.test('request abort increments mediaRequestsAborted stat', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.abort();
+      this.clock.tick(1);
+
+      // verify stats
+      assert.equal(loader.mediaRequests, 1, '1 request');
+      assert.equal(loader.mediaRequestsAborted, 1, '1 aborted request');
+    });
+
+    QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 0,
+        endList: false
+      }));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      // Start at mediaIndex 2 which means that the next segment we request
+      // should mediaIndex 3
+      loader.mediaIndex = 2;
+      this.clock.tick(1);
+
+      assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex starts at 2');
+      assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.clock.tick(1);
+      this.updateend();
+
+      assert.equal(loader.mediaIndex, 3, 'mediaIndex ends at 3');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex starts at 3');
+      assert.equal(this.requests[0].url, '4.ts', 'requesting the segment at mediaIndex 4');
+
+      // Update the playlist shifting the mediaSequence by 2 which will result
+      // in a decrement of the mediaIndex by 2 to 1
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex is updated to 1');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.clock.tick(1);
+      this.updateend();
+
+      assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex ends at 2');
+    });
+
+    QUnit.test('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
+      // Setting currentTime to 31 so that we start requesting at segment #3
+      this.currentTime = 31;
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 0,
+        endList: false
+      }));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      // Start at mediaIndex null which means that the next segment we request
+      // should be based on currentTime (mediaIndex 3)
+      loader.mediaIndex = null;
+      loader.syncPoint_ = {
+        segmentIndex: 0,
+        time: 0
+      };
+      this.clock.tick(1);
+
+      let segmentInfo = loader.pendingSegment_;
+
+      assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
+      assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.clock.tick(1);
+      this.updateend();
+
+      assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex ends at 3');
+
+      loader.mediaIndex = null;
+      loader.fetchAtBuffer_ = false;
+      this.clock.tick(1);
+      segmentInfo = loader.pendingSegment_;
+
+      assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
+      assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
+
+      // Update the playlist shifting the mediaSequence by 2 which will result
+      // in a decrement of the mediaIndex by 2 to 1
+      loader.playlist(playlistWithDuration(50, {
+        mediaSequence: 2,
+        endList: false
+      }));
+
+      assert.equal(segmentInfo.mediaIndex, 1, 'segmentInfo.mediaIndex is updated to 1');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.clock.tick(1);
+      this.updateend();
+
+      assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex ends at 1');
+    });
+
+    QUnit.test('segment 404s should trigger an error', function(assert) {
+      let errors = [];
+
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.on('error', function(error) {
+        errors.push(error);
+      });
+      this.requests.shift().respond(404, null, '');
+
+      assert.equal(errors.length, 1, 'triggered an error');
+      assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
+      assert.ok(loader.error().xhr, 'included the request object');
+      assert.ok(loader.paused(), 'paused the loader');
+      assert.equal(loader.state, 'READY', 'returned to the ready state');
+    });
+
+    QUnit.test('segment 5xx status codes trigger an error', function(assert) {
+      let errors = [];
+
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.on('error', function(error) {
+        errors.push(error);
+      });
+      this.requests.shift().respond(500, null, '');
+
+      assert.equal(errors.length, 1, 'triggered an error');
+      assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
+      assert.ok(loader.error().xhr, 'included the request object');
+      assert.ok(loader.paused(), 'paused the loader');
+      assert.equal(loader.state, 'READY', 'returned to the ready state');
+    });
+
+    QUnit.test('remains ready if there are no segments', function(assert) {
+      loader.playlist(playlistWithDuration(0));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'READY', 'in the ready state');
+    });
+
+    QUnit.test('dispose cleans up outstanding work', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.dispose();
+      assert.ok(this.requests[0].aborted, 'aborted segment request');
+      assert.equal(this.requests.length, 1, 'did not open another request');
+
+      // Check that media source was properly cleaned up if it exists on the loader
+      if (loader.mediaSource_) {
+        loader.mediaSource_.sourceBuffers.forEach((sourceBuffer, i) => {
+          let lastOperation = sourceBuffer.updates_.slice(-1)[0];
+
+          assert.ok(lastOperation.abort, 'aborted source buffer ' + i);
+        });
+      }
+    });
+
+    // ----------
+    // Decryption
+    // ----------
+
+    QUnit.test('calling load with an encrypted segment requests key and segment', function(assert) {
+      assert.equal(loader.state, 'INIT', 'starts in the init state');
+      loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
+      assert.equal(loader.state, 'INIT', 'starts in the init state');
+      assert.ok(loader.paused(), 'starts paused');
+
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'moves to the ready state');
+      assert.ok(!loader.paused(), 'loading is not paused');
+      assert.equal(this.requests.length, 2, 'requested a segment and key');
+      assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
+      assert.equal(this.requests[1].url, '0.ts', 'requested the first segment');
+    });
+
+    QUnit.test('dispose cleans up key requests for encrypted segments', function(assert) {
+      loader.playlist(playlistWithDuration(20, {isEncrypted: true}));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.dispose();
+      assert.equal(this.requests.length, 2, 'requested a segment and key');
+      assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
+      assert.ok(this.requests[0].aborted, 'aborted the first segment\s key request');
+      assert.equal(this.requests.length, 2, 'did not open another request');
+    });
+
+    QUnit.test('key 404s should trigger an error', function(assert) {
+      let errors = [];
+
+      loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.on('error', function(error) {
+        errors.push(error);
+      });
+      this.requests.shift().respond(404, null, '');
+      this.clock.tick(1);
+
+      assert.equal(errors.length, 1, 'triggered an error');
+      assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
+      assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
+            'receieved a key error message');
+      assert.ok(loader.error().xhr, 'included the request object');
+      assert.ok(loader.paused(), 'paused the loader');
+      assert.equal(loader.state, 'READY', 'returned to the ready state');
+    });
+
+    QUnit.test('key 5xx status codes trigger an error', function(assert) {
+      let errors = [];
+
+      loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.on('error', function(error) {
+        errors.push(error);
+      });
+      this.requests.shift().respond(500, null, '');
+
+      assert.equal(errors.length, 1, 'triggered an error');
+      assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
+      assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
+            'receieved a key error message');
+      assert.ok(loader.error().xhr, 'included the request object');
+      assert.ok(loader.paused(), 'paused the loader');
+      assert.equal(loader.state, 'READY', 'returned to the ready state');
+    });
+
+    QUnit.test('key request timeouts reset bandwidth', function(assert) {
+      loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
+      assert.equal(this.requests[1].url, '0.ts', 'requested the first segment');
+      // a lot of time passes so the request times out
+      this.requests[0].timedout = true;
+      this.clock.tick(100 * 1000);
+
+      assert.equal(loader.bandwidth, 1, 'reset bandwidth');
+      assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
+    });
+
+    QUnit.test('checks the goal buffer configuration every loading opportunity', function(assert) {
+      let playlist = playlistWithDuration(20);
+      let defaultGoal = Config.GOAL_BUFFER_LENGTH;
+      let segmentInfo;
+
+      Config.GOAL_BUFFER_LENGTH = 1;
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
+                                        playlist,
+                                        null,
+                                        loader.hasPlayed_(),
+                                        0,
+                                        null);
+      assert.ok(!segmentInfo, 'no request generated');
+      Config.GOAL_BUFFER_LENGTH = defaultGoal;
+    });
+
+    QUnit.test('does not skip over segment if live playlist update occurs while processing',
+    function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered = () => buffered;
+
+      playlist.endList = false;
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.pendingSegment_.uri, '0.ts', 'retrieving first segment');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
+      assert.equal(loader.state, 'WAITING', 'waiting for response');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      // playlist updated during append
+      let playlistUpdated = playlistWithDuration(40);
+
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence++;
+      loader.playlist(playlistUpdated);
+      // finish append
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'retrieving second segment');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+      assert.equal(loader.state, 'WAITING', 'waiting for response');
+    });
+
+    QUnit.test('processing segment reachable even after playlist update removes it',
+    function(assert) {
+      const handleUpdateEnd_ = loader.handleUpdateEnd_.bind(loader);
+      let expectedURI = '0.ts';
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
+
+      loader.handleUpdateEnd_ = () => {
+        // we need to check for the right state, as normally handleResponse would throw an
+        // error under failing cases, but sinon swallows it as part of fake XML HTTP request's
+        // response
+        assert.equal(loader.state, 'APPENDING', 'moved to appending state');
+        assert.equal(loader.pendingSegment_.uri, expectedURI, 'correct pending segment');
+        assert.equal(loader.pendingSegment_.segment.uri, expectedURI, 'correct segment reference');
+
+        handleUpdateEnd_();
+      };
+
+      loader.buffered = () => buffered;
+
+      playlist.endList = false;
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
+
+      // wrap up the first request to set mediaIndex and start normal live streaming
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      expectedURI = '1.ts';
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      // playlist updated during waiting
+      let playlistUpdated = playlistWithDuration(40);
+
+      playlistUpdated.segments.shift();
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence += 2;
+      loader.playlist(playlistUpdated);
+
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.updateend();
+    });
+
+    QUnit.test('new playlist always triggers syncinfoupdate', function(assert) {
+      let playlist = playlistWithDuration(100, { endList: false });
+      let syncInfoUpdates = 0;
+
+      loader.on('syncinfoupdate', () => syncInfoUpdates++);
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      assert.equal(syncInfoUpdates, 1, 'first playlist triggers an update');
+      loader.playlist(playlist);
+      assert.equal(syncInfoUpdates, 2, 'same playlist triggers an update');
+      playlist = playlistWithDuration(100, { endList: false });
+      loader.playlist(playlist);
+      assert.equal(syncInfoUpdates, 3, 'new playlist with same info triggers an update');
+      playlist.segments[0].start = 10;
+      playlist = playlistWithDuration(100, { endList: false, mediaSequence: 1 });
+      loader.playlist(playlist);
+      assert.equal(syncInfoUpdates,
+                   5,
+                   'new playlist after expiring segment triggers two updates');
+    });
+
+    QUnit.module('Loading Calculation', function(hooks) {
+      QUnit.test('requests the first segment with an empty buffer', function(assert) {
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+        let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges(),
+                                              playlistWithDuration(20),
+                                              null,
+                                              loader.hasPlayed_(),
+                                              0,
+                                              null);
+
+        assert.ok(segmentInfo, 'generated a request');
+        assert.equal(segmentInfo.uri, '0.ts', 'requested the first segment');
+      });
+
+      QUnit.test('no request if video not played and 1 segment is buffered', function(assert) {
+        this.hasPlayed = false;
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+        let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
+                                              playlistWithDuration(20),
+                                              0,
+                                              loader.hasPlayed_(),
+                                              0,
+                                              null);
+
+        assert.ok(!segmentInfo, 'no request generated');
+
+      });
+
+      QUnit.test('does not download the next segment if the buffer is full', function(assert) {
+        let buffered;
+        let segmentInfo;
+
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+        buffered = videojs.createTimeRanges([
+          [0, 15 + Config.GOAL_BUFFER_LENGTH]
+        ]);
+        segmentInfo = loader.checkBuffer_(buffered,
+                                          playlistWithDuration(30),
+                                          null,
+                                          true,
+                                          15,
+                                          { segmentIndex: 0, time: 0 });
+
+        assert.ok(!segmentInfo, 'no segment request generated');
+      });
+
+      QUnit.test('downloads the next segment if the buffer is getting low', function(assert) {
+        let buffered;
+        let segmentInfo;
+        let playlist = playlistWithDuration(30);
+
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+        loader.playlist(playlist);
+
+        buffered = videojs.createTimeRanges([[0, 19.999]]);
+        segmentInfo = loader.checkBuffer_(buffered,
+                                          playlist,
+                                          1,
+                                          true,
+                                          15,
+                                          { segmentIndex: 0, time: 0 });
+
+        assert.ok(segmentInfo, 'made a request');
+        assert.equal(segmentInfo.uri, '2.ts', 'requested the third segment');
+      });
+
+      QUnit.test('stops downloading segments at the end of the playlist', function(assert) {
+        let buffered;
+        let segmentInfo;
+
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+        buffered = videojs.createTimeRanges([[0, 60]]);
+        segmentInfo = loader.checkBuffer_(buffered,
+                                          playlistWithDuration(60),
+                                          null,
+                                          true,
+                                          0,
+                                          null);
+
+        assert.ok(!segmentInfo, 'no request was made');
+      });
+
+      QUnit.test('stops downloading segments if buffered past reported end of the playlist',
+      function(assert) {
+        let buffered;
+        let segmentInfo;
+        let playlist;
+
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+
+        buffered = videojs.createTimeRanges([[0, 59.9]]);
+        playlist = playlistWithDuration(60);
+        playlist.segments[playlist.segments.length - 1].end = 59.9;
+        segmentInfo = loader.checkBuffer_(buffered,
+                                          playlist,
+                                          playlist.segments.length - 1,
+                                          true,
+                                          50,
+                                          { segmentIndex: 0, time: 0 });
+
+        assert.ok(!segmentInfo, 'no request was made');
+      });
+
+      QUnit.test('doesn\'t allow more than one monitor buffer timer to be set', function(assert) {
+        let timeoutCount = this.clock.methods.length;
+
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+        loader.monitorBuffer_();
+
+        assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
+
+        loader.monitorBuffer_();
+
+        assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
+
+        loader.monitorBuffer_();
+        loader.monitorBuffer_();
+
+        assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
+      });
+    })
+  });
+};

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -78,7 +78,7 @@ QUnit.module('Segment Loader', {
   }
 });
 
-QUnit.test('fails without required initialization options', function(assert) {
+QUnit.skip('fails without required initialization options', function(assert) {
   /* eslint-disable no-new */
   assert.throws(function() {
     new SegmentLoader();
@@ -94,7 +94,7 @@ QUnit.test('fails without required initialization options', function(assert) {
   /* eslint-enable */
 });
 
-QUnit.test('load waits until a playlist and mime type are specified to proceed',
+QUnit.skip('load waits until a playlist and mime type are specified to proceed',
 function(assert) {
   loader.load();
 
@@ -110,7 +110,7 @@ function(assert) {
   assert.equal(loader.state, 'WAITING', 'transitioned states');
 });
 
-QUnit.test('calling mime type and load begins buffering', function(assert) {
+QUnit.skip('calling mime type and load begins buffering', function(assert) {
   assert.equal(loader.state, 'INIT', 'starts in the init state');
   loader.playlist(playlistWithDuration(10));
   assert.equal(loader.state, 'INIT', 'starts in the init state');
@@ -126,7 +126,7 @@ QUnit.test('calling mime type and load begins buffering', function(assert) {
   assert.equal(this.requests.length, 1, 'requested a segment');
 });
 
-QUnit.test('calling load is idempotent', function(assert) {
+QUnit.skip('calling load is idempotent', function(assert) {
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -152,7 +152,7 @@ QUnit.test('calling load is idempotent', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('calling load should unpause', function(assert) {
+QUnit.skip('calling load should unpause', function(assert) {
   let sourceBuffer;
 
   loader.playlist(playlistWithDuration(20));
@@ -188,7 +188,7 @@ QUnit.test('calling load should unpause', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('regularly checks the buffer while unpaused', function(assert) {
+QUnit.skip('regularly checks the buffer while unpaused', function(assert) {
   let sourceBuffer;
 
   loader.playlist(playlistWithDuration(90));
@@ -219,7 +219,7 @@ QUnit.test('regularly checks the buffer while unpaused', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('does not check the buffer while paused', function(assert) {
+QUnit.skip('does not check the buffer while paused', function(assert) {
   let sourceBuffer;
 
   loader.playlist(playlistWithDuration(90));
@@ -243,7 +243,7 @@ QUnit.test('does not check the buffer while paused', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('calculates bandwidth after downloading a segment', function(assert) {
+QUnit.skip('calculates bandwidth after downloading a segment', function(assert) {
   loader.playlist(playlistWithDuration(10));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -263,7 +263,7 @@ QUnit.test('calculates bandwidth after downloading a segment', function(assert) 
   assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
 });
 
-QUnit.test('segment request timeouts reset bandwidth', function(assert) {
+QUnit.skip('segment request timeouts reset bandwidth', function(assert) {
   loader.playlist(playlistWithDuration(10));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -277,7 +277,7 @@ QUnit.test('segment request timeouts reset bandwidth', function(assert) {
   assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
 });
 
-QUnit.test('progress on segment requests are redispatched', function(assert) {
+QUnit.skip('progress on segment requests are redispatched', function(assert) {
   let progressEvents = 0;
 
   loader.on('progress', function() {
@@ -318,7 +318,7 @@ QUnit.test('updates timestamps when segments do not start at zero', function(ass
   assert.equal(loader.sourceUpdater_.timestampOffset(), -11, 'set timestampOffset');
 });
 
-QUnit.test('appending a segment when loader is in walk-forward mode triggers bandwidthupdate', function(assert) {
+QUnit.skip('appending a segment when loader is in walk-forward mode triggers bandwidthupdate', function(assert) {
   let progresses = 0;
 
   loader.on('bandwidthupdate', function() {
@@ -363,7 +363,7 @@ QUnit.test('only requests one segment at a time', function(assert) {
   assert.equal(this.requests.length, 1, 'only one request was made');
 });
 
-QUnit.test('only appends one segment at a time', function(assert) {
+QUnit.skip('only appends one segment at a time', function(assert) {
   loader.playlist(playlistWithDuration(10));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -387,7 +387,7 @@ QUnit.test('only appends one segment at a time', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('downloads init segments if specified', function(assert) {
+QUnit.skip('downloads init segments if specified', function(assert) {
   let playlist = playlistWithDuration(20);
   let map = {
     resolvedUri: 'main.mp4',
@@ -433,7 +433,7 @@ QUnit.test('downloads init segments if specified', function(assert) {
               'did not re-request the init segment');
 });
 
-QUnit.test('detects init segment changes and downloads it', function(assert) {
+QUnit.skip('detects init segment changes and downloads it', function(assert) {
   let playlist = playlistWithDuration(20);
 
   playlist.segments[0].map = {
@@ -542,7 +542,7 @@ QUnit.test('abort does not cancel segment processing in progress', function(asse
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('request error increments mediaRequestsErrored stat', function(assert) {
+QUnit.skip('request error increments mediaRequestsErrored stat', function(assert) {
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -555,7 +555,7 @@ QUnit.test('request error increments mediaRequestsErrored stat', function(assert
   assert.equal(loader.mediaRequestsErrored, 1, '1 errored request');
 });
 
-QUnit.test('request timeout increments mediaRequestsTimedout stat', function(assert) {
+QUnit.skip('request timeout increments mediaRequestsTimedout stat', function(assert) {
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -568,7 +568,7 @@ QUnit.test('request timeout increments mediaRequestsTimedout stat', function(ass
   assert.equal(loader.mediaRequestsTimedout, 1, '1 timed-out request');
 });
 
-QUnit.test('request abort increments mediaRequestsAborted stat', function(assert) {
+QUnit.skip('request abort increments mediaRequestsAborted stat', function(assert) {
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -582,7 +582,7 @@ QUnit.test('request abort increments mediaRequestsAborted stat', function(assert
   assert.equal(loader.mediaRequestsAborted, 1, '1 aborted request');
 });
 
-QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
+QUnit.skip('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
   loader.playlist(playlistWithDuration(50, {
     mediaSequence: 0,
     endList: false
@@ -626,7 +626,7 @@ QUnit.test('SegmentLoader.mediaIndex is adjusted when live playlist is updated',
   assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex ends at 2');
 });
 
-QUnit.test('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
+QUnit.skip('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
   // Setting currentTime to 31 so that we start requesting at segment #3
   this.currentTime = 31;
   loader.playlist(playlistWithDuration(50, {
@@ -827,7 +827,7 @@ QUnit.test('adds cues with segment information to the segment-metadata track as 
     assert.equal(loader.mediaRequests, 4, '4 requests');
   });
 
-QUnit.test('segment 404s should trigger an error', function(assert) {
+QUnit.skip('segment 404s should trigger an error', function(assert) {
   let errors = [];
 
   loader.playlist(playlistWithDuration(10));
@@ -847,7 +847,7 @@ QUnit.test('segment 404s should trigger an error', function(assert) {
   assert.equal(loader.state, 'READY', 'returned to the ready state');
 });
 
-QUnit.test('segment 5xx status codes trigger an error', function(assert) {
+QUnit.skip('segment 5xx status codes trigger an error', function(assert) {
   let errors = [];
 
   loader.playlist(playlistWithDuration(10));
@@ -929,7 +929,7 @@ QUnit.test('live playlists do not trigger ended', function(assert) {
   assert.equal(loader.mediaRequests, 1, '1 request');
 });
 
-QUnit.test('remains ready if there are no segments', function(assert) {
+QUnit.skip('remains ready if there are no segments', function(assert) {
   loader.playlist(playlistWithDuration(0));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -938,7 +938,7 @@ QUnit.test('remains ready if there are no segments', function(assert) {
   assert.equal(loader.state, 'READY', 'in the ready state');
 });
 
-QUnit.test('dispose cleans up outstanding work', function(assert) {
+QUnit.skip('dispose cleans up outstanding work', function(assert) {
   loader.playlist(playlistWithDuration(20));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -958,7 +958,7 @@ QUnit.test('dispose cleans up outstanding work', function(assert) {
 // Decryption
 // ----------
 
-QUnit.test('calling load with an encrypted segment requests key and segment', function(assert) {
+QUnit.skip('calling load with an encrypted segment requests key and segment', function(assert) {
   assert.equal(loader.state, 'INIT', 'starts in the init state');
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
   assert.equal(loader.state, 'INIT', 'starts in the init state');
@@ -975,7 +975,7 @@ QUnit.test('calling load with an encrypted segment requests key and segment', fu
   assert.equal(this.requests[1].url, '0.ts', 'requested the first segment');
 });
 
-QUnit.test('dispose cleans up key requests for encrypted segments', function(assert) {
+QUnit.skip('dispose cleans up key requests for encrypted segments', function(assert) {
   loader.playlist(playlistWithDuration(20, {isEncrypted: true}));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -988,7 +988,7 @@ QUnit.test('dispose cleans up key requests for encrypted segments', function(ass
   assert.equal(this.requests.length, 2, 'did not open another request');
 });
 
-QUnit.test('key 404s should trigger an error', function(assert) {
+QUnit.skip('key 404s should trigger an error', function(assert) {
   let errors = [];
 
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
@@ -1011,7 +1011,7 @@ QUnit.test('key 404s should trigger an error', function(assert) {
   assert.equal(loader.state, 'READY', 'returned to the ready state');
 });
 
-QUnit.test('key 5xx status codes trigger an error', function(assert) {
+QUnit.skip('key 5xx status codes trigger an error', function(assert) {
   let errors = [];
 
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
@@ -1033,7 +1033,7 @@ QUnit.test('key 5xx status codes trigger an error', function(assert) {
   assert.equal(loader.state, 'READY', 'returned to the ready state');
 });
 
-QUnit.test('key request timeouts reset bandwidth', function(assert) {
+QUnit.skip('key request timeouts reset bandwidth', function(assert) {
   loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
   loader.mimeType(this.mimeType);
   loader.load();
@@ -1049,7 +1049,7 @@ QUnit.test('key request timeouts reset bandwidth', function(assert) {
   assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
 });
 
-QUnit.test('checks the goal buffer configuration every loading opportunity', function(assert) {
+QUnit.skip('checks the goal buffer configuration every loading opportunity', function(assert) {
   let playlist = playlistWithDuration(20);
   let defaultGoal = Config.GOAL_BUFFER_LENGTH;
   let segmentInfo;
@@ -1069,7 +1069,7 @@ QUnit.test('checks the goal buffer configuration every loading opportunity', fun
   Config.GOAL_BUFFER_LENGTH = defaultGoal;
 });
 
-QUnit.test('does not skip over segment if live playlist update occurs while processing',
+QUnit.skip('does not skip over segment if live playlist update occurs while processing',
 function(assert) {
   let playlist = playlistWithDuration(40);
 
@@ -1102,7 +1102,7 @@ function(assert) {
   assert.equal(loader.state, 'WAITING', 'waiting for response');
 });
 
-QUnit.test('processing segment reachable even after playlist update removes it',
+QUnit.skip('processing segment reachable even after playlist update removes it',
 function(assert) {
   let playlist = playlistWithDuration(40);
 
@@ -1265,7 +1265,7 @@ function(assert) {
             'no end info for first segment of new playlist');
 });
 
-QUnit.test('new playlist always triggers syncinfoupdate', function(assert) {
+QUnit.skip('new playlist always triggers syncinfoupdate', function(assert) {
   let playlist = playlistWithDuration(100, { endList: false });
   let syncInfoUpdates = 0;
 
@@ -1287,152 +1287,4 @@ QUnit.test('new playlist always triggers syncinfoupdate', function(assert) {
   assert.equal(syncInfoUpdates,
                5,
                'new playlist after expiring segment triggers two updates');
-});
-
-QUnit.module('Segment Loading Calculation', {
-  beforeEach(assert) {
-    this.env = useFakeEnvironment(assert);
-    this.mse = useFakeMediaSource();
-    this.hasPlayed = true;
-    this.clock = this.env.clock;
-
-    this.currentTime = 0;
-    syncController = new SyncController();
-    loader = new SegmentLoader({
-      currentTime() {
-        return currentTime;
-      },
-      mediaSource: new videojs.MediaSource(),
-      hasPlayed: () => this.hasPlayed,
-      syncController
-    });
-  },
-  afterEach() {
-    this.env.restore();
-    this.mse.restore();
-  }
-});
-
-QUnit.test('requests the first segment with an empty buffer', function(assert) {
-  loader.mimeType(this.mimeType);
-
-  let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges(),
-                                        playlistWithDuration(20),
-                                        null,
-                                        loader.hasPlayed_(),
-                                        0,
-                                        null);
-
-  assert.ok(segmentInfo, 'generated a request');
-  assert.equal(segmentInfo.uri, '0.ts', 'requested the first segment');
-});
-
-QUnit.test('no request if video not played and 1 segment is buffered', function(assert) {
-  this.hasPlayed = false;
-  loader.mimeType(this.mimeType);
-
-  let segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
-                                        playlistWithDuration(20),
-                                        0,
-                                        loader.hasPlayed_(),
-                                        0,
-                                        null);
-
-  assert.ok(!segmentInfo, 'no request generated');
-
-});
-
-QUnit.test('does not download the next segment if the buffer is full', function(assert) {
-  let buffered;
-  let segmentInfo;
-
-  loader.mimeType(this.mimeType);
-
-  buffered = videojs.createTimeRanges([
-    [0, 15 + Config.GOAL_BUFFER_LENGTH]
-  ]);
-  segmentInfo = loader.checkBuffer_(buffered,
-                                    playlistWithDuration(30),
-                                    null,
-                                    true,
-                                    15,
-                                    { segmentIndex: 0, time: 0 });
-
-  assert.ok(!segmentInfo, 'no segment request generated');
-});
-
-QUnit.test('downloads the next segment if the buffer is getting low', function(assert) {
-  let buffered;
-  let segmentInfo;
-  let playlist = playlistWithDuration(30);
-
-  loader.mimeType(this.mimeType);
-  loader.playlist(playlist);
-
-  buffered = videojs.createTimeRanges([[0, 19.999]]);
-  segmentInfo = loader.checkBuffer_(buffered,
-                                    playlist,
-                                    1,
-                                    true,
-                                    15,
-                                    { segmentIndex: 0, time: 0 });
-
-  assert.ok(segmentInfo, 'made a request');
-  assert.equal(segmentInfo.uri, '2.ts', 'requested the third segment');
-});
-
-QUnit.test('stops downloading segments at the end of the playlist', function(assert) {
-  let buffered;
-  let segmentInfo;
-
-  loader.mimeType(this.mimeType);
-
-  buffered = videojs.createTimeRanges([[0, 60]]);
-  segmentInfo = loader.checkBuffer_(buffered,
-                                    playlistWithDuration(60),
-                                    null,
-                                    true,
-                                    0,
-                                    null);
-
-  assert.ok(!segmentInfo, 'no request was made');
-});
-
-QUnit.test('stops downloading segments if buffered past reported end of the playlist',
-function(assert) {
-  let buffered;
-  let segmentInfo;
-  let playlist;
-
-  loader.mimeType(this.mimeType);
-
-  buffered = videojs.createTimeRanges([[0, 59.9]]);
-  playlist = playlistWithDuration(60);
-  playlist.segments[playlist.segments.length - 1].end = 59.9;
-  segmentInfo = loader.checkBuffer_(buffered,
-                                    playlist,
-                                    playlist.segments.length - 1,
-                                    true,
-                                    50,
-                                    { segmentIndex: 0, time: 0 });
-
-  assert.ok(!segmentInfo, 'no request was made');
-});
-
-QUnit.test('doesn\'t allow more than one monitor buffer timer to be set', function(assert) {
-  let timeoutCount = this.clock.methods.length;
-
-  loader.mimeType(this.mimeType);
-  loader.monitorBuffer_();
-
-  assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
-
-  loader.monitorBuffer_();
-
-  assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
-
-  loader.monitorBuffer_();
-  loader.monitorBuffer_();
-
-  assert.equal(this.clock.methods.length, timeoutCount, 'timeout count remains the same');
 });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -1,19 +1,22 @@
 import QUnit from 'qunit';
 import SegmentLoader from '../src/segment-loader';
 import videojs from 'video.js';
-import xhrFactory from '../src/xhr';
 import mp4probe from 'mux.js/lib/mp4/probe';
-import Config from '../src/config';
 import {
   playlistWithDuration,
-  useFakeEnvironment,
-  useFakeMediaSource,
   MockTextTrack
 } from './test-helpers.js';
+import {
+  LoaderCommonHooks,
+  LoaderCommonSettings,
+  LoaderCommonFactory
+} from './loader-common.js';
 import sinon from 'sinon';
-import SyncController from '../src/sync-controller';
-import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+
+const mimeTypeOrTrack = {
+  method: 'mimeType',
+  init: () => 'video/mp2t'
+};
 
 // noop addSegmentMetadataCue_ since most test segments dont have real timing information
 // save the original function to a variable to patch it back in for the metadata cue
@@ -22,1269 +25,476 @@ const ogAddSegmentMetadataCue_ = SegmentLoader.prototype.addSegmentMetadataCue_;
 
 SegmentLoader.prototype.addSegmentMetadataCue_ = function() {};
 
-let currentTime;
-let mediaSource;
-let loader;
-let syncController;
-let decrypter;
-let segmentMetadataTrack;
+QUnit.module('SegmentLoader', function(hooks) {
+  hooks.beforeEach(LoaderCommonHooks.beforeEach);
+  hooks.afterEach(LoaderCommonHooks.afterEach);
 
-QUnit.module('Segment Loader', {
-  beforeEach(assert) {
-    this.env = useFakeEnvironment(assert);
-    this.clock = this.env.clock;
-    this.requests = this.env.requests;
-    this.mse = useFakeMediaSource();
-    this.currentTime = 0;
-    this.seekable = {
-      length: 0
-    };
-    this.mimeType = 'video/mp2t';
-    this.fakeHls = {
-      xhr: xhrFactory()
-    };
+  LoaderCommonFactory(SegmentLoader, { loaderType: 'main' }, mimeTypeOrTrack);
 
-    this.timescale = sinon.stub(mp4probe, 'timescale');
-    this.startTime = sinon.stub(mp4probe, 'startTime');
+  // Tests specific to the main segment loader go in this module
+  QUnit.module('Loader Main', function(subHooks) {
+    let loader;
 
-    mediaSource = new videojs.MediaSource();
-    mediaSource.trigger('sourceopen');
-    this.syncController = new SyncController();
-    decrypter = worker(Decrypter);
-    segmentMetadataTrack = new MockTextTrack();
-    loader = new SegmentLoader({
-      hls: this.fakeHls,
-      currentTime: () => this.currentTime,
-      seekable: () => this.seekable,
-      seeking: () => false,
-      hasPlayed: () => true,
-      duration: () => mediaSource.duration,
-      mediaSource,
-      syncController: this.syncController,
-      decrypter,
-      loaderType: 'main',
-      segmentMetadataTrack
+    subHooks.beforeEach(function(assert) {
+      this.segmentMetadataTrack = new MockTextTrack();
+      this.startTime = sinon.stub(mp4probe, 'startTime');
+
+      loader = new SegmentLoader(LoaderCommonSettings.call(this, {
+        loaderType: 'main',
+        segmentMetadataTrack: this.segmentMetadataTrack
+      }));
+
+      // shim updateend trigger to be a noop if the loader has no media source
+      this.updateend = function() {
+        if (loader.mediaSource_) {
+          loader.mediaSource_.sourceBuffers[0].trigger('updateend');
+        }
+      };
+
+      mimeTypeOrTrack.value = mimeTypeOrTrack.init();
     });
-    decrypter.onmessage = (event) => {
-      loader.handleDecrypted_(event.data);
-    };
-  },
-  afterEach() {
-    this.env.restore();
-    this.mse.restore();
-    this.timescale.restore();
-    this.startTime.restore();
-    decrypter.terminate();
-  }
-});
 
-QUnit.skip('fails without required initialization options', function(assert) {
-  /* eslint-disable no-new */
-  assert.throws(function() {
-    new SegmentLoader();
-  }, 'requires options');
-  assert.throws(function() {
-    new SegmentLoader({});
-  }, 'requires a currentTime callback');
-  assert.throws(function() {
-    new SegmentLoader({
-      currentTime() {}
+    subHooks.afterEach(function(assert) {
+      delete mimeTypeOrTrack.value;
+      this.startTime.restore();
     });
-  }, 'requires a media source');
-  /* eslint-enable */
-});
 
-QUnit.skip('load waits until a playlist and mime type are specified to proceed',
-function(assert) {
-  loader.load();
+    QUnit.test('only appends one segment at a time', function(assert) {
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  assert.equal(loader.state, 'INIT', 'waiting in init');
-  assert.equal(loader.paused(), false, 'not paused');
+      // some time passes and a segment is received
+      this.clock.tick(100);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-  loader.playlist(playlistWithDuration(10));
-  assert.equal(this.requests.length, 0, 'have not made a request yet');
-  loader.mimeType(this.mimeType);
-  this.clock.tick(1);
+      // a lot of time goes by without "updateend"
+      this.clock.tick(20 * 1000);
 
-  assert.equal(this.requests.length, 1, 'made a request');
-  assert.equal(loader.state, 'WAITING', 'transitioned states');
-});
+      assert.equal(this.mediaSource.sourceBuffers[0].updates_.filter(
+        update => update.append).length, 1, 'only one append');
+      assert.equal(this.requests.length, 0, 'only made one request');
 
-QUnit.skip('calling mime type and load begins buffering', function(assert) {
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  loader.playlist(playlistWithDuration(10));
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  assert.ok(loader.paused(), 'starts paused');
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
 
-  loader.mimeType(this.mimeType);
-  assert.equal(loader.state, 'INIT', 'still in the init state');
-  loader.load();
-  this.clock.tick(1);
+    QUnit.test('updates timestamps when segments do not start at zero', function(assert) {
+      let playlist = playlistWithDuration(10);
 
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.ok(!loader.paused(), 'loading is not paused');
-  assert.equal(this.requests.length, 1, 'requested a segment');
-});
+      playlist.segments.forEach((segment) => {
+        segment.map = {
+          resolvedUri: 'init.mp4',
+          byterange: { length: Infinity, offset: 0 }
+        };
+      });
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
 
-QUnit.skip('calling load is idempotent', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
+      this.startTime.returns(11);
 
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.equal(this.requests.length, 1, 'made one request');
+      this.clock.tick(100);
+      // init
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      // segment
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-  loader.load();
-  assert.equal(loader.state, 'WAITING', 'still in the ready state');
-  assert.equal(this.requests.length, 1, 'still one request');
+      assert.equal(loader.sourceUpdater_.timestampOffset(), -11, 'set timestampOffset');
+    });
 
-  // some time passes and a response is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  loader.load();
-  assert.equal(this.requests.length, 0, 'load has no effect');
+    QUnit.test('triggers syncinfoupdate before attempting a resync', function(assert) {
+      let syncInfoUpdates = 0;
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-QUnit.skip('calling load should unpause', function(assert) {
-  let sourceBuffer;
+      this.seekable = videojs.createTimeRanges([[0, 10]]);
+      this.syncController.probeSegmentInfo = (segmentInfo) => {
+        let segment = segmentInfo.segment;
 
-  loader.playlist(playlistWithDuration(20));
-  loader.pause();
+        segment.end = 10;
+      };
+      loader.on('syncinfoupdate', () => {
+        syncInfoUpdates++;
+        // Simulate the seekable window updating
+        this.seekable = videojs.createTimeRanges([[200, 210]]);
+        // Simulate the seek to live that should happen in playback-watcher
+        this.currentTime = 210;
+      });
 
-  loader.mimeType(this.mimeType);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      this.updateend();
+      this.clock.tick(1);
 
-  loader.load();
-  this.clock.tick(1);
-  assert.equal(loader.paused(), false, 'loading unpauses');
+      assert.equal(loader.mediaIndex, null, 'mediaIndex reset by seek to seekable');
+      assert.equal(syncInfoUpdates, 1, 'syncinfoupdate was triggered');
+    });
 
-  loader.pause();
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
+    QUnit.test('abort does not cancel segment processing in progress', function(assert) {
+      loader.playlist(playlistWithDuration(20));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  assert.equal(loader.paused(), true, 'stayed paused');
-  loader.load();
-  assert.equal(loader.paused(), false, 'unpaused during processing');
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-  loader.pause();
-  sourceBuffer = mediaSource.sourceBuffers[0];
-  sourceBuffer.trigger('updateend');
-  assert.equal(loader.state, 'READY', 'finished processing');
-  assert.ok(loader.paused(), 'stayed paused');
+      loader.abort();
+      this.clock.tick(1);
 
-  loader.load();
-  assert.equal(loader.paused(), false, 'unpaused');
+      assert.equal(loader.state, 'APPENDING', 'still appending');
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
 
-QUnit.skip('regularly checks the buffer while unpaused', function(assert) {
-  let sourceBuffer;
+    QUnit.test('sets the timestampOffset on timeline change', function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
 
-  loader.playlist(playlistWithDuration(90));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
+      loader.buffered_ = () => buffered;
 
-  sourceBuffer = mediaSource.sourceBuffers[0];
+      playlist.discontinuityStarts = [1];
+      playlist.segments[1].timeline = 1;
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  // fill the buffer
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  sourceBuffer.buffered = videojs.createTimeRanges([[
-    0, Config.GOAL_BUFFER_LENGTH
-  ]]);
-  sourceBuffer.trigger('updateend');
-  assert.equal(this.requests.length, 0, 'no outstanding requests');
+      // segment 0
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
 
-  // play some video to drain the buffer
-  this.currentTime = Config.GOAL_BUFFER_LENGTH;
-  this.clock.tick(10 * 1000);
-  assert.equal(this.requests.length, 1, 'requested another segment');
+      // segment 1, discontinuity
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      assert.equal(loader.mediaSource_.sourceBuffers[0].timestampOffset, 10, 'set timestampOffset');
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
+      assert.equal(loader.mediaRequests, 2, '2 requests');
+    });
 
-QUnit.skip('does not check the buffer while paused', function(assert) {
-  let sourceBuffer;
+    QUnit.test('tracks segment end times as they are buffered', function(assert) {
+      let playlist = playlistWithDuration(20);
 
-  loader.playlist(playlistWithDuration(90));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-  sourceBuffer = mediaSource.sourceBuffers[0];
+      loader.syncController_.probeTsSegment_ = function(segmentInfo) {
+        return { start: 0, end: 9.5 };
+      };
 
-  loader.pause();
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  sourceBuffer.trigger('updateend');
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  this.clock.tick(10 * 1000);
-  assert.equal(this.requests.length, 0, 'did not make a request');
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      this.updateend();
+      this.clock.tick(1);
 
-QUnit.skip('calculates bandwidth after downloading a segment', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
+      assert.equal(playlist.segments[0].end, 9.5, 'updated duration');
 
-  // some time passes and a response is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
 
-  assert.equal(loader.bandwidth, (10 / 100) * 8 * 1000, 'calculated bandwidth');
-  assert.equal(loader.roundTrip, 100, 'saves request round trip time');
+    QUnit.test('adds cues with segment information to the segment-metadata track as they are buffered',
+      function(assert) {
+        const track = loader.segmentMetadataTrack_;
+        let playlist = playlistWithDuration(40);
+        let probeResponse;
+        let expectedCue;
 
-  // TODO: Bandwidth Stat will be stale??
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-});
+        loader.addSegmentMetadataCue_ = ogAddSegmentMetadataCue_;
+        loader.syncController_.probeTsSegment_ = function(segmentInfo) {
+          return probeResponse;
+        };
 
-QUnit.skip('segment request timeouts reset bandwidth', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
+        loader.playlist(playlist);
+        loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+        loader.load();
+        this.clock.tick(1);
 
-  // a lot of time passes so the request times out
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
+        assert.ok(!track.cues.length, 'segment-metadata track empty when no segments appended');
 
-  assert.equal(loader.bandwidth, 1, 'reset bandwidth');
-  assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
-});
+        // Start appending some segments
+        probeResponse = { start: 0, end: 9.5 };
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+        this.updateend();
+        this.clock.tick(1);
+        expectedCue = {
+          uri: '0.ts',
+          timeline: 0,
+          playlist: 'playlist.m3u8',
+          start: 0,
+          end: 9.5
+        };
 
-QUnit.skip('progress on segment requests are redispatched', function(assert) {
-  let progressEvents = 0;
+        assert.equal(track.cues.length, 1, 'one cue added for segment');
+        assert.deepEqual(track.cues[0].value, expectedCue,
+          'added correct segment info to cue');
 
-  loader.on('progress', function() {
-    progressEvents++;
+        probeResponse = { start: 9.56, end: 19.2 };
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+        this.updateend();
+        this.clock.tick(1);
+        expectedCue = {
+          uri: '1.ts',
+          timeline: 0,
+          playlist: 'playlist.m3u8',
+          start: 9.56,
+          end: 19.2
+        };
+
+        assert.equal(track.cues.length, 2, 'one cue added for segment');
+        assert.deepEqual(track.cues[1].value, expectedCue,
+          'added correct segment info to cue');
+
+        probeResponse = { start: 19.24, end: 28.99 };
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+        this.updateend();
+        this.clock.tick(1);
+        expectedCue = {
+          uri: '2.ts',
+          timeline: 0,
+          playlist: 'playlist.m3u8',
+          start: 19.24,
+          end: 28.99
+        };
+
+        assert.equal(track.cues.length, 3, 'one cue added for segment');
+        assert.deepEqual(track.cues[2].value, expectedCue,
+          'added correct segment info to cue');
+
+        // append overlapping segment, emmulating segment-loader fetching behavior on
+        // rendtion switch
+        probeResponse = { start: 19.21, end: 28.98 };
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+        this.updateend();
+        expectedCue = {
+          uri: '3.ts',
+          timeline: 0,
+          playlist: 'playlist.m3u8',
+          start: 19.21,
+          end: 28.98
+        };
+
+        assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');
+        assert.deepEqual(track.cues[2].value, expectedCue,
+          'added correct segment info to cue');
+
+        // verify stats
+        assert.equal(loader.mediaBytesTransferred, 40, '40 bytes');
+        assert.equal(loader.mediaRequests, 4, '4 requests');
+      });
+
+    QUnit.test('fires ended at the end of a playlist', function(assert) {
+      let endOfStreams = 0;
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered_ = () => buffered;
+
+      loader.playlist(playlistWithDuration(10));
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.mediaSource_ = {
+        readyState: 'open',
+        sourceBuffers: this.mediaSource.sourceBuffers,
+        endOfStream() {
+          endOfStreams++;
+          this.readyState = 'ended';
+        }
+      };
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(endOfStreams, 1, 'triggered ended');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('live playlists do not trigger ended', function(assert) {
+      let endOfStreams = 0;
+      let playlist;
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered_ = () => buffered;
+
+      playlist = playlistWithDuration(10);
+      playlist.endList = false;
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      loader.mediaSource_ = {
+        readyState: 'open',
+        sourceBuffers: this.mediaSource.sourceBuffers,
+        endOfStream() {
+          endOfStreams++;
+        }
+      };
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(endOfStreams, 0, 'did not trigger ended');
+
+      // verify stats
+      assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
+      assert.equal(loader.mediaRequests, 1, '1 request');
+    });
+
+    QUnit.test('saves segment info to new segment after playlist refresh',
+    function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered_ = () => buffered;
+
+      playlist.endList = false;
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
+
+      // wrap up the first request to set mediaIndex and start normal live streaming
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      // playlist updated during waiting
+      let playlistUpdated = playlistWithDuration(40);
+
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence++;
+      loader.playlist(playlistUpdated);
+
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
+      // time info)
+      loader.syncController_.probeSegmentInfo = (segmentInfo) => {
+        segmentInfo.segment.start = 10;
+        segmentInfo.segment.end = 20;
+      };
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(playlistUpdated.segments[0].start,
+                   10,
+                   'set start on segment of new playlist');
+      assert.equal(playlistUpdated.segments[0].end,
+                   20,
+                   'set end on segment of new playlist');
+      assert.ok(!playlist.segments[1].start, 'did not set start on segment of old playlist');
+      assert.ok(!playlist.segments[1].end, 'did not set end on segment of old playlist');
+    });
+
+    QUnit.test('saves segment info to old segment after playlist refresh if segment fell off',
+    function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
+
+      loader.buffered_ = () => buffered;
+
+      playlist.endList = false;
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
+
+      // wrap up the first request to set mediaIndex and start normal live streaming
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      // playlist updated during waiting
+      let playlistUpdated = playlistWithDuration(40);
+
+      playlistUpdated.segments.shift();
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence += 2;
+      loader.playlist(playlistUpdated);
+
+      assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
+
+      // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
+      // time info)
+      loader.syncController_.probeSegmentInfo = (segmentInfo) => {
+        segmentInfo.segment.start = 10;
+        segmentInfo.segment.end = 20;
+      };
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(playlist.segments[1].start,
+                   10,
+                   'set start on segment of old playlist');
+      assert.equal(playlist.segments[1].end,
+                   20,
+                   'set end on segment of old playlist');
+      assert.ok(!playlistUpdated.segments[0].start,
+                'no start info for first segment of new playlist');
+      assert.ok(!playlistUpdated.segments[0].end,
+                'no end info for first segment of new playlist');
+    });
   });
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].dispatchEvent({ type: 'progress', target: this.requests[0] });
-  assert.equal(progressEvents, 1, 'triggered progress');
-});
-
-QUnit.test('updates timestamps when segments do not start at zero', function(assert) {
-  let playlist = playlistWithDuration(10);
-
-  playlist.segments.forEach((segment) => {
-    segment.map = {
-      resolvedUri: 'init.mp4',
-      byterange: { length: Infinity, offset: 0 }
-    };
-  });
-  loader.playlist(playlist);
-  loader.mimeType('video/mp4');
-  loader.load();
-
-  this.startTime.returns(11);
-
-  this.clock.tick(100);
-  // init
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  // segment
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(loader.sourceUpdater_.timestampOffset(), -11, 'set timestampOffset');
-});
-
-QUnit.skip('appending a segment when loader is in walk-forward mode triggers bandwidthupdate', function(assert) {
-  let progresses = 0;
-
-  loader.on('bandwidthupdate', function() {
-    progresses++;
-  });
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  // some time passes and a response is received
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(progresses, 0, 'no bandwidthupdate fired');
-
-  this.clock.tick(2);
-  // if mediaIndex is set, then the SegmentLoader is in walk-forward mode
-  loader.mediaIndex = 1;
-
-  // some time passes and a response is received
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(progresses, 1, 'fired bandwidthupdate');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
-  assert.equal(loader.mediaRequests, 2, '2 request');
-});
-
-QUnit.test('only requests one segment at a time', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  // a bunch of time passes without recieving a response
-  this.clock.tick(20 * 1000);
-  assert.equal(this.requests.length, 1, 'only one request was made');
-});
-
-QUnit.skip('only appends one segment at a time', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  // some time passes and a segment is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // a lot of time goes by without "updateend"
-  this.clock.tick(20 * 1000);
-
-  assert.equal(mediaSource.sourceBuffers[0].updates_.filter(
-    update => update.append).length, 1, 'only one append');
-  assert.equal(this.requests.length, 0, 'only made one request');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('downloads init segments if specified', function(assert) {
-  let playlist = playlistWithDuration(20);
-  let map = {
-    resolvedUri: 'main.mp4',
-    byterange: {
-      length: 20,
-      offset: 0
-    }
-  };
-
-  playlist.segments[0].map = map;
-  playlist.segments[1].map = map;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-
-  loader.load();
-  this.clock.tick(1);
-  let sourceBuffer = mediaSource.sourceBuffers[0];
-
-  assert.equal(this.requests.length, 2, 'made requests');
-
-  // init segment response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, 'main.mp4', 'requested the init segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-  // 0.ts response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, '0.ts',
-              'requested the segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // append the init segment
-  sourceBuffer.buffered = videojs.createTimeRanges([]);
-  sourceBuffer.trigger('updateend');
-  // append the segment
-  sourceBuffer.buffered = videojs.createTimeRanges([[0, 10]]);
-  sourceBuffer.trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 1, 'made a request');
-  assert.equal(this.requests[0].url, '1.ts',
-              'did not re-request the init segment');
-});
-
-QUnit.skip('detects init segment changes and downloads it', function(assert) {
-  let playlist = playlistWithDuration(20);
-
-  playlist.segments[0].map = {
-    resolvedUri: 'init0.mp4',
-    byterange: {
-      length: 20,
-      offset: 0
-    }
-  };
-  playlist.segments[1].map = {
-    resolvedUri: 'init0.mp4',
-    byterange: {
-      length: 20,
-      offset: 20
-    }
-  };
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-
-  loader.load();
-  this.clock.tick(1);
-
-  let sourceBuffer = mediaSource.sourceBuffers[0];
-
-  assert.equal(this.requests.length, 2, 'made requests');
-
-  // init segment response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, 'init0.mp4', 'requested the init segment');
-  assert.equal(this.requests[0].headers.Range, 'bytes=0-19',
-              'requested the init segment byte range');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-  // 0.ts response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, '0.ts',
-              'requested the segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // append the init segment
-  sourceBuffer.buffered = videojs.createTimeRanges([]);
-  sourceBuffer.trigger('updateend');
-  // append the segment
-  sourceBuffer.buffered = videojs.createTimeRanges([[0, 10]]);
-  sourceBuffer.trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 2, 'made requests');
-  assert.equal(this.requests[0].url, 'init0.mp4', 'requested the init segment');
-  assert.equal(this.requests[0].headers.Range, 'bytes=20-39',
-              'requested the init segment byte range');
-  assert.equal(this.requests[1].url, '1.ts',
-              'did not re-request the init segment');
-});
-
-QUnit.test('triggers syncinfoupdate before attempting a resync', function(assert) {
-  let syncInfoUpdates = 0;
-
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  let sourceBuffer = mediaSource.sourceBuffers[0];
-
-  this.seekable = videojs.createTimeRanges([[0, 10]]);
-  this.syncController.probeSegmentInfo = (segmentInfo) => {
-    let segment = segmentInfo.segment;
-
-    segment.end = 10;
-  };
-  loader.on('syncinfoupdate', () => {
-    syncInfoUpdates++;
-    // Simulate the seekable window updating
-    this.seekable = videojs.createTimeRanges([[200, 210]]);
-    // Simulate the seek to live that should happen in playback-watcher
-    this.currentTime = 210;
-  });
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  sourceBuffer.trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, null, 'mediaIndex reset by seek to seekable');
-  assert.equal(syncInfoUpdates, 1, 'syncinfoupdate was triggered');
-});
-
-QUnit.test('abort does not cancel segment processing in progress', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  loader.abort();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'APPENDING', 'still appending');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('request error increments mediaRequestsErrored stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests.shift().respond(404, null, '');
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsErrored, 1, '1 errored request');
-});
-
-QUnit.skip('request timeout increments mediaRequestsTimedout stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsTimedout, 1, '1 timed-out request');
-});
-
-QUnit.skip('request abort increments mediaRequestsAborted stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.abort();
-  this.clock.tick(1);
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsAborted, 1, '1 aborted request');
-});
-
-QUnit.skip('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 0,
-    endList: false
-  }));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  // Start at mediaIndex 2 which means that the next segment we request
-  // should mediaIndex 3
-  loader.mediaIndex = 2;
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex starts at 2');
-  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(loader.mediaIndex, 3, 'mediaIndex ends at 3');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex starts at 3');
-  assert.equal(this.requests[0].url, '4.ts', 'requesting the segment at mediaIndex 4');
-
-  // Update the playlist shifting the mediaSequence by 2 which will result
-  // in a decrement of the mediaIndex by 2 to 1
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 2,
-    endList: false
-  }));
-
-  assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex is updated to 1');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex ends at 2');
-});
-
-QUnit.skip('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
-  // Setting currentTime to 31 so that we start requesting at segment #3
-  this.currentTime = 31;
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 0,
-    endList: false
-  }));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  // Start at mediaIndex null which means that the next segment we request
-  // should be based on currentTime (mediaIndex 3)
-  loader.mediaIndex = null;
-  loader.syncPoint_ = {
-    segmentIndex: 0,
-    time: 0
-  };
-  this.clock.tick(1);
-
-  let segmentInfo = loader.pendingSegment_;
-
-  assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
-  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex ends at 3');
-
-  loader.mediaIndex = null;
-  loader.fetchAtBuffer_ = false;
-  this.clock.tick(1);
-  segmentInfo = loader.pendingSegment_;
-
-  assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
-  assert.equal(this.requests[0].url, '3.ts', 'requesting the segment at mediaIndex 3');
-
-  // Update the playlist shifting the mediaSequence by 2 which will result
-  // in a decrement of the mediaIndex by 2 to 1
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 2,
-    endList: false
-  }));
-
-  assert.equal(segmentInfo.mediaIndex, 1, 'segmentInfo.mediaIndex is updated to 1');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-
-  assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex ends at 1');
-});
-
-QUnit.test('sets the timestampOffset on timeline change', function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.discontinuityStarts = [1];
-  playlist.segments[1].timeline = 1;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  // segment 0
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  // segment 1, discontinuity
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  assert.equal(mediaSource.sourceBuffers[0].timestampOffset, 10, 'set timestampOffset');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
-  assert.equal(loader.mediaRequests, 2, '2 requests');
-});
-
-QUnit.test('tracks segment end times as they are buffered', function(assert) {
-  let playlist = playlistWithDuration(20);
-
-  loader.syncController_.probeTsSegment_ = function(segmentInfo) {
-    return { start: 0, end: 9.5 };
-  };
-
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(playlist.segments[0].end, 9.5, 'updated duration');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.test('adds cues with segment information to the segment-metadata track as they are buffered',
-  function(assert) {
-    const track = loader.segmentMetadataTrack_;
-    let playlist = playlistWithDuration(40);
-    let probeResponse;
-    let expectedCue;
-
-    loader.addSegmentMetadataCue_ = ogAddSegmentMetadataCue_;
-    loader.syncController_.probeTsSegment_ = function(segmentInfo) {
-      return probeResponse;
-    };
-
-    loader.playlist(playlist);
-    loader.mimeType(this.mimeType);
-    loader.load();
-    this.clock.tick(1);
-
-    assert.ok(!track.cues.length, 'segment-metadata track empty when no segments appended');
-
-    // Start appending some segments
-    probeResponse = { start: 0, end: 9.5 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '0.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 0,
-      end: 9.5
-    };
-
-    assert.equal(track.cues.length, 1, 'one cue added for segment');
-    assert.deepEqual(track.cues[0].value, expectedCue,
-      'added correct segment info to cue');
-
-    probeResponse = { start: 9.56, end: 19.2 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '1.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 9.56,
-      end: 19.2
-    };
-
-    assert.equal(track.cues.length, 2, 'one cue added for segment');
-    assert.deepEqual(track.cues[1].value, expectedCue,
-      'added correct segment info to cue');
-
-    probeResponse = { start: 19.24, end: 28.99 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '2.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 19.24,
-      end: 28.99
-    };
-
-    assert.equal(track.cues.length, 3, 'one cue added for segment');
-    assert.deepEqual(track.cues[2].value, expectedCue,
-      'added correct segment info to cue');
-
-    // append overlapping segment, emmulating segment-loader fetching behavior on
-    // rendtion switch
-    probeResponse = { start: 19.21, end: 28.98 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    expectedCue = {
-      uri: '3.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 19.21,
-      end: 28.98
-    };
-
-    assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');
-    assert.deepEqual(track.cues[2].value, expectedCue,
-      'added correct segment info to cue');
-
-    // verify stats
-    assert.equal(loader.mediaBytesTransferred, 40, '40 bytes');
-    assert.equal(loader.mediaRequests, 4, '4 requests');
-  });
-
-QUnit.skip('segment 404s should trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(404, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('segment 5xx status codes trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(500, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.test('fires ended at the end of a playlist', function(assert) {
-  let endOfStreams = 0;
-
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.mediaSource_ = {
-    readyState: 'open',
-    sourceBuffers: mediaSource.sourceBuffers,
-    endOfStream() {
-      endOfStreams++;
-      this.readyState = 'ended';
-    }
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(endOfStreams, 1, 'triggered ended');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.test('live playlists do not trigger ended', function(assert) {
-  let endOfStreams = 0;
-  let playlist;
-
-  playlist = playlistWithDuration(10);
-  playlist.endList = false;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.mediaSource_ = {
-    readyState: 'open',
-    sourceBuffers: mediaSource.sourceBuffers,
-    endOfStream() {
-      endOfStreams++;
-    }
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(endOfStreams, 0, 'did not trigger ended');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('remains ready if there are no segments', function(assert) {
-  loader.playlist(playlistWithDuration(0));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'READY', 'in the ready state');
-});
-
-QUnit.skip('dispose cleans up outstanding work', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.dispose();
-  assert.ok(this.requests[0].aborted, 'aborted segment request');
-  assert.equal(this.requests.length, 1, 'did not open another request');
-  mediaSource.sourceBuffers.forEach((sourceBuffer, i) => {
-    let lastOperation = sourceBuffer.updates_.slice(-1)[0];
-
-    assert.ok(lastOperation.abort, 'aborted source buffer ' + i);
-  });
-});
-
-// ----------
-// Decryption
-// ----------
-
-QUnit.skip('calling load with an encrypted segment requests key and segment', function(assert) {
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  assert.ok(loader.paused(), 'starts paused');
-
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.ok(!loader.paused(), 'loading is not paused');
-  assert.equal(this.requests.length, 2, 'requested a segment and key');
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.equal(this.requests[1].url, '0.ts', 'requested the first segment');
-});
-
-QUnit.skip('dispose cleans up key requests for encrypted segments', function(assert) {
-  loader.playlist(playlistWithDuration(20, {isEncrypted: true}));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.dispose();
-  assert.equal(this.requests.length, 2, 'requested a segment and key');
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.ok(this.requests[0].aborted, 'aborted the first segment\s key request');
-  assert.equal(this.requests.length, 2, 'did not open another request');
-});
-
-QUnit.skip('key 404s should trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(404, null, '');
-  this.clock.tick(1);
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
-        'receieved a key error message');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('key 5xx status codes trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(500, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
-        'receieved a key error message');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('key request timeouts reset bandwidth', function(assert) {
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.equal(this.requests[1].url, '0.ts', 'requested the first segment');
-  // a lot of time passes so the request times out
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
-
-  assert.equal(loader.bandwidth, 1, 'reset bandwidth');
-  assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
-});
-
-QUnit.skip('checks the goal buffer configuration every loading opportunity', function(assert) {
-  let playlist = playlistWithDuration(20);
-  let defaultGoal = Config.GOAL_BUFFER_LENGTH;
-  let segmentInfo;
-
-  Config.GOAL_BUFFER_LENGTH = 1;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-
-  segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
-                                    playlist,
-                                    null,
-                                    loader.hasPlayed_(),
-                                    0,
-                                    null);
-  assert.ok(!segmentInfo, 'no request generated');
-  Config.GOAL_BUFFER_LENGTH = defaultGoal;
-});
-
-QUnit.skip('does not skip over segment if live playlist update occurs while processing',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.pendingSegment_.uri, '0.ts', 'retrieving first segment');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
-  assert.equal(loader.state, 'WAITING', 'waiting for response');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  // playlist updated during append
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence++;
-  loader.playlist(playlistUpdated);
-  // finish append
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'retrieving second segment');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-  assert.equal(loader.state, 'WAITING', 'waiting for response');
-});
-
-QUnit.skip('processing segment reachable even after playlist update removes it',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence += 2;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // we need to check for the right state, as normally handleResponse would throw an
-  // error under failing cases, but sinon swallows it as part of fake XML HTTP request's
-  // response
-  assert.equal(loader.state, 'APPENDING', 'moved to appending state');
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'still using second segment');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-});
-
-QUnit.test('saves segment info to new segment after playlist refresh',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence++;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
-  // time info)
-  loader.syncController_.probeSegmentInfo = (segmentInfo) => {
-    segmentInfo.segment.start = 10;
-    segmentInfo.segment.end = 20;
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(playlistUpdated.segments[0].start,
-               10,
-               'set start on segment of new playlist');
-  assert.equal(playlistUpdated.segments[0].end,
-               20,
-               'set end on segment of new playlist');
-  assert.ok(!playlist.segments[1].start, 'did not set start on segment of old playlist');
-  assert.ok(!playlist.segments[1].end, 'did not set end on segment of old playlist');
-});
-
-QUnit.test('saves segment info to old segment after playlist refresh if segment fell off',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.ts', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.ts', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence += 2;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.ts', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.ts', 'correct segment reference');
-
-  // mock probeSegmentInfo as the response bytes aren't parsable (and won't provide
-  // time info)
-  loader.syncController_.probeSegmentInfo = (segmentInfo) => {
-    segmentInfo.segment.start = 10;
-    segmentInfo.segment.end = 20;
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(playlist.segments[1].start,
-               10,
-               'set start on segment of old playlist');
-  assert.equal(playlist.segments[1].end,
-               20,
-               'set end on segment of old playlist');
-  assert.ok(!playlistUpdated.segments[0].start,
-            'no start info for first segment of new playlist');
-  assert.ok(!playlistUpdated.segments[0].end,
-            'no end info for first segment of new playlist');
-});
-
-QUnit.skip('new playlist always triggers syncinfoupdate', function(assert) {
-  let playlist = playlistWithDuration(100, { endList: false });
-  let syncInfoUpdates = 0;
-
-  loader.on('syncinfoupdate', () => syncInfoUpdates++);
-
-  loader.playlist(playlist);
-  loader.mimeType('video/mp4');
-  loader.load();
-
-  assert.equal(syncInfoUpdates, 1, 'first playlist triggers an update');
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates, 2, 'same playlist triggers an update');
-  playlist = playlistWithDuration(100, { endList: false });
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates, 3, 'new playlist with same info triggers an update');
-  playlist.segments[0].start = 10;
-  playlist = playlistWithDuration(100, { endList: false, mediaSequence: 1 });
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates,
-               5,
-               'new playlist after expiring segment triggers two updates');
 });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -87,6 +87,23 @@ class MockMediaSource extends videojs.EventTarget {
   }
 }
 
+export class MockTextTrack {
+  constructor() {
+    this.cues = [];
+  }
+  addCue(cue) {
+    this.cues.push(cue);
+  }
+  removeCue(cue) {
+    for (let i = 0; i < this.cues.length; i++) {
+      if (this.cues[i] === cue) {
+        this.cues.splice(i, 1);
+        break;
+      }
+    }
+  }
+}
+
 export const useFakeMediaSource = function() {
   let RealMediaSource = videojs.MediaSource;
   let realCreateObjectURL = videojs.URL.createObjectURL;

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -1,19 +1,15 @@
 import QUnit from 'qunit';
 import VTTSegmentLoader from '../src/vtt-segment-loader';
 import videojs from 'video.js';
-import xhrFactory from '../src/xhr';
-import mp4probe from 'mux.js/lib/mp4/probe';
-import Config from '../src/config';
 import {
   playlistWithDuration as oldPlaylistWithDuration,
-  useFakeEnvironment,
-  useFakeMediaSource,
   MockTextTrack
 } from './test-helpers.js';
-import sinon from 'sinon';
-import SyncController from '../src/sync-controller';
-import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+import {
+  LoaderCommonHooks,
+  LoaderCommonSettings,
+  LoaderCommonFactory
+} from './loader-common.js';
 
 const oldVTT = window.WebVTT;
 
@@ -21,27 +17,15 @@ const playlistWithDuration = function(time, conf) {
   return oldPlaylistWithDuration(time, videojs.mergeOptions({ extension: '.vtt' }, conf));
 };
 
-let currentTime;
-let mediaSource;
-let loader;
-let syncController;
-let decrypter;
+const mimeTypeOrTrack = {
+  method: 'track',
+  init: () => new MockTextTrack()
+};
 
-QUnit.module('VTT Segment Loader', {
-  beforeEach(assert) {
-    this.env = useFakeEnvironment(assert);
-    this.clock = this.env.clock;
-    this.requests = this.env.requests;
-    this.mse = useFakeMediaSource();
-    this.currentTime = 0;
-    this.seekable = {
-      length: 0
-    };
-    this.track = new MockTextTrack();
-    this.fakeHls = {
-      xhr: xhrFactory()
-    };
-    this.extension = '.vtt';
+QUnit.module('VTTSegmentLoader', function(hooks) {
+  hooks.beforeEach(function(assert) {
+    LoaderCommonHooks.beforeEach.call(this);
+
     this.parserCreated = false;
 
     window.WebVTT = () => {};
@@ -57,1533 +41,428 @@ QUnit.module('VTT Segment Loader', {
       };
     };
 
-    this.timescale = sinon.stub(mp4probe, 'timescale');
-    this.startTime = sinon.stub(mp4probe, 'startTime');
-
-    mediaSource = new videojs.MediaSource();
-    mediaSource.trigger('sourceopen');
-    this.syncController = new SyncController();
+    // mock an initial timeline sync point on the SyncController
     this.syncController.timelines[0] = { time: 0, mapping: 0 };
-    decrypter = worker(Decrypter);
-    loader = new VTTSegmentLoader({
-      hls: this.fakeHls,
-      currentTime: () => this.currentTime,
-      seekable: () => this.seekable,
-      seeking: () => false,
-      duration: () => mediaSource.duration,
-      hasPlayed: () => true,
-      mediaSource,
-      syncController: this.syncController,
-      decrypter,
-      loaderType: 'vtt'
-    });
-    decrypter.onmessage = (event) => {
-      loader.handleDecrypted_(event.data);
-    };
-  },
-  afterEach() {
-    this.env.restore();
-    this.mse.restore();
-    this.timescale.restore();
-    this.startTime.restore();
-    decrypter.terminate();
+  });
+
+  hooks.afterEach(function(assert) {
+    LoaderCommonHooks.afterEach.call(this);
+
     window.WebVTT = oldVTT;
-  }
-});
+  });
 
-QUnit.skip('fails without required initialization options', function(assert) {
-  /* eslint-disable no-new */
-  assert.throws(function() {
-    new VTTSegmentLoader();
-  }, 'requires options');
-  assert.throws(function() {
-    new VTTSegmentLoader({});
-  }, 'requires a currentTime callback');
-  assert.throws(function() {
-    new VTTSegmentLoader({
-      currentTime() {}
+  LoaderCommonFactory(VTTSegmentLoader, { loaderType: 'vtt' }, mimeTypeOrTrack);
+
+  // Tests specific to the vtt loader go in this module
+  QUnit.module('Loader VTT', function(subHooks) {
+    let loader;
+
+    subHooks.beforeEach(function(assert) {
+      loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
+        loaderType: 'vtt'
+      }));
+
+      mimeTypeOrTrack.value = mimeTypeOrTrack.init();
     });
-  }, 'requires a media source');
-  /* eslint-enable */
-});
 
-QUnit.skip('load waits until a playlist and track are specified to proceed',
-function(assert) {
-  loader.load();
+    subHooks.afterEach(function(assert) {
+      delete mimeTypeOrTrack.value;
+    });
 
-  assert.equal(loader.state, 'INIT', 'waiting in init');
-  assert.equal(loader.paused(), false, 'not paused');
+    QUnit.test('saves segment info to new segment after playlist refresh',
+    function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
 
-  loader.playlist(playlistWithDuration(10));
-  assert.equal(this.requests.length, 0, 'have not made a request yet');
-  loader.track(this.track);
-  this.clock.tick(1);
+      loader.buffered_ = () => buffered;
 
-  assert.equal(this.requests.length, 1, 'made a request');
-  assert.equal(loader.state, 'WAITING', 'transitioned states');
-});
+      playlist.endList = false;
 
-QUnit.skip('calling track and load begins buffering', function(assert) {
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  loader.playlist(playlistWithDuration(10));
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  assert.ok(loader.paused(), 'starts paused');
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  loader.track(this.track);
-  assert.equal(loader.state, 'INIT', 'still in the init state');
-  loader.load();
-  this.clock.tick(1);
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '0.vtt', 'first segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
 
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.ok(!loader.paused(), 'loading is not paused');
-  assert.equal(this.requests.length, 1, 'requested a segment');
-});
+      // wrap up the first request to set mediaIndex and start normal live streaming
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.clock.tick(1);
 
-QUnit.skip('calling load is idempotent', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
 
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.equal(this.requests.length, 1, 'made one request');
+      // playlist updated during waiting
+      let playlistUpdated = playlistWithDuration(40);
 
-  loader.load();
-  assert.equal(loader.state, 'WAITING', 'still in the ready state');
-  assert.equal(this.requests.length, 1, 'still one request');
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence++;
+      loader.playlist(playlistUpdated);
 
-  // some time passes and a response is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  loader.load();
-  assert.equal(this.requests.length, 0, 'load has no effect');
+      assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment still pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      // mock parseVttCues_ to respond empty cue array
+      loader.parseVTTCues_ = (segmentInfo) => {
+        segmentInfo.cues = [];
+        segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+      };
 
-QUnit.skip('calling load should unpause', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.pause();
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-  loader.track(this.track);
+      assert.ok(playlistUpdated.segments[0].empty, 'set empty on segment of new playlist');
+      assert.ok(!playlist.segments[1].empty, 'did not set empty on segment of old playlist');
+    });
 
-  loader.load();
-  this.clock.tick(1);
-  assert.equal(loader.paused(), false, 'loading unpauses');
+    QUnit.test('saves segment info to old segment after playlist refresh if segment fell off',
+    function(assert) {
+      let playlist = playlistWithDuration(40);
+      let buffered = videojs.createTimeRanges();
 
-  loader.pause();
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
+      loader.buffered_ = () => buffered;
 
-  assert.equal(loader.paused(), true, 'stayed paused');
-  loader.load();
-  assert.equal(loader.paused(), false, 'unpaused during processing');
+      playlist.endList = false;
 
-  loader.pause();
-  assert.equal(loader.state, 'READY', 'finished processing');
-  assert.ok(loader.paused(), 'stayed paused');
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+      this.clock.tick(1);
 
-  loader.load();
-  assert.equal(loader.paused(), false, 'unpaused');
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '0.vtt', 'first segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      // wrap up the first request to set mediaIndex and start normal live streaming
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+      buffered = videojs.createTimeRanges([[0, 10]]);
+      this.clock.tick(1);
 
-QUnit.skip('regularly checks the buffer while unpaused', function(assert) {
-  let buffered = videojs.createTimeRanges();
+      assert.equal(loader.state, 'WAITING', 'in waiting state');
+      assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
 
-  loader.playlist(playlistWithDuration(90));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
+      // playlist updated during waiting
+      let playlistUpdated = playlistWithDuration(40);
 
-  loader.buffered = () => buffered;
+      playlistUpdated.segments.shift();
+      playlistUpdated.segments.shift();
+      playlistUpdated.mediaSequence += 2;
+      loader.playlist(playlistUpdated);
 
-  // fill the buffer
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  buffered = videojs.createTimeRanges([[
-    0, Config.GOAL_BUFFER_LENGTH
-  ]]);
-  assert.equal(this.requests.length, 0, 'no outstanding requests');
+      assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment still pending');
+      assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
 
-  // play some video to drain the buffer
-  this.currentTime = Config.GOAL_BUFFER_LENGTH;
-  this.clock.tick(10 * 1000);
-  assert.equal(this.requests.length, 1, 'requested another segment');
+      // mock parseVttCues_ to respond empty cue array
+      loader.parseVTTCues_ = (segmentInfo) => {
+        segmentInfo.cues = [];
+        segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
+      };
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
 
-QUnit.skip('does not check the buffer while paused', function(assert) {
-  loader.playlist(playlistWithDuration(90));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
+      assert.ok(playlist.segments[1].empty,
+                'set empty on segment of old playlist');
+      assert.ok(!playlistUpdated.segments[0].empty,
+                'no empty info for first segment of new playlist');
+    });
 
-  loader.pause();
-  this.clock.tick(1);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
+    QUnit.test('waits for syncController to have sync info for the timeline of the vtt' +
+      'segment being requested before loading', function(assert) {
+      let playlist = playlistWithDuration(40);
+      let loadedSegment = false;
 
-  this.clock.tick(10 * 1000);
-  assert.equal(this.requests.length, 0, 'did not make a request');
+      loader.loadSegment_ = () => {
+        loader.state = 'WAITING';
+        loadedSegment = true;
+      };
+      loader.checkBuffer_ = () => {
+        return { mediaIndex: 2, timeline: 2, segment: { } };
+      };
 
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 1, '1 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
 
-QUnit.skip('calculates bandwidth after downloading a segment', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
+      assert.equal(loader.state, 'READY', 'loader is ready at start');
+      assert.ok(!loadedSegment, 'no segment requests made yet');
 
-  // some time passes and a response is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
+      this.clock.tick(1);
 
-  assert.equal(loader.bandwidth, (10 / 100) * 8 * 1000, 'calculated bandwidth');
-  assert.equal(loader.roundTrip, 100, 'saves request round trip time');
+      assert.equal(loader.state, 'WAITING_ON_TIMELINE', 'loader waiting for timeline info');
+      assert.ok(!loadedSegment, 'no segment requests made yet');
 
-  // TODO: Bandwidth Stat will be stale??
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-});
+      // simulate the main segment loader finding timeline info for the new timeline
+      loader.syncController_.timelines[2] = { time: 20, mapping: -10 };
+      loader.syncController_.trigger('timestampoffset');
 
-QUnit.skip('segment request timeouts reset bandwidth', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
+      assert.equal(loader.state, 'READY', 'ready after sync controller reports timeline info');
+      assert.ok(!loadedSegment, 'no segment requests made yet');
 
-  // a lot of time passes so the request times out
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
+      this.clock.tick(1);
 
-  assert.equal(loader.bandwidth, 1, 'reset bandwidth');
-  assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
-});
+      assert.equal(loader.state, 'WAITING', 'loader waiting on segment request');
+      assert.ok(loadedSegment, 'made call to load segment on new timeline');
+    });
 
-QUnit.skip('progress on segment requests are redispatched', function(assert) {
-  let progressEvents = 0;
+    QUnit.test('waits for vtt.js to be loaded before attempting to parse cues', function(assert) {
+      const vttjs = window.WebVTT;
+      let playlist = playlistWithDuration(40);
+      let parsedCues = false;
 
-  loader.on('progress', function() {
-    progressEvents++;
+      delete window.WebVTT;
+
+      loader.handleUpdateEnd_ = () => {
+        parsedCues = true;
+        loader.state = 'READY';
+      };
+
+      let vttjsCallback = () => {};
+
+      mimeTypeOrTrack.value.tech_ = {
+        one(event, callback) {
+          if (event === 'vttjsloaded') {
+            vttjsCallback = callback;
+          }
+        },
+        trigger(event) {
+          if (event === 'vttjsloaded') {
+            vttjsCallback();
+          }
+        },
+        off() {}
+      };
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      assert.equal(loader.state, 'READY', 'loader is ready at start');
+      assert.ok(!parsedCues, 'no cues parsed yet');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'loader is waiting on segment request');
+      assert.ok(!parsedCues, 'no cues parsed yet');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING_ON_VTTJS', 'loader is waiting for vttjs to be loaded');
+      assert.ok(!parsedCues, 'no cues parsed yet');
+
+      window.WebVTT = vttjs;
+
+      loader.subtitlesTrack_.tech_.trigger('vttjsloaded');
+
+      assert.equal(loader.state, 'READY', 'loader is ready to load next segment');
+      assert.ok(parsedCues, 'parsed cues');
+    });
+
+    QUnit.test('uses timestampmap from vtt header to set cue and segment timing', function(assert) {
+      const cues = [
+        { startTime: 10, endTime: 12 },
+        { startTime: 14, endTime: 16 },
+        { startTime: 15, endTime: 19 }
+      ];
+      const expectedCueTimes = [
+        { startTime: 14, endTime: 16 },
+        { startTime: 18, endTime: 20 },
+        { startTime: 19, endTime: 23 }
+      ];
+      const expectedSegment = {
+        duration: 10
+      };
+      const expectedPlaylist = {
+        mediaSequence: 100,
+        syncInfo: { mediaSequence: 102, time: 9 }
+      };
+      const mappingObj = {
+        time: 0,
+        mapping: -10
+      };
+      const playlist = { mediaSequence: 100 };
+      const segment = { duration: 10 };
+      const segmentInfo = {
+        timestampmap: { MPEGTS: 1260000, LOCAL: 0 },
+        mediaIndex: 2,
+        cues,
+        segment
+      };
+
+      loader.updateTimeMapping_(segmentInfo, mappingObj, playlist);
+
+      assert.deepEqual(cues, expectedCueTimes, 'adjusted cue timing based on timestampmap');
+      assert.deepEqual(segment, expectedSegment, 'set segment start and end based on cue content');
+      assert.deepEqual(playlist, expectedPlaylist, 'set syncInfo for playlist based on learned segment start');
+    });
+
+    QUnit.test('loader logs vtt.js ParsingErrors and does not trigger an error event', function(assert) {
+      let playlist = playlistWithDuration(40);
+
+      window.WebVTT.Parser = () => {
+        this.parserCreated = true;
+        return {
+          oncue() {},
+          onparsingerror() {},
+          onflush() {},
+          parse() {
+            // MOCK parsing the cues below
+            this.onparsingerror({ message: 'BAD CUE'});
+            this.oncue({ startTime: 5, endTime: 6});
+            this.onparsingerror({ message: 'BAD --> CUE' });
+          },
+          flush() {}
+        };
+      };
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      this.clock.tick(1);
+
+      const vttString = `
+        WEBVTT
+
+        00:00:03.000 -> 00:00:05.000
+        <i>BAD CUE</i>
+
+        00:00:05.000 --> 00:00:06.000
+        <b>GOOD CUE</b>
+
+        00:00:07.000 --> 00:00:10.000
+        <i>BAD --> CUE</i>
+      `;
+
+      // state WAITING for segment response
+      this.requests[0].response = new Uint8Array(vttString.split('').map(char => char.charCodeAt(0)));
+      this.requests.shift().respond(200, null, '');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.subtitlesTrack_.cues.length, 1, 'only appended the one good cue');
+      assert.equal(this.env.log.warn.callCount, 2, 'logged two warnings, one for each invalid cue');
+      this.env.log.warn.callCount = 0;
+    });
+
+    QUnit.test('loader does not re-request segments that contain no subtitles', function(assert) {
+      let playlist = playlistWithDuration(60);
+
+      playlist.endList = false;
+
+      loader.parseVTTCues_ = (segmentInfo) => {
+        // mock empty segment
+        segmentInfo.cues = [];
+      };
+
+      loader.currentTime_ = () => {
+        return 30;
+      };
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      this.clock.tick(1);
+
+      assert.equal(loader.pendingSegment_.mediaIndex, 2, 'requesting initial segment guess');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.clock.tick(1);
+
+      assert.ok(playlist.segments[2].empty, 'marked empty segment as empty');
+      assert.equal(loader.pendingSegment_.mediaIndex, 3, 'walked forward skipping requesting empty segment');
+    });
+
+    QUnit.test('loader triggers error event on fatal vtt.js errors', function(assert) {
+      let playlist = playlistWithDuration(40);
+      let errors = 0;
+
+      loader.parseVTTCues_ = () => {
+        throw new Error('fatal error');
+      };
+      loader.on('error', () => errors++);
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      assert.equal(errors, 0, 'no error at loader start');
+
+      this.clock.tick(1);
+
+      // state WAITING for segment response
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.clock.tick(1);
+
+      assert.equal(errors, 1, 'triggered error when parser emmitts fatal error');
+      assert.ok(loader.paused(), 'loader paused when encountering fatal error');
+      assert.equal(loader.state, 'READY', 'loader reset after error');
+    });
+
+    QUnit.test('loader triggers error event when vtt.js fails to load', function(assert) {
+      let playlist = playlistWithDuration(40);
+      let errors = 0;
+
+      delete window.WebVTT;
+      let vttjsCallback = () => {};
+
+      mimeTypeOrTrack.value.tech_ = {
+        one(event, callback) {
+          if (event === 'vttjserror') {
+            vttjsCallback = callback;
+          }
+        },
+        trigger(event) {
+          if (event === 'vttjserror') {
+            vttjsCallback();
+          }
+        },
+        off() {}
+      };
+
+      loader.on('error', () => errors++);
+
+      loader.playlist(playlist);
+      loader[mimeTypeOrTrack.method](mimeTypeOrTrack.value);
+      loader.load();
+
+      assert.equal(loader.state, 'READY', 'loader is ready at start');
+      assert.equal(errors, 0, 'no errors yet');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING', 'loader is waiting on segment request');
+      assert.equal(errors, 0, 'no errors yet');
+
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.clock.tick(1);
+
+      assert.equal(loader.state, 'WAITING_ON_VTTJS', 'loader is waiting for vttjs to be loaded');
+      assert.equal(errors, 0, 'no errors yet');
+
+      loader.subtitlesTrack_.tech_.trigger('vttjserror');
+
+      assert.equal(loader.state, 'READY', 'loader is reset to ready');
+      assert.ok(loader.paused(), 'loader is paused after error');
+      assert.equal(errors, 1, 'loader triggered error when vtt.js load triggers error');
+    });
+
   });
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].dispatchEvent({ type: 'progress', target: this.requests[0] });
-  assert.equal(progressEvents, 1, 'triggered progress');
-});
-
-QUnit.skip('updates timestamps when segments do not start at zero', function(assert) {
-  let playlist = playlistWithDuration(10);
-
-  playlist.segments.forEach((segment) => {
-    segment.map = {
-      resolvedUri: 'init.mp4',
-      bytes: new Uint8Array(10)
-    };
-  });
-  loader.playlist(playlist);
-  loader.mimeType('video/mp4');
-  loader.load();
-
-  this.startTime.returns(11);
-
-  this.clock.tick(100);
-  // init
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  // segment
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(loader.sourceUpdater_.timestampOffset(), -11, 'set timestampOffset');
-});
-
-QUnit.skip('appending a segment when loader is in walk-forward mode triggers bandwidthupdate', function(assert) {
-  let progresses = 0;
-
-  loader.on('bandwidthupdate', function() {
-    progresses++;
-  });
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  // some time passes and a response is received
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(progresses, 0, 'no bandwidthupdate fired');
-
-  this.clock.tick(2);
-  // if mediaIndex is set, then the SegmentLoader is in walk-forward mode
-  loader.mediaIndex = 1;
-
-  // some time passes and a response is received
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.equal(progresses, 1, 'fired bandwidthupdate');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
-  assert.equal(loader.mediaRequests, 2, '2 request');
-});
-
-QUnit.test('only requests one segment at a time', function(assert) {
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  // a bunch of time passes without recieving a response
-  this.clock.tick(20 * 1000);
-  assert.equal(this.requests.length, 1, 'only one request was made');
-});
-
-QUnit.skip('only appends one segment at a time', function(assert) {
-  let updates = 0;
-  let handleupdateend = loader.handleUpdateEnd_.bind(loader);
-
-  loader.handleUpdateEnd_ = () => {
-    updates++;
-    handleupdateend();
-  };
-
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  // some time passes and a segment is received
-  this.clock.tick(100);
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // a lot of time goes by without "updateend"
-  this.clock.tick(20 * 1000);
-
-  assert.equal(updates, 1, 'only one append');
-  assert.equal(this.requests.length, 0, 'only made one request');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaTransferDuration, 100, '100 ms (clock above)');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('downloads init segments if specified', function(assert) {
-  let playlist = playlistWithDuration(20);
-  let map = {
-    resolvedUri: 'main.vtt',
-    byterange: {
-      length: 20,
-      offset: 0
-    }
-  };
-
-  let buffered = videojs.createTimeRanges();
-
-  loader.buffered = () => buffered;
-
-  playlist.segments[0].map = map;
-  playlist.segments[1].map = map;
-  loader.playlist(playlist);
-  loader.track(this.track);
-
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 2, 'made requests');
-
-  // init segment response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, 'main.vtt', 'requested the init segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-  // 0.ts response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, '0.vtt',
-              'requested the segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  // append the segment
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 1, 'made a request');
-  assert.equal(this.requests[0].url, '1.vtt',
-              'did not re-request the init segment');
-});
-
-QUnit.skip('detects init segment changes and downloads it', function(assert) {
-  let playlist = playlistWithDuration(20);
-  let buffered = videojs.createTimeRanges();
-
-  playlist.segments[0].map = {
-    resolvedUri: 'init0.vtt',
-    byterange: {
-      length: 20,
-      offset: 0
-    }
-  };
-  playlist.segments[1].map = {
-    resolvedUri: 'init0.vtt',
-    byterange: {
-      length: 20,
-      offset: 20
-    }
-  };
-
-  loader.buffered = () => buffered;
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 2, 'made requests');
-
-  // init segment response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, 'init0.vtt', 'requested the init segment');
-  assert.equal(this.requests[0].headers.Range, 'bytes=0-19',
-              'requested the init segment byte range');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-  // 0.vtt response
-  this.clock.tick(1);
-  assert.equal(this.requests[0].url, '0.vtt',
-              'requested the segment');
-  this.requests[0].response = new Uint8Array(20).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  this.clock.tick(1);
-
-  assert.equal(this.requests.length, 2, 'made requests');
-  assert.equal(this.requests[0].url, 'init0.vtt', 'requested the init segment');
-  assert.equal(this.requests[0].headers.Range, 'bytes=20-39',
-              'requested the init segment byte range');
-  assert.equal(this.requests[1].url, '1.vtt',
-              'did not re-request the init segment');
-});
-
-QUnit.skip('triggers syncinfoupdate before attempting a resync', function(assert) {
-  let syncInfoUpdates = 0;
-
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  let sourceBuffer = mediaSource.sourceBuffers[0];
-
-  this.seekable = videojs.createTimeRanges([[0, 10]]);
-  this.syncController.probeSegmentInfo = (segmentInfo) => {
-    let segment = segmentInfo.segment;
-
-    segment.end = 10;
-  };
-  loader.on('syncinfoupdate', () => {
-    syncInfoUpdates++;
-    // Simulate the seekable window updating
-    this.seekable = videojs.createTimeRanges([[200, 210]]);
-    // Simulate the seek to live that should happen in playback-watcher
-    this.currentTime = 210;
-  });
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  sourceBuffer.trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, null, 'mediaIndex reset by seek to seekable');
-  assert.equal(syncInfoUpdates, 1, 'syncinfoupdate was triggered');
-});
-
-QUnit.skip('abort does not cancel segment processing in progress', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  loader.abort();
-
-  assert.equal(loader.state, 'READY', 'finished processing and is READY again');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('request error increments mediaRequestsErrored stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests.shift().respond(404, null, '');
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsErrored, 1, '1 errored request');
-});
-
-QUnit.skip('request timeout increments mediaRequestsTimedout stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsTimedout, 1, '1 timed-out request');
-});
-
-QUnit.skip('request abort increments mediaRequestsAborted stat', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.abort();
-  this.clock.tick(1);
-
-  // verify stats
-  assert.equal(loader.mediaRequests, 1, '1 request');
-  assert.equal(loader.mediaRequestsAborted, 1, '1 aborted request');
-});
-
-QUnit.skip('SegmentLoader.mediaIndex is adjusted when live playlist is updated', function(assert) {
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 0,
-    endList: false
-  }));
-  loader.track(this.track);
-  loader.load();
-  // Start at mediaIndex 2 which means that the next segment we request
-  // should mediaIndex 3
-  loader.mediaIndex = 2;
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex starts at 2');
-  assert.equal(this.requests[0].url, '3.vtt', 'requesting the segment at mediaIndex 3');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 3, 'mediaIndex ends at 3');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 3, 'SegmentLoader.mediaIndex starts at 3');
-  assert.equal(this.requests[0].url, '4.vtt', 'requesting the segment at mediaIndex 4');
-
-  // Update the playlist shifting the mediaSequence by 2 which will result
-  // in a decrement of the mediaIndex by 2 to 1
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 2,
-    endList: false
-  }));
-
-  assert.equal(loader.mediaIndex, 1, 'SegmentLoader.mediaIndex is updated to 1');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-
-  assert.equal(loader.mediaIndex, 2, 'SegmentLoader.mediaIndex ends at 2');
-});
-
-QUnit.skip('segmentInfo.mediaIndex is adjusted when live playlist is updated', function(assert) {
-  const handleUpdateEnd_ = loader.handleUpdateEnd_.bind(loader);
-  let expectedLoaderIndex = 3;
-
-  loader.handleUpdateEnd_ = function() {
-    handleUpdateEnd_();
-
-    assert.equal(loader.mediaIndex, expectedLoaderIndex, 'SegmentLoader.mediaIndex ends at ' + expectedLoaderIndex);
-    loader.mediaIndex = null;
-    loader.fetchAtBuffer_ = false;
-  };
-  // Setting currentTime to 31 so that we start requesting at segment #3
-  this.currentTime = 31;
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 0,
-    endList: false
-  }));
-  loader.track(this.track);
-  // Start at mediaIndex null which means that the next segment we request
-  // should be based on currentTime (mediaIndex 3)
-  loader.mediaIndex = null;
-  loader.syncPoint_ = {
-    segmentIndex: 0,
-    time: 0
-  };
-  loader.load();
-  this.clock.tick(1);
-
-  let segmentInfo = loader.pendingSegment_;
-
-  assert.equal(segmentInfo.mediaIndex, 3, 'segmentInfo.mediaIndex starts at 3');
-  assert.equal(this.requests[0].url, '3.vtt', 'requesting the segment at mediaIndex 3');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-  this.clock.tick(1);
-  segmentInfo = loader.pendingSegment_;
-
-  // segment 3 had no cue data (because we didn't mock any) so next request should be
-  // segment 4 because of skipping empty segments
-  assert.equal(segmentInfo.mediaIndex, 4, 'segmentInfo.mediaIndex starts at 4');
-  assert.equal(this.requests[0].url, '4.vtt', 'requesting the segment at mediaIndex 4');
-
-  // Update the playlist shifting the mediaSequence by 2 which will result
-  // in a decrement of the mediaIndex by 4 to 2
-  loader.playlist(playlistWithDuration(50, {
-    mediaSequence: 2,
-    endList: false
-  }));
-
-  assert.equal(segmentInfo.mediaIndex, 2, 'segmentInfo.mediaIndex is updated to 2');
-
-  expectedLoaderIndex = 2;
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  this.clock.tick(1);
-});
-
-QUnit.skip('sets the timestampOffset on timeline change', function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  playlist.discontinuityStarts = [1];
-  playlist.segments[1].timeline = 1;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  // segment 0
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  // segment 1, discontinuity
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  assert.equal(mediaSource.sourceBuffers[0].timestampOffset, 10, 'set timestampOffset');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 20, '20 bytes');
-  assert.equal(loader.mediaRequests, 2, '2 requests');
-});
-
-QUnit.skip('tracks segment end times as they are buffered', function(assert) {
-  let playlist = playlistWithDuration(20);
-
-  loader.parseVTTCues_ = function(segmentInfo) {
-    segmentInfo.cues = [
-      {
-        startTime: 3,
-        endTime: 5
-      },
-      {
-        startTime: 4,
-        endTime: 7
-      }
-    ];
-    segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
-  };
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.equal(playlist.segments[0].start, -1.5, 'updated start time of segment');
-  assert.equal(playlist.segments[0].end, 8.5, 'updated end time of segment');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('adds cues with segment information to the segment-metadata track as they are buffered',
-  function(assert) {
-    const track = loader.segmentMetadataTrack_;
-    let playlist = playlistWithDuration(40);
-    let probeResponse;
-    let expectedCue;
-
-    // loader.addSegmentMetadataCue_ = ogAddSegmentMetadataCue_;
-    loader.syncController_.probeTsSegment_ = function(segmentInfo) {
-      return probeResponse;
-    };
-
-    loader.playlist(playlist);
-    loader.mimeType(this.mimeType);
-    loader.load();
-    this.clock.tick(1);
-
-    assert.ok(!track.cues.length, 'segment-metadata track empty when no segments appended');
-
-    // Start appending some segments
-    probeResponse = { start: 0, end: 9.5 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '0.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 0,
-      end: 9.5
-    };
-
-    assert.equal(track.cues.length, 1, 'one cue added for segment');
-    assert.deepEqual(track.cues[0].value, expectedCue,
-      'added correct segment info to cue');
-
-    probeResponse = { start: 9.56, end: 19.2 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '1.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 9.56,
-      end: 19.2
-    };
-
-    assert.equal(track.cues.length, 2, 'one cue added for segment');
-    assert.deepEqual(track.cues[1].value, expectedCue,
-      'added correct segment info to cue');
-
-    probeResponse = { start: 19.24, end: 28.99 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    this.clock.tick(1);
-    expectedCue = {
-      uri: '2.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 19.24,
-      end: 28.99
-    };
-
-    assert.equal(track.cues.length, 3, 'one cue added for segment');
-    assert.deepEqual(track.cues[2].value, expectedCue,
-      'added correct segment info to cue');
-
-    // append overlapping segment, emmulating segment-loader fetching behavior on
-    // rendtion switch
-    probeResponse = { start: 19.21, end: 28.98 };
-    this.requests[0].response = new Uint8Array(10).buffer;
-    this.requests.shift().respond(200, null, '');
-    mediaSource.sourceBuffers[0].trigger('updateend');
-    expectedCue = {
-      uri: '3.ts',
-      timeline: 0,
-      playlist: 'playlist.m3u8',
-      start: 19.21,
-      end: 28.98
-    };
-
-    assert.equal(track.cues.length, 3, 'overlapped cue removed, new one added');
-    assert.deepEqual(track.cues[2].value, expectedCue,
-      'added correct segment info to cue');
-
-    // verify stats
-    assert.equal(loader.mediaBytesTransferred, 40, '40 bytes');
-    assert.equal(loader.mediaRequests, 4, '4 requests');
-  });
-
-QUnit.skip('segment 404s should trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(404, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('segment 5xx status codes trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(500, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('fires ended at the end of a playlist', function(assert) {
-  let endOfStreams = 0;
-
-  loader.playlist(playlistWithDuration(10));
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.mediaSource_ = {
-    readyState: 'open',
-    sourceBuffers: mediaSource.sourceBuffers,
-    endOfStream() {
-      endOfStreams++;
-      this.readyState = 'ended';
-    }
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(endOfStreams, 1, 'triggered ended');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('live playlists do not trigger ended', function(assert) {
-  let endOfStreams = 0;
-  let playlist;
-
-  playlist = playlistWithDuration(10);
-  playlist.endList = false;
-  loader.playlist(playlist);
-  loader.mimeType(this.mimeType);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.mediaSource_ = {
-    readyState: 'open',
-    sourceBuffers: mediaSource.sourceBuffers,
-    endOfStream() {
-      endOfStreams++;
-    }
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  mediaSource.sourceBuffers[0].buffered = videojs.createTimeRanges([[0, 10]]);
-  mediaSource.sourceBuffers[0].trigger('updateend');
-  this.clock.tick(1);
-
-  assert.equal(endOfStreams, 0, 'did not trigger ended');
-
-  // verify stats
-  assert.equal(loader.mediaBytesTransferred, 10, '10 bytes');
-  assert.equal(loader.mediaRequests, 1, '1 request');
-});
-
-QUnit.skip('remains ready if there are no segments', function(assert) {
-  loader.playlist(playlistWithDuration(0));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'READY', 'in the ready state');
-});
-
-QUnit.skip('dispose cleans up outstanding work', function(assert) {
-  loader.playlist(playlistWithDuration(20));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.dispose();
-  assert.ok(this.requests[0].aborted, 'aborted segment request');
-  assert.equal(this.requests.length, 1, 'did not open another request');
-});
-
-// ----------
-// Decryption
-// ----------
-
-QUnit.skip('calling load with an encrypted segment requests key and segment', function(assert) {
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  assert.equal(loader.state, 'INIT', 'starts in the init state');
-  assert.ok(loader.paused(), 'starts paused');
-
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'moves to the ready state');
-  assert.ok(!loader.paused(), 'loading is not paused');
-  assert.equal(this.requests.length, 2, 'requested a segment and key');
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.equal(this.requests[1].url, '0.vtt', 'requested the first segment');
-});
-
-QUnit.skip('dispose cleans up key requests for encrypted segments', function(assert) {
-  loader.playlist(playlistWithDuration(20, {isEncrypted: true}));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.dispose();
-  assert.equal(this.requests.length, 2, 'requested a segment and key');
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.ok(this.requests[0].aborted, 'aborted the first segment\s key request');
-  assert.equal(this.requests.length, 2, 'did not open another request');
-});
-
-QUnit.skip('key 404s should trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(404, null, '');
-  this.clock.tick(1);
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
-        'receieved a key error message');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('key 5xx status codes trigger an error', function(assert) {
-  let errors = [];
-
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  loader.on('error', function(error) {
-    errors.push(error);
-  });
-  this.requests.shift().respond(500, null, '');
-
-  assert.equal(errors.length, 1, 'triggered an error');
-  assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
-  assert.equal(loader.error().message, 'HLS request errored at URL: 0-key.php',
-        'receieved a key error message');
-  assert.ok(loader.error().xhr, 'included the request object');
-  assert.ok(loader.paused(), 'paused the loader');
-  assert.equal(loader.state, 'READY', 'returned to the ready state');
-});
-
-QUnit.skip('key request timeouts reset bandwidth', function(assert) {
-  loader.playlist(playlistWithDuration(10, {isEncrypted: true}));
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(this.requests[0].url, '0-key.php', 'requested the first segment\'s key');
-  assert.equal(this.requests[1].url, '0.vtt', 'requested the first segment');
-  // a lot of time passes so the request times out
-  this.requests[0].timedout = true;
-  this.clock.tick(100 * 1000);
-
-  assert.equal(loader.bandwidth, 1, 'reset bandwidth');
-  assert.ok(isNaN(loader.roundTrip), 'reset round trip time');
-});
-
-QUnit.skip('checks the goal buffer configuration every loading opportunity', function(assert) {
-  let playlist = playlistWithDuration(20);
-  let defaultGoal = Config.GOAL_BUFFER_LENGTH;
-  let segmentInfo;
-
-  Config.GOAL_BUFFER_LENGTH = 1;
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  segmentInfo = loader.checkBuffer_(videojs.createTimeRanges([[0, 1]]),
-                                    playlist,
-                                    null,
-                                    loader.hasPlayed_(),
-                                    0,
-                                    null);
-  assert.ok(!segmentInfo, 'no request generated');
-  Config.GOAL_BUFFER_LENGTH = defaultGoal;
-});
-
-QUnit.skip('does not skip over segment if live playlist update occurs while processing',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-  let buffered = videojs.createTimeRanges();
-
-  loader.buffered = () => buffered;
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.pendingSegment_.uri, '0.vtt', 'retrieving first segment');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
-  assert.equal(loader.state, 'WAITING', 'waiting for response');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  // playlist updated during append
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence++;
-  loader.playlist(playlistUpdated);
-  // finish append
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  this.clock.tick(1);
-
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'retrieving second segment');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-  assert.equal(loader.state, 'WAITING', 'waiting for response');
-});
-
-QUnit.skip('processing segment reachable even after playlist update removes it',
-function(assert) {
-  const handleUpdateEnd_ = loader.handleUpdateEnd_.bind(loader);
-  let expectedURI = '0.vtt';
-  let playlist = playlistWithDuration(40);
-  let buffered = videojs.createTimeRanges();
-
-  loader.handleUpdateEnd_ = () => {
-    assert.equal(loader.state, 'APPENDING', 'moved to appending state');
-    assert.equal(loader.pendingSegment_.uri, expectedURI, 'correct pending segment');
-    assert.equal(loader.pendingSegment_.segment.uri, expectedURI, 'correct segment reference');
-
-    handleUpdateEnd_();
-  };
-
-  loader.buffered = () => buffered;
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.vtt', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  expectedURI = '1.vtt';
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence += 2;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-});
-
-QUnit.test('saves segment info to new segment after playlist refresh',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-  let buffered = videojs.createTimeRanges();
-
-  loader.buffered = () => buffered;
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.vtt', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence++;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  // mock parseVttCues_ to respond empty cue array
-  loader.parseVTTCues_ = (segmentInfo) => {
-    segmentInfo.cues = [];
-    segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.ok(playlistUpdated.segments[0].empty, 'set empty on segment of new playlist');
-  assert.ok(!playlist.segments[1].empty, 'did not set empty on segment of old playlist');
-});
-
-QUnit.test('saves segment info to old segment after playlist refresh if segment fell off',
-function(assert) {
-  let playlist = playlistWithDuration(40);
-  let buffered = videojs.createTimeRanges();
-
-  loader.buffered = () => buffered;
-
-  playlist.endList = false;
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '0.vtt', 'first segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '0.vtt', 'correct segment reference');
-
-  // wrap up the first request to set mediaIndex and start normal live streaming
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-  buffered = videojs.createTimeRanges([[0, 10]]);
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'in waiting state');
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  // playlist updated during waiting
-  let playlistUpdated = playlistWithDuration(40);
-
-  playlistUpdated.segments.shift();
-  playlistUpdated.segments.shift();
-  playlistUpdated.mediaSequence += 2;
-  loader.playlist(playlistUpdated);
-
-  assert.equal(loader.pendingSegment_.uri, '1.vtt', 'second segment still pending');
-  assert.equal(loader.pendingSegment_.segment.uri, '1.vtt', 'correct segment reference');
-
-  // mock parseVttCues_ to respond empty cue array
-  loader.parseVTTCues_ = (segmentInfo) => {
-    segmentInfo.cues = [];
-    segmentInfo.timestampmap = { MPEGTS: 0, LOCAL: 0 };
-  };
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  assert.ok(playlist.segments[1].empty,
-            'set empty on segment of old playlist');
-  assert.ok(!playlistUpdated.segments[0].empty,
-            'no empty info for first segment of new playlist');
-});
-
-QUnit.skip('new playlist always triggers syncinfoupdate', function(assert) {
-  let playlist = playlistWithDuration(100, { endList: false });
-  let syncInfoUpdates = 0;
-
-  loader.on('syncinfoupdate', () => syncInfoUpdates++);
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  assert.equal(syncInfoUpdates, 1, 'first playlist triggers an update');
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates, 2, 'same playlist triggers an update');
-  playlist = playlistWithDuration(100, { endList: false });
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates, 3, 'new playlist with same info triggers an update');
-  playlist.segments[0].start = 10;
-  playlist = playlistWithDuration(100, { endList: false, mediaSequence: 1 });
-  loader.playlist(playlist);
-  assert.equal(syncInfoUpdates,
-               5,
-               'new playlist after expiring segment triggers two updates');
-});
-
-QUnit.test('waits for syncController to have sync info for the timeline of the vtt' +
-  'segment being requested before loading', function(assert) {
-  let playlist = playlistWithDuration(40);
-  let loadedSegment = false;
-
-  loader.loadSegment_ = () => {
-    loader.state = 'WAITING';
-    loadedSegment = true;
-  };
-  loader.checkBuffer_ = () => {
-    return { mediaIndex: 2, timeline: 2, segment: { } };
-  };
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  assert.equal(loader.state, 'READY', 'loader is ready at start');
-  assert.ok(!loadedSegment, 'no segment requests made yet');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING_ON_TIMELINE', 'loader waiting for timeline info');
-  assert.ok(!loadedSegment, 'no segment requests made yet');
-
-  // simulate the main segment loader finding timeline info for the new timeline
-  loader.syncController_.timelines[2] = { time: 20, mapping: -10 };
-  loader.syncController_.trigger('timestampoffset');
-
-  assert.equal(loader.state, 'READY', 'ready after sync controller reports timeline info');
-  assert.ok(!loadedSegment, 'no segment requests made yet');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'loader waiting on segment request');
-  assert.ok(loadedSegment, 'made call to load segment on new timeline');
-});
-
-QUnit.test('waits for vtt.js to be loaded before attempting to parse cues', function(assert) {
-  const vttjs = window.WebVTT;
-  let playlist = playlistWithDuration(40);
-  let parsedCues = false;
-
-  delete window.WebVTT;
-
-  loader.handleUpdateEnd_ = () => {
-    parsedCues = true;
-    loader.state = 'READY';
-  };
-
-  let vttjsCallback = () => {};
-
-  this.track.tech_ = {
-    one(event, callback) {
-      if (event === 'vttjsloaded') {
-        vttjsCallback = callback;
-      }
-    },
-    trigger(event) {
-      if (event === 'vttjsloaded') {
-        vttjsCallback();
-      }
-    },
-    off() {}
-  };
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  assert.equal(loader.state, 'READY', 'loader is ready at start');
-  assert.ok(!parsedCues, 'no cues parsed yet');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'loader is waiting on segment request');
-  assert.ok(!parsedCues, 'no cues parsed yet');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING_ON_VTTJS', 'loader is waiting for vttjs to be loaded');
-  assert.ok(!parsedCues, 'no cues parsed yet');
-
-  window.WebVTT = vttjs;
-
-  loader.subtitlesTrack_.tech_.trigger('vttjsloaded');
-
-  assert.equal(loader.state, 'READY', 'loader is ready to load next segment');
-  assert.ok(parsedCues, 'parsed cues');
-});
-
-QUnit.test('uses timestampmap from vtt header to set cue and segment timing', function(assert) {
-  const cues = [
-    { startTime: 10, endTime: 12 },
-    { startTime: 14, endTime: 16 },
-    { startTime: 15, endTime: 19 }
-  ];
-  const expectedCueTimes = [
-    { startTime: 14, endTime: 16 },
-    { startTime: 18, endTime: 20 },
-    { startTime: 19, endTime: 23 }
-  ];
-  const expectedSegment = {
-    duration: 10
-  };
-  const expectedPlaylist = {
-    mediaSequence: 100,
-    syncInfo: { mediaSequence: 102, time: 9 }
-  };
-  const mappingObj = {
-    time: 0,
-    mapping: -10
-  };
-  const playlist = { mediaSequence: 100 };
-  const segment = { duration: 10 };
-  const segmentInfo = {
-    timestampmap: { MPEGTS: 1260000, LOCAL: 0 },
-    mediaIndex: 2,
-    cues,
-    segment
-  };
-
-  loader.updateTimeMapping_(segmentInfo, mappingObj, playlist);
-
-  assert.deepEqual(cues, expectedCueTimes, 'adjusted cue timing based on timestampmap');
-  assert.deepEqual(segment, expectedSegment, 'set segment start and end based on cue content');
-  assert.deepEqual(playlist, expectedPlaylist, 'set syncInfo for playlist based on learned segment start');
-});
-
-QUnit.test('loader logs vtt.js ParsingErrors and does not trigger an error event', function(assert) {
-  let playlist = playlistWithDuration(40);
-
-  window.WebVTT.Parser = () => {
-    this.parserCreated = true;
-    return {
-      oncue() {},
-      onparsingerror() {},
-      onflush() {},
-      parse() {
-        // MOCK parsing the cues below
-        this.onparsingerror({ message: 'BAD CUE'});
-        this.oncue({ startTime: 5, endTime: 6});
-        this.onparsingerror({ message: 'BAD --> CUE' });
-      },
-      flush() {}
-    };
-  };
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  this.clock.tick(1);
-
-  const vttString = `
-    WEBVTT
-
-    00:00:03.000 -> 00:00:05.000
-    <i>BAD CUE</i>
-
-    00:00:05.000 --> 00:00:06.000
-    <b>GOOD CUE</b>
-
-    00:00:07.000 --> 00:00:10.000
-    <i>BAD --> CUE</i>
-  `;
-
-  // state WAITING for segment response
-  this.requests[0].response = new Uint8Array(vttString.split('').map(char => char.charCodeAt(0)));
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.equal(this.track.cues.length, 1, 'only appended the one good cue');
-  assert.equal(this.env.log.warn.callCount, 2, 'logged two warnings, one for each invalid cue');
-  this.env.log.warn.callCount = 0;
-});
-
-QUnit.test('loader does not re-request segments that contain no subtitles', function(assert) {
-  let playlist = playlistWithDuration(60);
-
-  playlist.endList = false;
-
-  loader.parseVTTCues_ = (segmentInfo) => {
-    // mock empty segment
-    segmentInfo.cues = [];
-  };
-
-  loader.currentTime_ = () => {
-    return 30;
-  };
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  this.clock.tick(1);
-
-  assert.equal(loader.pendingSegment_.mediaIndex, 2, 'requesting initial segment guess');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.ok(playlist.segments[2].empty, 'marked empty segment as empty');
-  assert.equal(loader.pendingSegment_.mediaIndex, 3, 'walked forward skipping requesting empty segment');
-});
-
-QUnit.test('loader triggers error event on fatal vtt.js errors', function(assert) {
-  let playlist = playlistWithDuration(40);
-  let errors = 0;
-
-  loader.parseVTTCues_ = () => {
-    throw new Error('fatal error');
-  };
-  loader.on('error', () => errors++);
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  assert.equal(errors, 0, 'no error at loader start');
-
-  this.clock.tick(1);
-
-  // state WAITING for segment response
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.equal(errors, 1, 'triggered error when parser emmitts fatal error');
-  assert.ok(loader.paused(), 'loader paused when encountering fatal error');
-  assert.equal(loader.state, 'READY', 'loader reset after error');
-});
-
-QUnit.test('loader triggers error event when vtt.js fails to load', function(assert) {
-  let playlist = playlistWithDuration(40);
-  let errors = 0;
-
-  delete window.WebVTT;
-  let vttjsCallback = () => {};
-
-  this.track.tech_ = {
-    one(event, callback) {
-      if (event === 'vttjserror') {
-        vttjsCallback = callback;
-      }
-    },
-    trigger(event) {
-      if (event === 'vttjserror') {
-        vttjsCallback();
-      }
-    },
-    off() {}
-  };
-
-  loader.on('error', () => errors++);
-
-  loader.playlist(playlist);
-  loader.track(this.track);
-  loader.load();
-
-  assert.equal(loader.state, 'READY', 'loader is ready at start');
-  assert.equal(errors, 0, 'no errors yet');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING', 'loader is waiting on segment request');
-  assert.equal(errors, 0, 'no errors yet');
-
-  this.requests[0].response = new Uint8Array(10).buffer;
-  this.requests.shift().respond(200, null, '');
-
-  this.clock.tick(1);
-
-  assert.equal(loader.state, 'WAITING_ON_VTTJS', 'loader is waiting for vttjs to be loaded');
-  assert.equal(errors, 0, 'no errors yet');
-
-  loader.subtitlesTrack_.tech_.trigger('vttjserror');
-
-  assert.equal(loader.state, 'READY', 'loader is reset to ready');
-  assert.ok(loader.paused(), 'loader is paused after error');
-  assert.equal(errors, 1, 'loader triggered error when vtt.js load triggers error');
 });

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -7,29 +7,13 @@ import Config from '../src/config';
 import {
   playlistWithDuration as oldPlaylistWithDuration,
   useFakeEnvironment,
-  useFakeMediaSource
+  useFakeMediaSource,
+  MockTextTrack
 } from './test-helpers.js';
 import sinon from 'sinon';
 import SyncController from '../src/sync-controller';
 import Decrypter from '../src/decrypter-worker';
 import worker from 'webworkify';
-
-class MockTextTrack {
-  constructor() {
-    this.cues = [];
-  }
-  addCue(cue) {
-    this.cues.push(cue);
-  }
-  removeCue(cue) {
-    for (let i = 0; i < this.cues.length; i++) {
-      if (this.cues[i] === cue) {
-        this.cues.splice(i, 1);
-        break;
-      }
-    }
-  }
-}
 
 const oldVTT = window.WebVTT;
 
@@ -86,6 +70,7 @@ QUnit.module('VTT Segment Loader', {
       currentTime: () => this.currentTime,
       seekable: () => this.seekable,
       seeking: () => false,
+      duration: () => mediaSource.duration,
       hasPlayed: () => true,
       mediaSource,
       syncController: this.syncController,


### PR DESCRIPTION
Continuation of #1057 adding segmented WebVTT support. This PR was separated from #1057 as it is mainly a refactor of the code to remove duplications between `SegmentLoader` and `VTTSegmentLoader` and their respective test files
