### PR TITLE
update readme: when using beforeRequest, source should be added at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,9 @@ player.hls.xhr.beforeRequest = function(options) {
 
 The global `videojs.Hls` also exposes an `xhr` property. Specifying a
 `beforeRequest` function on that will allow you to intercept the options
-for *all* requests in every player on a page.
+for *all* requests in every player on a page. For consistency across
+browsers the video source should be set at runtime once the video player
+is ready. 
 
 Example
 ```javascript
@@ -426,6 +428,14 @@ videojs.Hls.xhr.beforeRequest = function(options) {
 
   return options;
 };
+
+var player = videojs('video-player-id');
+player.ready(function() {
+  this.src({
+    src: 'https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
+    type: 'application/x-mpegURL',
+  });
+});
 ```
 
 For information on the type of options that you can modify see the


### PR DESCRIPTION
## Description
Specifically in Edge, the `beforeRequest` function doesn't consistently get called if the video source was set with a source tag.  It seems to be because Edge starts loading the video segments before videojs initializes. This is a problem because if your using `beforeRequest` for anything like attaching authorization headers the video player will go bang.

You can see an example here: http://jsbin.com/cijiyidego/1/edit?html,console,output

Wrapping the video player initialization in a timeout exaggerates the issue. If you watch the network inspector in Edge segments start downloading before the player initializes.  Removing the source tag and using `player.src` when the player is ready fixes the issue.

## Specific Changes proposed
This PR just updates the readme so people don't get hung up on this as long as I did.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
