### PR TITLE
Minor loader fixes

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -40,19 +40,13 @@ const segmentXhrHeaders = function(segment) {
 };
 
 /**
- * Abort all requests that have not already returned data
+ * Abort all requests
  *
  * @param {Object} activeXhrs - an object that tracks all XHR requests
  */
 const abortAll = (activeXhrs) => {
   activeXhrs.forEach((xhr) => {
-    // only abort xhrs that haven't had a response
-    if (!xhr.responseTime) {
-      // set an aborted property so that we can correctly
-      // track the request and not treat it as an error
-      xhr.aborted = true;
-      xhr.abort();
-    }
+    xhr.abort();
   });
 };
 
@@ -102,17 +96,6 @@ const getProgressStats = (progressEvent) => {
  * @param {Object} request -  the XHR request that possibly generated the error
  */
 const handleErrors = (error, request) => {
-  const response = request.response;
-
-  if (!request.aborted && error) {
-    return {
-      status: request.status,
-      message: 'HLS request errored at URL: ' + request.uri,
-      code: REQUEST_ERRORS.FAILURE,
-      xhr: request
-    };
-  }
-
   if (request.timedout) {
     return {
       status: request.status,
@@ -122,11 +105,20 @@ const handleErrors = (error, request) => {
     };
   }
 
-  if (request.aborted || !response || response.byteLength === 0) {
+  if (request.aborted) {
     return {
       status: request.status,
       message: 'HLS request aborted at URL: ' + request.uri,
       code: REQUEST_ERRORS.ABORTED,
+      xhr: request
+    };
+  }
+
+  if (error) {
+    return {
+      status: request.status,
+      message: 'HLS request errored at URL: ' + request.uri,
+      code: REQUEST_ERRORS.FAILURE,
       xhr: request
     };
   }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1024,7 +1024,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // fire if playback reaches that point.
     const isEndOfStream = detectEndOfStream(segmentInfo.playlist,
                                             this.mediaSource_,
-                                            this.mediaIndex + 1);
+                                            segmentInfo.mediaIndex + 1);
 
     if (isEndOfStream) {
       this.mediaSource_.endOfStream();

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -41,9 +41,9 @@ const xhrFactory = function() {
         }
       }
 
-      // videojs.xhr now uses a specific code
-      // on the error object to signal that a request has
-      // timed out errors of setting a boolean on the request object
+      // videojs.xhr now uses a specific code on the error
+      // object to signal that a request has timed out instead
+      // of setting a boolean on the request object
       if (error && error.code === 'ETIMEDOUT') {
         request.timedout = true;
       }

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -173,9 +173,62 @@ QUnit.test('cancels outstanding key requests on timeout', function(assert) {
   assert.equal(keyReq.uri, '0-key.php', 'the first request is for a key');
   assert.equal(segmentReq.uri, '0-test.ts', 'the second request is for a segment');
 
-  keyReq.timedout = true;
   // Timeout request
   this.clock.tick(2000);
+});
+
+QUnit.test('ensure the aborted property is set on aborted requests', function(assert) {
+  let keyReq;
+  const done = assert.async();
+  let oldXHRPrototype = XMLHttpRequest.prototype;
+
+  assert.expect(7);
+  // Sinon automatically adds the aborted property so let's stop it from
+  // doing that to make sure we add it under the expected condition when
+  // running on a real, native XHR object
+  XMLHttpRequest.prototype = Object.create(XMLHttpRequest.prototype);
+  XMLHttpRequest.prototype.abort = function abort() {
+    this.response = this.responseText = '';
+    this.errorFlag = true;
+    this.requestHeaders = {};
+    this.responseHeaders = {};
+
+    if (this.readyState > 0 && this.sendFlag) {
+      this.readyStateChange(4);
+      this.sendFlag = false;
+    }
+
+    this.readyState = 0;
+  };
+  let aborter = mediaSegmentRequest(
+    this.xhr,
+    this.xhrOptions,
+    this.noop,
+    {
+      resolvedUri: '0-test.ts',
+      key: {
+        resolvedUri: '0-key.php'
+      }
+    },
+    this.noop,
+    (error, segmentData) => {
+      assert.ok(keyReq.aborted, 'aborted the key request');
+      assert.equal(error.code, REQUEST_ERRORS.ABORTED, 'error code is aborted');
+
+      done();
+    });
+
+  assert.equal(this.requests.length, 2, 'there are two requests');
+
+  keyReq = this.requests.shift();
+  const segmentReq = this.requests.shift();
+
+  assert.equal(keyReq.uri, '0-key.php', 'the first request is for a key');
+  assert.equal(segmentReq.uri, '0-test.ts', 'the second request is for a segment');
+
+  aborter();
+  // Restore the FakeXHR prototype to be good test-citizens
+  XMLHttpRequest.prototype = oldXHRPrototype;
 });
 
 QUnit.test('the key response is converted to the correct format', function(assert) {

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -168,6 +168,26 @@ export const useFakeEnvironment = function(assert) {
   });
   fakeEnvironment.clock = sinon.useFakeTimers();
   fakeEnvironment.xhr = sinon.useFakeXMLHttpRequest();
+
+  // Sinon 1.10.2 handles abort incorrectly (triggering the error event)
+  // Later versions fixed this but broke the ability to set the response
+  // to an arbitrary object (in our case, a typed array).
+  XMLHttpRequest.prototype = Object.create(XMLHttpRequest.prototype);
+  XMLHttpRequest.prototype.abort = function abort() {
+    this.aborted = true;
+    this.response = this.responseText = '';
+    this.errorFlag = true;
+    this.requestHeaders = {};
+    this.responseHeaders = {};
+
+    if (this.readyState > 0 && this.sendFlag) {
+      this.readyStateChange(4);
+      this.sendFlag = false;
+    }
+
+    this.readyState = 0;
+  };
+
   fakeEnvironment.requests.length = 0;
   fakeEnvironment.xhr.onCreate = function(xhr) {
     fakeEnvironment.requests.push(xhr);

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -174,7 +174,6 @@ export const useFakeEnvironment = function(assert) {
   // to an arbitrary object (in our case, a typed array).
   XMLHttpRequest.prototype = Object.create(XMLHttpRequest.prototype);
   XMLHttpRequest.prototype.abort = function abort() {
-    this.aborted = true;
     this.response = this.responseText = '';
     this.errorFlag = true;
     this.requestHeaders = {};


### PR DESCRIPTION
## Description
This PR has two minor fixes that were discovered after testing some new tools:

* Fix for request timeouts being interpreted as errors
   * The tests not catching this problem because Sinon’s FakeXHR differs from real XHRs the way aborts are handled
* Fix to ensure `MediaSource#endOfStream` is still called when the final segment request causes a rendition switch

## Specific Changes proposed
The `xhrFactory` used by videojs-contrib-hls now ensures that the `aborted` property is set on aborted requests so that other parts of the project don't have to worry about it (and simplify the `handleErrors` function in media-segment-request).

In `handleUpdateEnd` we always use the `segmentInfo` object's `mediaIndex` so that it doesn't matter if the `SegmentLoader` is reset before we perform the check for end-of-stream condition.

Fixed, Sinon's  FakeXHR's `abort` function so that it doesn't call any error handlers when abort is called on the request (this was fixed by later versions of Sinon but we can't use them for other reasons).

## Requirements Checklist
- [x] Bug fixed
- [x] Unit Tests updated or fixed
- [x] Reviewed by Two Core Contributors
