### PR TITLE
Trigger error events when received empty response

### DIFF
--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -151,6 +151,16 @@ const handleKeyResponse = (segment, finishProcessingFn) => (error, request) => {
     }, segment);
   }
 
+  // stop processing if received empty content
+  if(response.byteLength === 0) {
+    return finishProcessingFn({
+      status: request.status,
+      message: 'Empty HLS content at URL: ' + request.uri,
+      code: REQUEST_ERRORS.FAILURE,
+      xhr: request
+    }, segment);
+  }
+
   const view = new DataView(response);
 
   segment.key.bytes = new Uint32Array([
@@ -170,11 +180,23 @@ const handleKeyResponse = (segment, finishProcessingFn) => (error, request) => {
  *                                        this request
  */
 const handleInitSegmentResponse = (segment, finishProcessingFn) => (error, request) => {
+  const response = request.response;
   const errorObj = handleErrors(error, request);
 
   if (errorObj) {
     return finishProcessingFn(errorObj, segment);
   }
+
+  // stop processing if received empty content
+  if(response.byteLength === 0) {
+    return finishProcessingFn({
+      status: request.status,
+      message: 'Empty HLS segment content at URL: ' + request.uri,
+      code: REQUEST_ERRORS.FAILURE,
+      xhr: request
+    }, segment);
+  }
+
   segment.map.bytes = new Uint8Array(request.response);
   return finishProcessingFn(null, segment);
 };
@@ -189,11 +211,23 @@ const handleInitSegmentResponse = (segment, finishProcessingFn) => (error, reque
  *                                        this request
  */
 const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) => {
+  const response = request.response;
   const errorObj = handleErrors(error, request);
 
   if (errorObj) {
     return finishProcessingFn(errorObj, segment);
   }
+
+  // stop processing if received empty content
+  if(response.byteLength === 0) {
+    return finishProcessingFn({
+      status: request.status,
+      message: 'Empty HLS segment content at URL: ' + request.uri,
+      code: REQUEST_ERRORS.FAILURE,
+      xhr: request
+    }, segment);
+  }
+
   segment.stats = getRequestStats(request);
 
   if (segment.key) {

--- a/src/media-segment-request.js
+++ b/src/media-segment-request.js
@@ -151,16 +151,6 @@ const handleKeyResponse = (segment, finishProcessingFn) => (error, request) => {
     }, segment);
   }
 
-  // stop processing if received empty content
-  if(response.byteLength === 0) {
-    return finishProcessingFn({
-      status: request.status,
-      message: 'Empty HLS content at URL: ' + request.uri,
-      code: REQUEST_ERRORS.FAILURE,
-      xhr: request
-    }, segment);
-  }
-
   const view = new DataView(response);
 
   segment.key.bytes = new Uint32Array([
@@ -188,7 +178,7 @@ const handleInitSegmentResponse = (segment, finishProcessingFn) => (error, reque
   }
 
   // stop processing if received empty content
-  if(response.byteLength === 0) {
+  if (response.byteLength === 0) {
     return finishProcessingFn({
       status: request.status,
       message: 'Empty HLS segment content at URL: ' + request.uri,
@@ -219,7 +209,7 @@ const handleSegmentResponse = (segment, finishProcessingFn) => (error, request) 
   }
 
   // stop processing if received empty content
-  if(response.byteLength === 0) {
+  if (response.byteLength === 0) {
     return finishProcessingFn({
       status: request.status,
       message: 'Empty HLS segment content at URL: ' + request.uri,

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -595,6 +595,27 @@ export const LoaderCommonFactory = (LoaderConstructor, loaderOptions, loaderBefo
       assert.equal(loader.state, 'READY', 'returned to the ready state');
     });
 
+    QUnit.test('empty segments should trigger an error', function(assert) {
+      let errors = [];
+
+      loader.playlist(playlistWithDuration(10));
+
+      loader.load();
+      this.clock.tick(1);
+
+      loader.on('error', function(error) {
+        errors.push(error);
+      });
+      this.requests[0].response = new Uint8Array(0).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(errors.length, 1, 'triggered an error');
+      assert.equal(loader.error().code, 2, 'triggered MEDIA_ERR_NETWORK');
+      assert.ok(loader.error().xhr, 'included the request object');
+      assert.ok(loader.paused(), 'paused the loader');
+      assert.equal(loader.state, 'READY', 'returned to the ready state');
+    });
+
     QUnit.test('segment 5xx status codes trigger an error', function(assert) {
       let errors = [];
 


### PR DESCRIPTION
Trigger error events when received empty response. For example, receive contents from outdated streaming server through CDN.

## Description
This is an segment loader enhancement for better response handles.
In some use cases(especially for LIVE streaming, plus through private/public CDN network), the streaming source may throw empty segments, cause XHR response 200 status code but actually get empty content. Trying to parse those problem segments will cause player programmatic errors and makes it unrecoverable. This enhancement detects those error and throws exception, make player able to handle those problems.

## Specific Changes proposed
After segment loader receive responses, detect `response.byteLength` not at zero size before any processing tasks.

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
