### PR TITLE
Fix SourceUpdater updating to be true during removes

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -45,7 +45,7 @@ export default class SourceUpdater {
     this.pendingCallback_ = null;
     this.timestampOffset_ = 0;
     this.mediaSource = mediaSource;
-    this.firstAppend_ = false;
+    this.processedAppend_ = false;
 
     if (mediaSource.readyState === 'closed') {
       mediaSource.addEventListener('sourceopen', createSourceBuffer);
@@ -61,7 +61,7 @@ export default class SourceUpdater {
    * @see http://w3c.github.io/media-source/#widl-SourceBuffer-abort-void
    */
   abort(done) {
-    if (this.firstAppend_) {
+    if (this.processedAppend_) {
       this.queueCallback_(() => {
         this.sourceBuffer_.abort();
       }, done);
@@ -76,7 +76,7 @@ export default class SourceUpdater {
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-appendBuffer-void-ArrayBuffer-data
    */
   appendBuffer(bytes, done) {
-    this.firstAppend_ = true;
+    this.processedAppend_ = true;
 
     this.queueCallback_(() => {
       this.sourceBuffer_.appendBuffer(bytes);
@@ -103,7 +103,7 @@ export default class SourceUpdater {
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-remove-void-double-start-unrestricted-double-end
    */
   remove(start, end) {
-    if (this.firstAppend_) {
+    if (this.processedAppend_) {
       this.queueCallback_(() => {
         this.sourceBuffer_.remove(start, end);
       }, noop);
@@ -111,7 +111,7 @@ export default class SourceUpdater {
   }
 
   /**
-   * wether the underlying sourceBuffer is updating or not
+   * Whether the underlying sourceBuffer is updating or not
    *
    * @return {Boolean} the updating status of the SourceBuffer
    */
@@ -135,7 +135,7 @@ export default class SourceUpdater {
   }
 
   /**
-   * que a callback to run
+   * Queue a callback to run
    */
   queueCallback_(callback, done) {
     this.callbacks_.push([callback.bind(this), done]);
@@ -143,7 +143,7 @@ export default class SourceUpdater {
   }
 
   /**
-   * run a queued callback
+   * Run a queued callback
    */
   runCallback_() {
     let callbacks;

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -3,6 +3,8 @@
  */
 import videojs from 'video.js';
 
+const noop = function() {};
+
 /**
  * A queue of callbacks to be serialized and applied when a
  * MediaSource and its associated SourceBuffers are not in the
@@ -43,6 +45,7 @@ export default class SourceUpdater {
     this.pendingCallback_ = null;
     this.timestampOffset_ = 0;
     this.mediaSource = mediaSource;
+    this.firstAppend_ = false;
 
     if (mediaSource.readyState === 'closed') {
       mediaSource.addEventListener('sourceopen', createSourceBuffer);
@@ -58,9 +61,11 @@ export default class SourceUpdater {
    * @see http://w3c.github.io/media-source/#widl-SourceBuffer-abort-void
    */
   abort(done) {
-    this.queueCallback_(() => {
-      this.sourceBuffer_.abort();
-    }, done);
+    if (this.firstAppend_) {
+      this.queueCallback_(() => {
+        this.sourceBuffer_.abort();
+      }, done);
+    }
   }
 
   /**
@@ -71,6 +76,8 @@ export default class SourceUpdater {
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-appendBuffer-void-ArrayBuffer-data
    */
   appendBuffer(bytes, done) {
+    this.firstAppend_ = true;
+
     this.queueCallback_(() => {
       this.sourceBuffer_.appendBuffer(bytes);
     }, done);
@@ -89,18 +96,6 @@ export default class SourceUpdater {
   }
 
   /**
-   * Queue an update to set the duration.
-   *
-   * @param {Double} duration what to set the duration to
-   * @see http://www.w3.org/TR/media-source/#widl-MediaSource-duration
-   */
-  duration(duration) {
-    this.queueCallback_(() => {
-      this.sourceBuffer_.duration = duration;
-    });
-  }
-
-  /**
    * Queue an update to remove a time range from the buffer.
    *
    * @param {Number} start where to start the removal
@@ -108,9 +103,11 @@ export default class SourceUpdater {
    * @see http://www.w3.org/TR/media-source/#widl-SourceBuffer-remove-void-double-start-unrestricted-double-end
    */
   remove(start, end) {
-    this.queueCallback_(() => {
-      this.sourceBuffer_.remove(start, end);
-    });
+    if (this.firstAppend_) {
+      this.queueCallback_(() => {
+        this.sourceBuffer_.remove(start, end);
+      }, noop);
+    }
   }
 
   /**

--- a/test/source-updater.test.js
+++ b/test/source-updater.test.js
@@ -124,9 +124,15 @@ QUnit.test('supports abort', function(assert) {
 
   updater.abort();
   this.mediaSource.trigger('sourceopen');
+  assert.equal(updater.callbacks_.length, 0, 'abort not queued before source buffers are appended to');
+
+  updater.appendBuffer(new Uint8Array([0]));
+
+  updater.abort();
 
   sourceBuffer = this.mediaSource.sourceBuffers[0];
-  assert.ok(sourceBuffer.updates_[0].abort, 'aborted the source buffer');
+  sourceBuffer.trigger('updateend');
+  assert.ok(sourceBuffer.updates_[1].abort, 'aborted the source buffer');
 });
 
 QUnit.test('supports buffered', function(assert) {
@@ -144,22 +150,18 @@ QUnit.test('supports removeBuffer', function(assert) {
 
   this.mediaSource.trigger('sourceopen');
   sourceBuffer = this.mediaSource.sourceBuffers[0];
+
   updater.remove(1, 14);
 
-  assert.equal(sourceBuffer.updates_.length, 1, 'ran an update');
-  assert.deepEqual(sourceBuffer.updates_[0].remove, [1, 14], 'removed the time range');
-});
+  assert.equal(sourceBuffer.updates_.length, 0, 'remove not queued before sourceBuffers are appended to');
 
-QUnit.test('supports setting duration', function(assert) {
-  let updater = new SourceUpdater(this.mediaSource, 'video/mp2t');
-  let sourceBuffer;
+  updater.appendBuffer(new Uint8Array([0]));
 
-  this.mediaSource.trigger('sourceopen');
-  sourceBuffer = this.mediaSource.sourceBuffers[0];
-  updater.duration(21);
+  updater.remove(1, 14);
 
-  assert.equal(sourceBuffer.updates_.length, 1, 'ran an update');
-  assert.deepEqual(sourceBuffer.updates_[0].duration, 21, 'changed duration');
+  sourceBuffer.trigger('updateend');
+  assert.equal(sourceBuffer.updates_.length, 2, 'ran an update');
+  assert.deepEqual(sourceBuffer.updates_[1].remove, [1, 14], 'removed the time range');
 });
 
 QUnit.test('supports timestampOffset', function(assert) {


### PR DESCRIPTION
Because Firefox changes the `updating` property on source buffers and then queues the `updateend` event to fire at a later time, the `SourceUpdater` may think the source buffer is not updating and overwrite the pending callback to be a different one. A similar issue was fixed previously by adding a check for `SourceUpdater.pendingCallback_` before considering `updating` to be `false`. However, `SourceUpdater.remove` did not add a `done` callback to run after the remove, so `updating` was not properly considered `true`. 

This change adds a no-op function as the `done` callback for removes. It also does not queue any remove actions until after the first call to `appendBuffer`, otherwise the `SourceUpdater` will be waiting for an `updateend` event from a source buffer that does not exist before completing the remove action.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
