### PR TITLE
use specified mediasequence for VOD expired sync instead of assuming 0

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1015,9 +1015,15 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return false;
     }
 
+    let expired = this.syncController_.getExpiredTime(playlist, this.mediaSource.duration);
+
+    if (expired === null) {
+      return false;
+    }
+
     // does not use the safe live end to calculate playlist end, since we
     // don't want to say we are stuck while there is still content
-    let absolutePlaylistEnd = Hls.Playlist.playlistEnd(playlist);
+    let absolutePlaylistEnd = Hls.Playlist.playlistEnd(playlist, expired);
     let currentTime = this.tech_.currentTime();
     let buffered = this.tech_.buffered();
 
@@ -1181,7 +1187,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
   }
 
   onSyncInfoUpdate_() {
-    let media;
     let mainSeekable;
     let audioSeekable;
 
@@ -1189,19 +1194,35 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
-    media = this.masterPlaylistLoader_.media();
+    let media = this.masterPlaylistLoader_.media();
 
     if (!media) {
       return;
     }
 
-    mainSeekable = Hls.Playlist.seekable(media);
+    let expired = this.syncController_.getExpiredTime(media, this.mediaSource.duration);
+
+    if (expired === null) {
+      // not enough information to update seekable
+      return;
+    }
+
+    mainSeekable = Hls.Playlist.seekable(media, expired);
+
     if (mainSeekable.length === 0) {
       return;
     }
 
     if (this.audioPlaylistLoader_) {
-      audioSeekable = Hls.Playlist.seekable(this.audioPlaylistLoader_.media());
+      media = this.audioPlaylistLoader_.media();
+      expired = this.syncController_.getExpiredTime(media, this.mediaSource.duration);
+
+      if (expired === null) {
+        return;
+      }
+
+      audioSeekable = Hls.Playlist.seekable(media, expired);
+
       if (audioSeekable.length === 0) {
         return;
       }

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -235,8 +235,15 @@ const getPlaylistSyncPoints = function(playlist) {
   if (!playlist || !playlist.segments) {
     return [null, null];
   }
-  let expiredSync = playlist.syncInfo || (playlist.endList ? { time: 0, mediaSequence: 0} : null);
+  let expiredSync = playlist.syncInfo;
   let segmentSync = null;
+
+  if (!expiredSync) {
+    // If there is no sync point via syncInfo object on the playlist, then assume
+    // a sync point of the specified media sequence in the playlist as time 0 if this is
+    // not live, otherwise there is no expired sync point yet.
+    expiredSync = playlist.endList ? { time: 0, mediaSequence: playlist.mediaSequence } : null;
+  }
 
   // Find the first segment with timing information
   for (let i = 0, l = playlist.segments.length; i < l; i++) {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -220,105 +220,11 @@ export const sumDurations = function(playlist, startIndex, endIndex) {
 };
 
 /**
- * Returns an array with two sync points. The first being an expired sync point, which is
- * the most recent segment with timing sync data that has fallen off the playlist. The
- * second is a segment sync point, which is the first segment that has timing sync data in
- * the current playlist.
- *
- * @param {Object} playlist a media playlist object
- * @returns {Object} an object containing the two sync points
- * @returns {Object.expiredSync|null} sync point data from an expired segment
- * @returns {Object.segmentSync|null} sync point data from a segment in the playlist
- * @function getPlaylistSyncPoints
- */
-const getPlaylistSyncPoints = function(playlist) {
-  if (!playlist || !playlist.segments) {
-    return [null, null];
-  }
-  let expiredSync = playlist.syncInfo;
-  let segmentSync = null;
-
-  if (!expiredSync) {
-    // If there is no sync point via syncInfo object on the playlist, then assume
-    // a sync point of the specified media sequence in the playlist as time 0 if this is
-    // not live, otherwise there is no expired sync point yet.
-    expiredSync = playlist.endList ? { time: 0, mediaSequence: playlist.mediaSequence } : null;
-  }
-
-  // Find the first segment with timing information
-  for (let i = 0, l = playlist.segments.length; i < l; i++) {
-    let segment = playlist.segments[i];
-
-    if (typeof segment.start !== 'undefined') {
-      segmentSync = {
-        mediaSequence: playlist.mediaSequence + i,
-        time: segment.start
-      };
-      break;
-    }
-  }
-
-  return { expiredSync, segmentSync };
-};
-
-/**
- * Calculates the amount of time expired from the playlist based on the provided
- * sync points.
- *
- * @param {Object} playlist a media playlist object
- * @param {Object|null} expiredSync sync point representing most recent segment with
- *                                  timing sync data that has fallen off the playlist
- * @param {Object|null} segmentSync sync point representing the first segment that has
- *                                  timing sync data in the playlist
- * @returns {Number} the amount of time expired from the playlist
- * @function calculateExpiredTime
- */
-const calculateExpiredTime = function(playlist) {
-  // If we have both an expired sync point and a segment sync point
-  // determine which sync point is closest to the start of the playlist
-  // so the minimal amount of timing estimation is done.
-  let { expiredSync, segmentSync } = getPlaylistSyncPoints(playlist);
-
-  if (expiredSync && segmentSync) {
-    let expiredDiff = expiredSync.mediaSequence - playlist.mediaSequence;
-    let segmentDiff = segmentSync.mediaSequence - playlist.mediaSequence;
-    let syncIndex;
-    let syncTime;
-
-    if (Math.abs(expiredDiff) > Math.abs(segmentDiff)) {
-      syncIndex = segmentDiff;
-      syncTime = -segmentSync.time;
-    } else {
-      syncIndex = expiredDiff;
-      syncTime = expiredSync.time;
-    }
-
-    return Math.abs(syncTime + sumDurations(playlist, syncIndex, 0));
-  }
-
-  // We only have an expired sync point, so base expired time on the expired sync point
-  // and estimate the time from that sync point to the start of the playlist.
-  if (expiredSync) {
-    let syncIndex = expiredSync.mediaSequence - playlist.mediaSequence;
-
-    return expiredSync.time + sumDurations(playlist, syncIndex, 0);
-  }
-
-  // We only have a segment sync point, so base expired time on the first segment we have
-  // sync point data for and estimate the time from that media index to the start of the
-  // playlist.
-  if (segmentSync) {
-    let syncIndex = segmentSync.mediaSequence - playlist.mediaSequence;
-
-    return segmentSync.time - sumDurations(playlist, syncIndex, 0);
-  }
-  return null;
-};
-
-/**
  * Calculates the playlist end time
  *
  * @param {Object} playlist a media playlist object
+ * @param {Number=} expired the amount of time that has
+ *                  dropped off the front of the playlist in a live scenario
  * @param {Boolean|false} useSafeLiveEnd a boolean value indicating whether or not the playlist
  *                        end calculation should consider the safe live end (truncate the playlist
  *                        end by three segments). This is normally used for calculating the end of
@@ -326,18 +232,16 @@ const calculateExpiredTime = function(playlist) {
  * @returns {Number} the end time of playlist
  * @function playlistEnd
  */
-export const playlistEnd = function(playlist, useSafeLiveEnd) {
+export const playlistEnd = function(playlist, expired, useSafeLiveEnd) {
   if (!playlist || !playlist.segments) {
     return null;
   }
   if (playlist.endList) {
     return duration(playlist);
   }
-  let expired = calculateExpiredTime(playlist);
 
-  if (expired === null) {
-    return null;
-  }
+  expired = expired || 0;
+
   let endSequence = useSafeLiveEnd ? Math.max(0, playlist.segments.length - Playlist.UNSAFE_LIVE_SEGMENTS) :
                                      Math.max(0, playlist.segments.length);
 
@@ -356,13 +260,15 @@ export const playlistEnd = function(playlist, useSafeLiveEnd) {
   *
   * @param {Object} playlist a media playlist object
   * dropped off the front of the playlist in a live scenario
+  * @param {Number=} expired the amount of time that has
+  * dropped off the front of the playlist in a live scenario
   * @return {TimeRanges} the periods of time that are valid targets
   * for seeking
   */
-export const seekable = function(playlist) {
+export const seekable = function(playlist, expired) {
   let useSafeLiveEnd = true;
-  let seekableStart = calculateExpiredTime(playlist);
-  let seekableEnd = playlistEnd(playlist, useSafeLiveEnd);
+  let seekableStart = expired || 0;
+  let seekableEnd = playlistEnd(playlist, expired, useSafeLiveEnd);
 
   if (seekableEnd === null) {
     return createTimeRange();

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -240,6 +240,10 @@ export const playlistEnd = function(playlist, expired, useSafeLiveEnd) {
     return duration(playlist);
   }
 
+  if (expired === null) {
+    return null;
+  }
+
   expired = expired || 0;
 
   let endSequence = useSafeLiveEnd ? Math.max(0, playlist.segments.length - Playlist.UNSAFE_LIVE_SEGMENTS) :

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -209,6 +209,29 @@ export default class SyncController extends videojs.EventTarget {
   }
 
   /**
+   *
+   */
+  getExpiredTime(playlist, duration) {
+    if (!playlist) {
+      return null;
+    }
+
+    const syncPoint = this.getSyncPoint(playlist, duration, playlist.discontinuitySequence, 0);
+
+    if (!syncPoint) {
+      return null;
+    }
+
+    // If the sync point is beyond the start of the playlist, we want to subtract the
+    // duration from index 0 to syncPoint.segmentIndex instead of adding.
+    if (syncPoint.segmentIndex > 0) {
+      syncPoint.time = -1 * syncPoint.time;
+    }
+
+    return Math.abs(syncPoint.time + sumDurations(playlist, syncPoint.segmentIndex, 0));
+  }
+
+  /**
    * Save any meta-data present on the segments when segments leave
    * the live window to the playlist to allow for synchronization at the
    * playlist level later.

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -447,6 +447,7 @@ QUnit.test('detects if the player is stuck at the playlist end', function(assert
   // not stuck at playlist end when currentTime not at seekable end
   // even if the buffer is empty
   this.masterPlaylistController.seekable = () => videojs.createTimeRange(0, 130);
+  this.masterPlaylistController.syncController_.getExpiredTime = () => 0;
   this.player.tech_.setCurrentTime(50);
   this.player.tech_.buffered = () => videojs.createTimeRange();
   Hls.Playlist.playlistEnd = () => 130;
@@ -833,6 +834,7 @@ function(assert) {
   };
 
   this.masterPlaylistController.masterPlaylistLoader_.media = () => mainMedia;
+  this.masterPlaylistController.syncController_.getExpiredTime = () => 0;
 
   Playlist.seekable = (media) => {
     if (media === mainMedia) {
@@ -970,6 +972,7 @@ function(assert) {
     return videojs.createTimeRanges(mainTimeRanges);
   };
   this.masterPlaylistController.masterPlaylistLoader_.media = () => media;
+  this.masterPlaylistController.syncController_.getExpiredTime = () => 0;
 
   mainTimeRanges = [[0, 10]];
   mpc.seekable_ = videojs.createTimeRanges();

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -435,8 +435,12 @@ QUnit.test('playlist with no sync points has empty seekable range and empty play
       uri: '3.ts'
     }]
   };
-  let seekable = Playlist.seekable(playlist);
-  let playlistEnd = Playlist.playlistEnd(playlist);
+
+  // seekable and playlistEnd take an optional expired parameter that is from
+  // SyncController.getExpiredTime which returns null when there is no sync point, so
+  // this test passes in null to simulate no sync points
+  let seekable = Playlist.seekable(playlist, null);
+  let playlistEnd = Playlist.playlistEnd(playlist, null);
 
   assert.equal(seekable.length, 0, 'no seekable range for playlist with no sync points');
   assert.equal(playlistEnd, null, 'no playlist end for playlist with no sync points');
@@ -474,8 +478,10 @@ QUnit.test('seekable and playlistEnd use available sync points for calculating',
         }
       ]
     };
-    let seekable = Playlist.seekable(playlist);
-    let playlistEnd = Playlist.playlistEnd(playlist);
+
+    // getExpiredTime would return 100 for this playlist
+    let seekable = Playlist.seekable(playlist, 100);
+    let playlistEnd = Playlist.playlistEnd(playlist, 100);
 
     assert.ok(seekable.length, 'seekable range calculated');
     assert.equal(seekable.start(0), 100, 'estimated start time based on expired sync point');
@@ -510,8 +516,10 @@ QUnit.test('seekable and playlistEnd use available sync points for calculating',
         }
       ]
     };
-    seekable = Playlist.seekable(playlist);
-    playlistEnd = Playlist.playlistEnd(playlist);
+
+    // getExpiredTime would return 98.5
+    seekable = Playlist.seekable(playlist, 98.5);
+    playlistEnd = Playlist.playlistEnd(playlist, 98.5);
 
     assert.ok(seekable.length, 'seekable range calculated');
     assert.equal(seekable.start(0), 98.5, 'estimated start time using segmentSync');
@@ -550,8 +558,10 @@ QUnit.test('seekable and playlistEnd use available sync points for calculating',
         }
       ]
     };
-    seekable = Playlist.seekable(playlist);
-    playlistEnd = Playlist.playlistEnd(playlist);
+
+    // getExpiredTime would return 98.5
+    seekable = Playlist.seekable(playlist, 98.5);
+    playlistEnd = Playlist.playlistEnd(playlist, 98.5);
 
     assert.ok(seekable.length, 'seekable range calculated');
     assert.equal(seekable.start(0), 98.5, 'estimated start time using nearest sync point (segmentSync in this case)');
@@ -590,8 +600,10 @@ QUnit.test('seekable and playlistEnd use available sync points for calculating',
         }
       ]
     };
-    seekable = Playlist.seekable(playlist);
-    playlistEnd = Playlist.playlistEnd(playlist);
+
+    // getExpiredTime would return 100.8
+    seekable = Playlist.seekable(playlist, 100.8);
+    playlistEnd = Playlist.playlistEnd(playlist, 100.8);
 
     assert.ok(seekable.length, 'seekable range calculated');
     assert.equal(seekable.start(0), 100.8, 'estimated start time using nearest sync point (expiredSync in this case)');

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -387,6 +387,36 @@ QUnit.test('seekable end and playlist end account for non-standard target durati
   assert.equal(playlistEnd, 9, 'playlist end at the last segment');
 });
 
+QUnit.test('seekable end and playlist end account for non-zero starting VOD media sequence', function(assert) {
+  let playlist = {
+    targetDuration: 2,
+    mediaSequence: 5,
+    endList: true,
+    segments: [{
+      duration: 2,
+      uri: '0.ts'
+    }, {
+      duration: 2,
+      uri: '1.ts'
+    }, {
+      duration: 1,
+      uri: '2.ts'
+    }, {
+      duration: 2,
+      uri: '3.ts'
+    }, {
+      duration: 2,
+      uri: '4.ts'
+    }]
+  };
+  let seekable = Playlist.seekable(playlist);
+  let playlistEnd = Playlist.playlistEnd(playlist);
+
+  assert.equal(seekable.start(0), 0, 'starts at the earliest available segment');
+  assert.equal(seekable.end(0), 9, 'seekable end is same as duration');
+  assert.equal(playlistEnd, 9, 'playlist end at the last segment');
+});
+
 QUnit.test('playlist with no sync points has empty seekable range and empty playlist end', function(assert) {
   let playlist = {
     targetDuration: 10,

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -397,4 +397,72 @@ QUnit.test('Correctly calculates expired time', function(assert) {
   expired = this.syncController.getExpiredTime(playlist, Infinity);
 
   assert.equal(expired, 100.8, 'estimated expired time using segmentSync');
+
+  playlist = {
+    targetDuration: 10,
+    discontinuityStarts: [],
+    mediaSequence: 100,
+    endList: true,
+    segments: [
+      {
+        duration: 10,
+        uri: '0.ts'
+      },
+      {
+        duration: 10,
+        uri: '1.ts'
+      },
+      {
+        duration: 10,
+        uri: '2.ts'
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  expired = this.syncController.getExpiredTime(playlist, 50);
+
+  assert.equal(expired, 0, 'estimated expired time using segmentSync');
+
+  playlist = {
+    targetDuration: 10,
+    discontinuityStarts: [],
+    mediaSequence: 100,
+    endList: true,
+    segments: [
+      {
+        start: 0.006,
+        duration: 10,
+        uri: '0.ts',
+        end: 9.982
+      },
+      {
+        duration: 10,
+        uri: '1.ts'
+      },
+      {
+        duration: 10,
+        uri: '2.ts'
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  expired = this.syncController.getExpiredTime(playlist, 50);
+
+  assert.equal(expired, 0, 'estimated expired time using segmentSync');
 });

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -249,3 +249,151 @@ QUnit.test('Correctly updates time mapping and discontinuity info when probing s
     assert.deepEqual(syncCon.discontinuities[1], { time: 30, accuracy: 0 },
       'discontinuity sync info correctly updated with new accuracy');
   });
+
+QUnit.test('Correctly calculates expired time', function(assert) {
+  let playlist = {
+    targetDuration: 10,
+    mediaSequence: 100,
+    discontinuityStarts: [],
+    syncInfo: {
+      time: 50,
+      mediaSequence: 95
+    },
+    segments: [
+      {
+        duration: 10,
+        uri: '0.ts'
+      },
+      {
+        duration: 10,
+        uri: '1.ts'
+      },
+      {
+        duration: 10,
+        uri: '2.ts'
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  let expired = this.syncController.getExpiredTime(playlist, Infinity);
+
+  assert.equal(expired, 100, 'seekable range calculated');
+
+  playlist = {
+    targetDuration: 10,
+    discontinuityStarts: [],
+    mediaSequence: 100,
+    segments: [
+      {
+        duration: 10,
+        uri: '0.ts'
+      },
+      {
+        duration: 10,
+        uri: '1.ts',
+        start: 108.5,
+        end: 118.4
+      },
+      {
+        duration: 10,
+        uri: '2.ts'
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  expired = this.syncController.getExpiredTime(playlist, Infinity);
+
+  assert.equal(expired, 98.5, 'estimated start time using segmentSync');
+
+  playlist = {
+    discontinuityStarts: [],
+    targetDuration: 10,
+    mediaSequence: 100,
+    syncInfo: {
+      time: 50,
+      mediaSequence: 95
+    },
+    segments: [
+      {
+        duration: 10,
+        uri: '0.ts'
+      },
+      {
+        duration: 10,
+        uri: '1.ts',
+        start: 108.5,
+        end: 118.5
+      },
+      {
+        duration: 10,
+        uri: '2.ts'
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  expired = this.syncController.getExpiredTime(playlist, Infinity);
+
+  assert.equal(expired, 98.5, 'estimated start time using segmentSync');
+
+  playlist = {
+    targetDuration: 10,
+    discontinuityStarts: [],
+    mediaSequence: 100,
+    syncInfo: {
+      time: 90.8,
+      mediaSequence: 99
+    },
+    segments: [
+      {
+        duration: 10,
+        uri: '0.ts'
+      },
+      {
+        duration: 10,
+        uri: '1.ts'
+      },
+      {
+        duration: 10,
+        uri: '2.ts',
+        start: 118.5,
+        end: 128.5
+      },
+      {
+        duration: 10,
+        uri: '3.ts'
+      },
+      {
+        duration: 10,
+        uri: '4.ts'
+      }
+    ]
+  };
+
+  expired = this.syncController.getExpiredTime(playlist, Infinity);
+
+  assert.equal(expired, 100.8, 'estimated start time using segmentSync');
+});

--- a/test/sync-controller.test.js
+++ b/test/sync-controller.test.js
@@ -158,10 +158,11 @@ QUnit.test('returns correct sync point for Playlist strategy', function(assert) 
   playlist.syncInfo = { time: 10, mediaSequence: 100};
 
   syncPoint = strategy.run(this.syncController, playlist, 40, 0);
-  assert.deepEqual(syncPoint, { time: 10, segmentIndex: -2 }, 'found sync point in playlist');
+  assert.deepEqual(syncPoint, { time: 10, segmentIndex: -2 },
+    'found sync point in playlist');
 });
 
-QUnit.test('saves expired info onto new playlist for possible sync point', function(assert) {
+QUnit.test('saves expired info onto new playlist for sync point', function(assert) {
   let oldPlaylist = playlistWithDuration(50);
   let newPlaylist = playlistWithDuration(50);
 
@@ -285,7 +286,7 @@ QUnit.test('Correctly calculates expired time', function(assert) {
 
   let expired = this.syncController.getExpiredTime(playlist, Infinity);
 
-  assert.equal(expired, 100, 'seekable range calculated');
+  assert.equal(expired, 100, 'estimated expired time using segmentSync');
 
   playlist = {
     targetDuration: 10,
@@ -319,7 +320,7 @@ QUnit.test('Correctly calculates expired time', function(assert) {
 
   expired = this.syncController.getExpiredTime(playlist, Infinity);
 
-  assert.equal(expired, 98.5, 'estimated start time using segmentSync');
+  assert.equal(expired, 98.5, 'estimated expired time using segmentSync');
 
   playlist = {
     discontinuityStarts: [],
@@ -357,7 +358,7 @@ QUnit.test('Correctly calculates expired time', function(assert) {
 
   expired = this.syncController.getExpiredTime(playlist, Infinity);
 
-  assert.equal(expired, 98.5, 'estimated start time using segmentSync');
+  assert.equal(expired, 98.5, 'estimated expired time using segmentSync');
 
   playlist = {
     targetDuration: 10,
@@ -395,5 +396,5 @@ QUnit.test('Correctly calculates expired time', function(assert) {
 
   expired = this.syncController.getExpiredTime(playlist, Infinity);
 
-  assert.equal(expired, 100.8, 'estimated start time using segmentSync');
+  assert.equal(expired, 100.8, 'estimated expired time using segmentSync');
 });


### PR DESCRIPTION
## Description
Seekable calculations assumed that VOD playlists have an `EXT-X-MEDIA-SEQUENCE` of `0`, however this is not always the case. ~~This fixes the calculations to use the media sequence specified in the playlist~~ This has been updated to now use the `SyncController` to pick a sync point and calculate expired time
