### PR TITLE
Fix playback stalls when everything appears okay

### DIFF
--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -218,8 +218,11 @@ export default class PlaybackWatcher {
 
     // Sometimes the player can stall for unknown reasons within a contiguous buffered
     // region with no indication that anything is amiss (seen in Firefox). Seeking to
-    // currentTime is usually enough to kickstart the player.
-    if (currentRange.length) {
+    // currentTime is usually enough to kickstart the player. This checks that the player
+    // is currently within a buffered region and there is at least half a second
+    // of forward buffer so that this isn't triggered when the player is just buffering
+    // due to slow connection.
+    if (currentRange.length && currentTime <= currentRange.end(0) - 0.5) {
       this.cancelTimer_();
       this.tech_.setCurrentTime(currentTime);
 

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -211,6 +211,19 @@ export default class PlaybackWatcher {
       this.timer_ = setTimeout(this.skipTheGap_.bind(this),
                                difference * 1000,
                                currentTime);
+      return;
+    }
+
+    // Sometimes the player can stall for unknown reasons within a contiguious buffered
+    // region with no indication that anything is amiss (Seen in Firefox). Seeking to
+    // currentTime is usually enough to kickstart the player
+    if (buffered.length && currentTime + 1 < buffered.end(buffered.length - 1)) {
+      this.cancelTimer_();
+      this.tech_.setCurrentTime(currentTime);
+
+      // unknown waiting corrections may be useful for monitoring QoS
+      this.tech_.trigger('unknownwaiting');
+      return;
     }
   }
 

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -101,6 +101,16 @@ export default class PlaybackWatcher {
     }
 
     let currentTime = this.tech_.currentTime();
+    let buffered = this.tech_.buffered();
+
+    if (buffered.length && currentTime + 0.1 >= buffered.end(buffered.length - 1)) {
+      // If current time is at the end of the final buffered region, then any playback
+      // stall is most likely caused by buffering in a low bandwidth environment. This
+      // prevents playback watcher from updating consecutive updates until the player
+      // has some forward buffer to avoid miscategorizing waiting on a slow connection
+      // as a playback issue.
+      return;
+    }
 
     if (this.consecutiveUpdates >= 5 &&
         currentTime === this.lastRecordedTime) {

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -8,6 +8,7 @@
  * my life and honor to the Playback Watch, for this Player and all the Players to come.
  */
 
+import window from 'global/window';
 import Ranges from './ranges';
 import videojs from 'video.js';
 
@@ -59,7 +60,7 @@ export default class PlaybackWatcher {
       this.tech_.off('waiting', waitingHandler);
       this.tech_.off(timerCancelEvents, cancelTimerHandler);
       if (this.checkCurrentTimeTimeout_) {
-        clearTimeout(this.checkCurrentTimeTimeout_);
+        window.clearTimeout(this.checkCurrentTimeTimeout_);
       }
       this.cancelTimer_();
     };
@@ -74,11 +75,11 @@ export default class PlaybackWatcher {
     this.checkCurrentTime_();
 
     if (this.checkCurrentTimeTimeout_) {
-      clearTimeout(this.checkCurrentTimeTimeout_);
+      window.clearTimeout(this.checkCurrentTimeTimeout_);
     }
 
     // 42 = 24 fps // 250 is what Webkit uses // FF uses 15
-    this.checkCurrentTimeTimeout_ = setTimeout(this.monitorCurrentTime_.bind(this), 250);
+    this.checkCurrentTimeTimeout_ = window.setTimeout(this.monitorCurrentTime_.bind(this), 250);
   }
 
   /**
@@ -156,7 +157,7 @@ export default class PlaybackWatcher {
   }
 
   /**
-   * Handler for situations when we determine the player is waiting
+   * Handler for situations when we determine the player is waiting.
    *
    * @private
    */
@@ -176,6 +177,9 @@ export default class PlaybackWatcher {
     // is currently within a buffered region and there is at least half a second
     // of forward buffer so that this isn't triggered when the player is just buffering
     // due to slow connection.
+    // Note: This is not done when the `waiting` event fired by the tech because the tech
+    // also fires `waiting` when the player is buffering in low bandwidth scenarios, which
+    // requires no action from playback watcher.
     if (currentRange.length && currentTime <= currentRange.end(0) - 0.5) {
       this.cancelTimer_();
       this.tech_.setCurrentTime(currentTime);

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -214,12 +214,17 @@ export default class PlaybackWatcher {
       return;
     }
 
-    // Sometimes the player can stall for unknown reasons within a contiguious buffered
-    // region with no indication that anything is amiss (Seen in Firefox). Seeking to
-    // currentTime is usually enough to kickstart the player
-    if (buffered.length && currentTime + 1 < buffered.end(buffered.length - 1)) {
+    let currentRange = Ranges.findRange(buffered, currentTime);
+
+    // Sometimes the player can stall for unknown reasons within a contiguous buffered
+    // region with no indication that anything is amiss (seen in Firefox). Seeking to
+    // currentTime is usually enough to kickstart the player.
+    if (currentRange.length) {
       this.cancelTimer_();
       this.tech_.setCurrentTime(currentTime);
+
+      this.logger_(`Stopped at ${currentTime} while inside a buffered region. Attempting
+        to resume playback by seeking to the current time.`);
 
       // unknown waiting corrections may be useful for monitoring QoS
       this.tech_.trigger('unknownwaiting');

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -103,7 +103,7 @@ export default class PlaybackWatcher {
     let currentTime = this.tech_.currentTime();
     let buffered = this.tech_.buffered();
 
-    if (buffered.length && currentTime + 0.1 >= buffered.end(buffered.length - 1)) {
+    if (!buffered.length || currentTime + 0.1 >= buffered.end(buffered.length - 1)) {
       // If current time is at the end of the final buffered region, then any playback
       // stall is most likely caused by buffering in a low bandwidth environment. This
       // prevents playback watcher from updating consecutive updates until the player

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -109,6 +109,8 @@ export default class PlaybackWatcher {
       // prevents playback watcher from updating consecutive updates until the player
       // has some forward buffer to avoid miscategorizing waiting on a slow connection
       // as a playback issue.
+      this.consecutiveUpdates = 0;
+      this.lastRecordedTime = currentTime;
       return;
     }
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -203,8 +203,59 @@ QUnit.test('seeks to current time when stuck inside buffered region', function(a
   this.player.tech_.seekable = () => videojs.createTimeRanges([[0, 30]]);
   this.player.tech_.paused = () => false;
 
-  this.clock.tick(1750);
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
 
+  // Loop has run through once, `lastRecordedTime` should have been recorded
+  // and `consecutiveUpdates` set to 0 to begin count
+  assert.equal(this.player.tech_.hls.playbackWatcher_.lastRecordedTime, 10,
+    'Playback Watcher stored current time');
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 0,
+    'consecutiveUpdates set to 0');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should increment consecutive updates until it is >= 5
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 1,
+    'consecutiveUpdates incremented');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should increment consecutive updates until it is >= 5
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 2,
+    'consecutiveUpdates incremented');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should increment consecutive updates until it is >= 5
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 3,
+    'consecutiveUpdates incremented');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should increment consecutive updates until it is >= 5
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 4,
+    'consecutiveUpdates incremented');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should increment consecutive updates until it is >= 5
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 5,
+    'consecutiveUpdates incremented');
+
+  // Playback watcher loop runs on a 250ms clock
+  this.clock.tick(250);
+
+  // Loop should see consecutive updates >= 5, call `waiting_`
+  assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 0,
+    'consecutiveUpdates reset');
+
+  // Playback watcher seeked to currentTime in `waiting_` to correct the `unknownwaiting`
   assert.equal(seeks.length, 1, 'one seek');
   assert.equal(seeks[0], 10, 'player seeked to currentTime');
 });
@@ -226,7 +277,7 @@ QUnit.test('does not seek to current time when stuck near edge of buffered regio
     this.player.tech_.trigger('playing');
     this.clock.tick(1);
 
-    this.player.currentTime(29.8);
+    this.player.currentTime(29.98);
 
     let seeks = [];
 
@@ -239,8 +290,28 @@ QUnit.test('does not seek to current time when stuck near edge of buffered regio
     this.player.tech_.seekable = () => videojs.createTimeRanges([[0, 30]]);
     this.player.tech_.paused = () => false;
 
-    this.clock.tick(250 * 8);
+    // Playback watcher loop runs on a 250ms clock
+    this.clock.tick(250);
 
+    // Loop has run through once, `lastRecordedTime` should have been recorded
+    // and `consecutiveUpdates` set to 0 to begin count
+    assert.equal(this.player.tech_.hls.playbackWatcher_.lastRecordedTime, 29.98,
+      'Playback Watcher stored current time');
+    assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 0,
+      'consecutiveUpdates set to 0');
+
+    // Playback watcher loop runs on a 250ms clock
+    this.clock.tick(250);
+
+    // Loop has run through a second time, should detect that currentTime hasn't made
+    // progress while at the end of the buffer. Since the currentTime is at the end of the
+    // buffer, `consecutiveUpdates` should not be incremented
+    assert.equal(this.player.tech_.hls.playbackWatcher_.lastRecordedTime, 29.98,
+      'Playback Watcher stored current time');
+    assert.equal(this.player.tech_.hls.playbackWatcher_.consecutiveUpdates, 0,
+      'consecutiveUpdates should still be 0');
+
+    // no corrective seek
     assert.equal(seeks.length, 0, 'no seek');
   });
 

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -174,6 +174,7 @@ QUnit.test('seek to live point if we fall off the end of a live playlist', funct
 });
 
 QUnit.test('seeks to current time when stuck inside buffered region', function(assert) {
+
   // set an arbitrary live source
   this.player.src({
     src: 'liveStart30sBefore.m3u8',
@@ -202,11 +203,46 @@ QUnit.test('seeks to current time when stuck inside buffered region', function(a
   this.player.tech_.seekable = () => videojs.createTimeRanges([[0, 30]]);
   this.player.tech_.paused = () => false;
 
-  this.player.tech_.trigger('waiting');
+  this.clock.tick(1750);
 
   assert.equal(seeks.length, 1, 'one seek');
   assert.equal(seeks[0], 10, 'player seeked to currentTime');
 });
+
+QUnit.test('does not seek to current time when stuck near edge of buffered region',
+  function(assert) {
+    // set an arbitrary live source
+    this.player.src({
+      src: 'liveStart30sBefore.m3u8',
+      type: 'application/vnd.apple.mpegurl'
+    });
+
+    // start playback normally
+    this.player.tech_.triggerReady();
+    this.clock.tick(1);
+    standardXHRResponse(this.requests.shift());
+    openMediaSource(this.player, this.clock);
+    this.player.tech_.trigger('play');
+    this.player.tech_.trigger('playing');
+    this.clock.tick(1);
+
+    this.player.currentTime(29.8);
+
+    let seeks = [];
+
+    this.player.tech_.setCurrentTime = (time) => {
+      seeks.push(time);
+    };
+
+    this.player.tech_.seeking = () => false;
+    this.player.tech_.buffered = () => videojs.createTimeRanges([[0, 30]]);
+    this.player.tech_.seekable = () => videojs.createTimeRanges([[0, 30]]);
+    this.player.tech_.paused = () => false;
+
+    this.clock.tick(250 * 8);
+
+    assert.equal(seeks.length, 0, 'no seek');
+  });
 
 QUnit.test('fires notifications when activated', function(assert) {
   let buffered = [[]];


### PR DESCRIPTION
## Description
Sometimes things go wrong when things look right. This change adds a last ditch effort correction in `PlaybackWatcher` to seek to `currentTime` if a playback stall occurs and there is at least 1 second of forward buffer.
