### PR TITLE
fix segment time mapping for fmp4 playback

### DIFF
--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -362,13 +362,13 @@ export default class SyncController extends videojs.EventTarget {
       this.logger_('tsO:', segmentInfo.timestampOffset);
 
       mappingObj = {
-        time: segmentInfo.timestampOffset,
-        mapping: segmentInfo.timestampOffset - timingInfo.start
+        time: segmentInfo.startOfSegment,
+        mapping: segmentInfo.startOfSegment - timingInfo.start
       };
       this.timelines[segmentInfo.timeline] = mappingObj;
       this.trigger('timestampoffset');
 
-      segment.start = segmentInfo.timestampOffset;
+      segment.start = segmentInfo.startOfSegment;
       segment.end = timingInfo.end + mappingObj.mapping;
     } else if (mappingObj) {
       segment.start = timingInfo.start + mappingObj.mapping;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -131,6 +131,8 @@ QUnit.module('SegmentLoader', function(hooks) {
       this.requests.shift().respond(200, null, '');
 
       assert.equal(loader.sourceUpdater_.timestampOffset(), -11, 'set timestampOffset');
+      assert.equal(playlist.segments[0].start, 0, 'segment start time not shifted by mp4 start time');
+      assert.equal(playlist.segments[0].end, 10, 'segment end time not shifted by mp4 start time');
     });
 
     QUnit.test('triggers syncinfoupdate before attempting a resync', function(assert) {

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -207,6 +207,7 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
       playlist,
       timeline: 0,
       timestampOffset: 0,
+      startOfSegment: 0,
       segment
     };
 
@@ -221,6 +222,7 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
       'discontinuity sync info correct');
 
     segmentInfo.timestampOffset = null;
+    segmentInfo.startOfSegment = 10;
     segmentInfo.mediaIndex = 1;
     segment = playlist.segments[1];
     segmentInfo.segment = segment;
@@ -232,6 +234,7 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
       'discontinuity sync info correctly updated with new accuracy');
 
     segmentInfo.timestampOffset = 30;
+    segmentInfo.startOfSegment = 30;
     segmentInfo.mediaIndex = 3;
     segmentInfo.timeline = 1;
     segment = playlist.segments[3];


### PR DESCRIPTION
## Description
Segment start and end times were being miscalculated for fragmented mp4s when `timestampOffset` was being set.

## Specific Changes proposed
Use `segmentInfo.startOfSegment` for setting the time mapping instead of `segmentInfo.timestampOffset`. These values are the same except in the fmp4 case  when `timestampOffset` is adjusted to account for offset start times since fmp4 playback uses native source buffers instead of our `VirtualSourceBuffer` and transmuxer for setting `baseMediaDecodeTime` properly.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
