### PR TITLE
chore: upgrade to babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [ "es3", ["es2015", {"loose": true}] ],
+}

--- a/package.json
+++ b/package.json
@@ -96,11 +96,13 @@
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1",
     "videojs-contrib-media-sources": "4.4.5",
-    "webworkify": "1.0.2"
+    "webworkify": "1.4.0"
   },
   "devDependencies": {
-    "babel": "^5.8.0",
-    "babelify": "^6.0.0",
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-es3": "^1.0.1",
+    "babelify": "^7.3.0",
     "bannerize": "^1.0.0",
     "browserify": "^11.0.0",
     "browserify-istanbul": "^2.0.0",
@@ -133,10 +135,10 @@
     "shelljs": "^0.5.3",
     "sinon": "1.10.2",
     "uglify-js": "^2.5.0",
-    "videojs-standard": "^4.0.3",
     "videojs-contrib-quality-levels": "^2.0.2",
+    "videojs-standard": "^4.0.3",
+    "videojs-swf": "^5.2.0",
     "watchify": "^3.6.0",
-    "webpack": "^1.13.2",
-    "videojs-swf": "^5.2.0"
+    "webpack": "^1.13.2"
   }
 }

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -94,9 +94,8 @@ export const hexDump = (data) => {
 };
 
 export const tagDump = (tag) => {
-  return utils.hexDump(tag.bytes);
+  return hexDump(tag.bytes);
 };
-
 
 export const textRanges = (ranges) => {
   let result = '';

--- a/src/bin-utils.js
+++ b/src/bin-utils.js
@@ -40,7 +40,7 @@ const formatAsciiString = function(e) {
  *         Modified message with TypedArray values expanded
  * @function createTransferableMessage
  */
-const createTransferableMessage = function(message) {
+export const createTransferableMessage = function(message) {
   const transferable = {};
 
   Object.keys(message).forEach((key) => {
@@ -64,7 +64,7 @@ const createTransferableMessage = function(message) {
  * Returns a unique string identifier for a media initialization
  * segment.
  */
-const initSegmentId = function(initSegment) {
+export const initSegmentId = function(initSegment) {
   let byterange = initSegment.byterange || {
     length: Infinity,
     offset: 0
@@ -78,35 +78,32 @@ const initSegmentId = function(initSegment) {
 /**
  * utils to help dump binary data to the console
  */
-const utils = {
-  hexDump(data) {
-    let bytes = Array.prototype.slice.call(data);
-    let step = 16;
-    let result = '';
-    let hex;
-    let ascii;
+export const hexDump = (data) => {
+  let bytes = Array.prototype.slice.call(data);
+  let step = 16;
+  let result = '';
+  let hex;
+  let ascii;
 
-    for (let j = 0; j < bytes.length / step; j++) {
-      hex = bytes.slice(j * step, j * step + step).map(formatHexString).join('');
-      ascii = bytes.slice(j * step, j * step + step).map(formatAsciiString).join('');
-      result += hex + ' ' + ascii + '\n';
-    }
-    return result;
-  },
-  tagDump(tag) {
-    return utils.hexDump(tag.bytes);
-  },
-  textRanges(ranges) {
-    let result = '';
-    let i;
-
-    for (i = 0; i < ranges.length; i++) {
-      result += textRange(ranges, i) + ' ';
-    }
-    return result;
-  },
-  createTransferableMessage,
-  initSegmentId
+  for (let j = 0; j < bytes.length / step; j++) {
+    hex = bytes.slice(j * step, j * step + step).map(formatHexString).join('');
+    ascii = bytes.slice(j * step, j * step + step).map(formatAsciiString).join('');
+    result += hex + ' ' + ascii + '\n';
+  }
+  return result;
 };
 
-export default utils;
+export const tagDump = (tag) => {
+  return utils.hexDump(tag.bytes);
+};
+
+
+export const textRanges = (ranges) => {
+  let result = '';
+  let i;
+
+  for (i = 0; i < ranges.length; i++) {
+    result += textRange(ranges, i) + ' ';
+  }
+  return result;
+};

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -395,6 +395,7 @@ QUnit.test('fixes bad seeks', function(assert) {
 
   playbackWatcher.seekable = () => seekable;
   playbackWatcher.tech_ = {
+    off: () => {},
     seeking: () => seeking,
     setCurrentTime: (time) => {
       seeks.push(time);
@@ -447,6 +448,7 @@ QUnit.test('seeks to live point if we try to seek outside of seekable', function
 
   playbackWatcher.seekable = () => seekable;
   playbackWatcher.tech_ = {
+    off: () => {},
     seeking: () => seeking,
     setCurrentTime: (time) => {
       seeks.push(time);


### PR DESCRIPTION
This is a WIP right now because of issues concerning IE8 https://github.com/videojs/videojs-contrib-media-sources/pull/71

However, updating to webworkify 1.4 fixes issues of upgrading to babel 6.