### PR TITLE
Trigger player error on initial request error instead of media source error

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -872,7 +872,12 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // trying to load the master OR while we were disposing of the tech
     if (!currentPlaylist) {
       this.error = error;
-      return this.mediaSource.endOfStream('network');
+
+      try {
+        return this.mediaSource.endOfStream('network');
+      } catch (e) {
+        return this.trigger('error');
+      }
     }
 
     let isFinalRendition = this.masterPlaylistLoader_.isFinalRendition_();

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -422,6 +422,12 @@ class HlsHandler extends Component {
         seekable: () => this.seekable()
       }));
 
+    this.masterPlaylistController_.on('error', () => {
+      let player = videojs.players[this.tech_.options_.playerId];
+
+      player.error(this.masterPlaylistController_.error);
+    });
+
     // `this` in selectPlaylist should be the HlsHandler for backwards
     // compatibility with < v2
     this.masterPlaylistController_.selectPlaylist =


### PR DESCRIPTION
## Description
See https://github.com/videojs/videojs-contrib-hls/issues/575
This is to resolve an issue where we try to trigger an error on a media source that isn't yet ready.

## Specific Changes proposed
Since we still want to trigger an error on the player, and can't use the media source (since it isn't ready yet), this fires the error directly on the player.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
