### PR TITLE
Add module field to support ES6 modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.5.3",
   "description": "Play back HLS with video.js, even where it's not natively supported",
   "main": "es5/videojs-contrib-hls.js",
+  "module": "src/videojs-contrib-hls.js",
   "engines": {
     "node": ">= 0.10.12"
   },


### PR DESCRIPTION
Tiny update to `package.json` so that Rollup (and other ES6 module systems) can `import` this library easily.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Reviewed by Two Core Contributors
