### PR TITLE
Create a moving-average playlist selector

### DIFF
--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -1,0 +1,203 @@
+import Config from './config';
+import Playlist from './playlist';
+
+/**
+ * Returns the CSS value for the specified property on an element
+ * using `getComputedStyle`. Firefox has a long-standing issue where
+ * getComputedStyle() may return null when running in an iframe with
+ * `display: none`.
+ *
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
+ * @param {HTMLElement} el the htmlelement to work on
+ * @param {string} the proprety to get the style for
+ */
+const safeGetComputedStyle = function(el, property) {
+  let result;
+
+  if (!el) {
+    return '';
+  }
+
+  result = window.getComputedStyle(el);
+  if (!result) {
+    return '';
+  }
+
+  return result[property];
+};
+
+/**
+ * Resuable stable sort function
+ *
+ * @param {Playlists} array
+ * @param {Function} sortFn Different comparators
+ * @function stableSort
+ */
+const stableSort = function(array, sortFn) {
+  let newArray = array.slice();
+
+  array.sort(function(left, right) {
+    let cmp = sortFn(left, right);
+
+    if (cmp === 0) {
+      return newArray.indexOf(left) - newArray.indexOf(right);
+    }
+    return cmp;
+  });
+};
+
+/**
+ * A comparator function to sort two playlist object by bandwidth.
+ *
+ * @param {Object} left a media playlist object
+ * @param {Object} right a media playlist object
+ * @return {Number} Greater than zero if the bandwidth attribute of
+ * left is greater than the corresponding attribute of right. Less
+ * than zero if the bandwidth of right is greater than left and
+ * exactly zero if the two are equal.
+ */
+export const comparePlaylistBandwidth = function(left, right) {
+  let leftBandwidth;
+  let rightBandwidth;
+
+  if (left.attributes && left.attributes.BANDWIDTH) {
+    leftBandwidth = left.attributes.BANDWIDTH;
+  }
+  leftBandwidth = leftBandwidth || window.Number.MAX_VALUE;
+  if (right.attributes && right.attributes.BANDWIDTH) {
+    rightBandwidth = right.attributes.BANDWIDTH;
+  }
+  rightBandwidth = rightBandwidth || window.Number.MAX_VALUE;
+
+  return leftBandwidth - rightBandwidth;
+};
+
+/**
+ * A comparator function to sort two playlist object by resolution (width).
+ * @param {Object} left a media playlist object
+ * @param {Object} right a media playlist object
+ * @return {Number} Greater than zero if the resolution.width attribute of
+ * left is greater than the corresponding attribute of right. Less
+ * than zero if the resolution.width of right is greater than left and
+ * exactly zero if the two are equal.
+ */
+export const comparePlaylistResolution = function(left, right) {
+  let leftWidth;
+  let rightWidth;
+
+  if (left.attributes &&
+      left.attributes.RESOLUTION &&
+      left.attributes.RESOLUTION.width) {
+    leftWidth = left.attributes.RESOLUTION.width;
+  }
+
+  leftWidth = leftWidth || window.Number.MAX_VALUE;
+
+  if (right.attributes &&
+      right.attributes.RESOLUTION &&
+      right.attributes.RESOLUTION.width) {
+    rightWidth = right.attributes.RESOLUTION.width;
+  }
+
+  rightWidth = rightWidth || window.Number.MAX_VALUE;
+
+  // NOTE - Fallback to bandwidth sort as appropriate in cases where multiple renditions
+  // have the same media dimensions/ resolution
+  if (leftWidth === rightWidth &&
+      left.attributes.BANDWIDTH &&
+      right.attributes.BANDWIDTH) {
+    return left.attributes.BANDWIDTH - right.attributes.BANDWIDTH;
+  }
+  return leftWidth - rightWidth;
+};
+
+/**
+ * Chooses the appropriate media playlist based on the current
+ * bandwidth estimate and the player size.
+ *
+ * @return {Playlist} the highest bitrate playlist less than the currently detected
+ * bandwidth, accounting for some amount of bandwidth variance
+ */
+export const STANDARD_PLAYLIST_SELECTOR = function() {
+  let sortedPlaylists = this.playlists.master.playlists.slice();
+  let bandwidthPlaylists = [];
+  let bandwidthBestVariant;
+  let resolutionPlusOne;
+  let resolutionBestVariant;
+  let width;
+  let height;
+  let systemBandwidth;
+  let haveResolution;
+  let resolutionPlusOneList = [];
+  let resolutionPlusOneSmallest = [];
+  let resolutionBestVariantList = [];
+
+  stableSort(sortedPlaylists, comparePlaylistBandwidth);
+
+  // filter out any playlists that have been excluded due to
+  // incompatible configurations or playback errors
+  sortedPlaylists = sortedPlaylists.filter(Playlist.isEnabled);
+  // filter out any variant that has greater effective bitrate
+  // than the current estimated bandwidth
+  systemBandwidth = this.systemBandwidth;
+  bandwidthPlaylists = sortedPlaylists.filter(function(elem) {
+    return elem.attributes &&
+           elem.attributes.BANDWIDTH &&
+           elem.attributes.BANDWIDTH * Config.BANDWIDTH_VARIANCE < systemBandwidth;
+  });
+
+  // get all of the renditions with the same (highest) bandwidth
+  // and then taking the very first element
+  bandwidthBestVariant = bandwidthPlaylists.filter(function(elem) {
+    return elem.attributes.BANDWIDTH === bandwidthPlaylists[bandwidthPlaylists.length - 1].attributes.BANDWIDTH;
+  })[0];
+
+  // sort variants by resolution
+  stableSort(bandwidthPlaylists, comparePlaylistResolution);
+
+  width = parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10);
+  height = parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10);
+
+  // filter out playlists without resolution information
+  haveResolution = bandwidthPlaylists.filter(function(elem) {
+    return elem.attributes &&
+           elem.attributes.RESOLUTION &&
+           elem.attributes.RESOLUTION.width &&
+           elem.attributes.RESOLUTION.height;
+  });
+
+  // if we have the exact resolution as the player use it
+  resolutionBestVariantList = haveResolution.filter(function(elem) {
+    return elem.attributes.RESOLUTION.width === width &&
+           elem.attributes.RESOLUTION.height === height;
+  });
+  // ensure that we pick the highest bandwidth variant that have exact resolution
+  resolutionBestVariant = resolutionBestVariantList.filter(function(elem) {
+    return elem.attributes.BANDWIDTH === resolutionBestVariantList[resolutionBestVariantList.length - 1].attributes.BANDWIDTH;
+  })[0];
+
+  // find the smallest variant that is larger than the player
+  // if there is no match of exact resolution
+  if (!resolutionBestVariant) {
+    resolutionPlusOneList = haveResolution.filter(function(elem) {
+      return elem.attributes.RESOLUTION.width > width ||
+             elem.attributes.RESOLUTION.height > height;
+    });
+    // find all the variants have the same smallest resolution
+    resolutionPlusOneSmallest = resolutionPlusOneList.filter(function(elem) {
+      return elem.attributes.RESOLUTION.width === resolutionPlusOneList[0].attributes.RESOLUTION.width &&
+             elem.attributes.RESOLUTION.height === resolutionPlusOneList[0].attributes.RESOLUTION.height;
+    });
+    // ensure that we also pick the highest bandwidth variant that
+    // is just-larger-than the video player
+    resolutionPlusOne = resolutionPlusOneSmallest.filter(function(elem) {
+      return elem.attributes.BANDWIDTH === resolutionPlusOneSmallest[resolutionPlusOneSmallest.length - 1].attributes.BANDWIDTH;
+    })[0];
+  }
+
+  // fallback chain of variants
+  return resolutionPlusOne ||
+    resolutionBestVariant ||
+    bandwidthBestVariant ||
+    sortedPlaylists[0];
+};

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -19,6 +19,7 @@ import renditionSelectionMixin from './rendition-mixin';
 import window from 'global/window';
 import PlaybackWatcher from './playback-watcher';
 import reloadSourceOnError from './reload-source-on-error';
+import { STANDARD_PLAYLIST_SELECTOR, comparePlaylistBandwidth, comparePlaylistResolution } from './playlist-selectors.js';
 
 const Hls = {
   PlaylistLoader,
@@ -27,6 +28,11 @@ const Hls = {
   AsyncStream,
   decrypt,
   utils,
+
+  STANDARD_PLAYLIST_SELECTOR,
+  comparePlaylistBandwidth,
+  comparePlaylistResolution,
+
   xhr: xhrFactory()
 };
 
@@ -67,31 +73,6 @@ Object.defineProperty(Hls, 'BANDWIDTH_VARIANCE', {
 });
 
 /**
- * Returns the CSS value for the specified property on an element
- * using `getComputedStyle`. Firefox has a long-standing issue where
- * getComputedStyle() may return null when running in an iframe with
- * `display: none`.
- *
- * @see https://bugzilla.mozilla.org/show_bug.cgi?id=548397
- * @param {HTMLElement} el the htmlelement to work on
- * @param {string} the proprety to get the style for
- */
-const safeGetComputedStyle = function(el, property) {
-  let result;
-
-  if (!el) {
-    return '';
-  }
-
-  result = window.getComputedStyle(el);
-  if (!result) {
-    return '';
-  }
-
-  return result[property];
-};
-
-/**
  * Updates the selectedIndex of the QualityLevelList when a mediachange happens in hls.
  *
  * @param {QualityLevelList} qualityLevels The QualityLevelList to update.
@@ -128,117 +109,6 @@ const handleHlsLoadedMetadata = function(qualityLevels, hls) {
     qualityLevels.addQualityLevel(rep);
   });
   handleHlsMediaChange(qualityLevels, hls.playlists);
-};
-
-/**
- * Resuable stable sort function
- *
- * @param {Playlists} array
- * @param {Function} sortFn Different comparators
- * @function stableSort
- */
-const stableSort = function(array, sortFn) {
-  let newArray = array.slice();
-
-  array.sort(function(left, right) {
-    let cmp = sortFn(left, right);
-
-    if (cmp === 0) {
-      return newArray.indexOf(left) - newArray.indexOf(right);
-    }
-    return cmp;
-  });
-};
-
-/**
- * Chooses the appropriate media playlist based on the current
- * bandwidth estimate and the player size.
- *
- * @return {Playlist} the highest bitrate playlist less than the currently detected
- * bandwidth, accounting for some amount of bandwidth variance
- */
-Hls.STANDARD_PLAYLIST_SELECTOR = function() {
-  let sortedPlaylists = this.playlists.master.playlists.slice();
-  let bandwidthPlaylists = [];
-  let bandwidthBestVariant;
-  let resolutionPlusOne;
-  let resolutionBestVariant;
-  let width;
-  let height;
-  let systemBandwidth;
-  let haveResolution;
-  let resolutionPlusOneList = [];
-  let resolutionPlusOneSmallest = [];
-  let resolutionBestVariantList = [];
-
-  stableSort(sortedPlaylists, Hls.comparePlaylistBandwidth);
-
-  // filter out any playlists that have been excluded due to
-  // incompatible configurations or playback errors
-  sortedPlaylists = sortedPlaylists.filter(Playlist.isEnabled);
-  // filter out any variant that has greater effective bitrate
-  // than the current estimated bandwidth
-  systemBandwidth = this.systemBandwidth;
-  bandwidthPlaylists = sortedPlaylists.filter(function(elem) {
-    return elem.attributes &&
-           elem.attributes.BANDWIDTH &&
-           elem.attributes.BANDWIDTH * Config.BANDWIDTH_VARIANCE < systemBandwidth;
-  });
-
-  // get all of the renditions with the same (highest) bandwidth
-  // and then taking the very first element
-  bandwidthBestVariant = bandwidthPlaylists.filter(function(elem) {
-    return elem.attributes.BANDWIDTH === bandwidthPlaylists[bandwidthPlaylists.length - 1].attributes.BANDWIDTH;
-  })[0];
-
-  // sort variants by resolution
-  stableSort(bandwidthPlaylists, Hls.comparePlaylistResolution);
-
-  width = parseInt(safeGetComputedStyle(this.tech_.el(), 'width'), 10);
-  height = parseInt(safeGetComputedStyle(this.tech_.el(), 'height'), 10);
-
-  // filter out playlists without resolution information
-  haveResolution = bandwidthPlaylists.filter(function(elem) {
-    return elem.attributes &&
-           elem.attributes.RESOLUTION &&
-           elem.attributes.RESOLUTION.width &&
-           elem.attributes.RESOLUTION.height;
-  });
-
-  // if we have the exact resolution as the player use it
-  resolutionBestVariantList = haveResolution.filter(function(elem) {
-    return elem.attributes.RESOLUTION.width === width &&
-           elem.attributes.RESOLUTION.height === height;
-  });
-  // ensure that we pick the highest bandwidth variant that have exact resolution
-  resolutionBestVariant = resolutionBestVariantList.filter(function(elem) {
-    return elem.attributes.BANDWIDTH === resolutionBestVariantList[resolutionBestVariantList.length - 1].attributes.BANDWIDTH;
-  })[0];
-
-  // find the smallest variant that is larger than the player
-  // if there is no match of exact resolution
-  if (!resolutionBestVariant) {
-    resolutionPlusOneList = haveResolution.filter(function(elem) {
-      return elem.attributes.RESOLUTION.width > width ||
-             elem.attributes.RESOLUTION.height > height;
-    });
-    // find all the variants have the same smallest resolution
-    resolutionPlusOneSmallest = resolutionPlusOneList.filter(function(elem) {
-      return elem.attributes.RESOLUTION.width === resolutionPlusOneList[0].attributes.RESOLUTION.width &&
-             elem.attributes.RESOLUTION.height === resolutionPlusOneList[0].attributes.RESOLUTION.height;
-    });
-    // ensure that we also pick the highest bandwidth variant that
-    // is just-larger-than the video player
-    resolutionPlusOne = resolutionPlusOneSmallest.filter(function(elem) {
-      return elem.attributes.BANDWIDTH === resolutionPlusOneSmallest[resolutionPlusOneSmallest.length - 1].attributes.BANDWIDTH;
-    })[0];
-  }
-
-  // fallback chain of variants
-  return resolutionPlusOne ||
-    resolutionBestVariant ||
-    bandwidthBestVariant ||
-    sortedPlaylists[0];
 };
 
 // HLS is a source handler, not a tech. Make sure attempts to use it
@@ -726,71 +596,6 @@ const HlsSourceHandler = function(mode) {
       return '';
     }
   };
-};
-
-/**
- * A comparator function to sort two playlist object by bandwidth.
- *
- * @param {Object} left a media playlist object
- * @param {Object} right a media playlist object
- * @return {Number} Greater than zero if the bandwidth attribute of
- * left is greater than the corresponding attribute of right. Less
- * than zero if the bandwidth of right is greater than left and
- * exactly zero if the two are equal.
- */
-Hls.comparePlaylistBandwidth = function(left, right) {
-  let leftBandwidth;
-  let rightBandwidth;
-
-  if (left.attributes && left.attributes.BANDWIDTH) {
-    leftBandwidth = left.attributes.BANDWIDTH;
-  }
-  leftBandwidth = leftBandwidth || window.Number.MAX_VALUE;
-  if (right.attributes && right.attributes.BANDWIDTH) {
-    rightBandwidth = right.attributes.BANDWIDTH;
-  }
-  rightBandwidth = rightBandwidth || window.Number.MAX_VALUE;
-
-  return leftBandwidth - rightBandwidth;
-};
-
-/**
- * A comparator function to sort two playlist object by resolution (width).
- * @param {Object} left a media playlist object
- * @param {Object} right a media playlist object
- * @return {Number} Greater than zero if the resolution.width attribute of
- * left is greater than the corresponding attribute of right. Less
- * than zero if the resolution.width of right is greater than left and
- * exactly zero if the two are equal.
- */
-Hls.comparePlaylistResolution = function(left, right) {
-  let leftWidth;
-  let rightWidth;
-
-  if (left.attributes &&
-      left.attributes.RESOLUTION &&
-      left.attributes.RESOLUTION.width) {
-    leftWidth = left.attributes.RESOLUTION.width;
-  }
-
-  leftWidth = leftWidth || window.Number.MAX_VALUE;
-
-  if (right.attributes &&
-      right.attributes.RESOLUTION &&
-      right.attributes.RESOLUTION.width) {
-    rightWidth = right.attributes.RESOLUTION.width;
-  }
-
-  rightWidth = rightWidth || window.Number.MAX_VALUE;
-
-  // NOTE - Fallback to bandwidth sort as appropriate in cases where multiple renditions
-  // have the same media dimensions/ resolution
-  if (leftWidth === rightWidth &&
-      left.attributes.BANDWIDTH &&
-      right.attributes.BANDWIDTH) {
-    return left.attributes.BANDWIDTH - right.attributes.BANDWIDTH;
-  }
-  return leftWidth - rightWidth;
 };
 
 HlsSourceHandler.canPlayType = function(type) {

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -19,7 +19,7 @@ import renditionSelectionMixin from './rendition-mixin';
 import window from 'global/window';
 import PlaybackWatcher from './playback-watcher';
 import reloadSourceOnError from './reload-source-on-error';
-import { STANDARD_PLAYLIST_SELECTOR, comparePlaylistBandwidth, comparePlaylistResolution } from './playlist-selectors.js';
+import { lastBandwidthSelector, comparePlaylistBandwidth, comparePlaylistResolution } from './playlist-selectors.js';
 
 const Hls = {
   PlaylistLoader,
@@ -29,7 +29,7 @@ const Hls = {
   decrypt,
   utils,
 
-  STANDARD_PLAYLIST_SELECTOR,
+  STANDARD_PLAYLIST_SELECTOR: lastBandwidthSelector,
   comparePlaylistBandwidth,
   comparePlaylistResolution,
 

--- a/test/playlist-selectors.test.js
+++ b/test/playlist-selectors.test.js
@@ -1,0 +1,52 @@
+import { module, test } from 'qunit';
+import { movingAverageBandwidthSelector } from '../src/playlist-selectors';
+import Config from '../src/config';
+
+const video = document.createElement('video');
+const hls = {
+  tech_: {
+    el() {
+      return video;
+    }
+  },
+  playlists: {
+    master: {
+      playlists: []
+    }
+  }
+};
+
+module('Playlist Selectors');
+
+test('Exponential moving average has a configurable decay parameter', function(assert) {
+  let playlist;
+  const instantAverage = movingAverageBandwidthSelector(1.0);
+
+  hls.playlists.master.playlists = [
+    { attributes: { BANDWIDTH: 1 } },
+    { attributes: { BANDWIDTH: 50 } },
+    { attributes: { BANDWIDTH: 100 } }
+  ];
+  hls.systemBandwidth = 50 * Config.BANDWIDTH_VARIANCE + 1;
+  playlist = instantAverage.bind(hls)();
+  assert.equal(playlist.attributes.BANDWIDTH, 50, 'selected the middle playlist');
+
+  hls.systemBandwidth = 100 * Config.BANDWIDTH_VARIANCE + 1;
+  playlist = instantAverage.bind(hls)();
+  assert.equal(playlist.attributes.BANDWIDTH, 100, 'selected the top playlist');
+
+  const fiftyPercentDecay = movingAverageBandwidthSelector(0.5);
+
+  hls.systemBandwidth = 100 * Config.BANDWIDTH_VARIANCE + 1;
+  playlist = fiftyPercentDecay.bind(hls)();
+  assert.equal(playlist.attributes.BANDWIDTH, 100, 'selected the top playlist');
+
+  // bandwidth = 0.5 * systemBandwidth + 0.5 * (100 * variance + 1)
+  // 50 * variance + 1 = 0.5 * (systemBandwidth + (100 * variance + 1))
+  // 2 * 50 * variance + 2 = systemBandwidth + (100 * variance + 1)
+  // 100 * variance + 2 - (100 * variance + 1) = systemBandwidth
+  // 1 = systemBandwidth
+  hls.systemBandwidth = 1;
+  playlist = fiftyPercentDecay.bind(hls)();
+  assert.equal(playlist.attributes.BANDWIDTH, 50, 'selected the middle playlist');
+});


### PR DESCRIPTION
## Description
- Define a variant of the standard playlist selector that calculates a moving average of bandwidth and uses that to select a playlist.
- Pull the basic playlist selector into a separate file so there's a shared place to build alternates.
