### PR TITLE
Allow overrideNative to be set as a player-level option

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -321,7 +321,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.seekable_ = videojs.createTimeRanges();
     this.hasPlayed_ = () => false;
 
-    this.syncController_ = new SyncController();
+    this.syncController_ = new SyncController(options);
     this.segmentMetadataTrack_ = tech.addRemoteTextTrack({
       kind: 'metadata',
       label: 'segment-metadata'
@@ -354,18 +354,18 @@ export class MasterPlaylistController extends videojs.EventTarget {
       new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
         segmentMetadataTrack: this.segmentMetadataTrack_,
         loaderType: 'main'
-      }));
+      }), options);
 
     // alternate audio track
     this.audioSegmentLoader_ =
       new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
         loaderType: 'audio'
-      }));
+      }), options);
 
     this.subtitleSegmentLoader_ =
       new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
         loaderType: 'vtt'
-      }));
+      }), options);
 
     this.setupSegmentLoaderListeners_();
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -329,7 +329,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     this.decrypter_ = worker(Decrypter);
 
-    let segmentLoaderOptions = {
+    const segmentLoaderSettings = {
       hls: this.hls_,
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
@@ -351,19 +351,19 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // setup segment loaders
     // combined audio/video or just video when alternate audio track is selected
     this.mainSegmentLoader_ =
-      new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
+      new SegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
         segmentMetadataTrack: this.segmentMetadataTrack_,
         loaderType: 'main'
       }), options);
 
     // alternate audio track
     this.audioSegmentLoader_ =
-      new SegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
+      new SegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
         loaderType: 'audio'
       }), options);
 
     this.subtitleSegmentLoader_ =
-      new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderOptions, {
+      new VTTSegmentLoader(videojs.mergeOptions(segmentLoaderSettings, {
         loaderType: 'vtt'
       }), options);
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -55,7 +55,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     super();
     // check pre-conditions
     if (!settings) {
-      throw new TypeError('Initialization options are required');
+      throw new TypeError('Initialization settings are required');
     }
     if (typeof settings.currentTime !== 'function') {
       throw new TypeError('No currentTime getter specified');

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -51,20 +51,18 @@ const detectEndOfStream = function(playlist, mediaSource, segmentIndex) {
  * @extends videojs.EventTarget
  */
 export default class SegmentLoader extends videojs.EventTarget {
-  constructor(options) {
+  constructor(settings, options) {
     super();
     // check pre-conditions
-    if (!options) {
+    if (!settings) {
       throw new TypeError('Initialization options are required');
     }
-    if (typeof options.currentTime !== 'function') {
+    if (typeof settings.currentTime !== 'function') {
       throw new TypeError('No currentTime getter specified');
     }
-    if (!options.mediaSource) {
+    if (!settings.mediaSource) {
       throw new TypeError('No MediaSource specified');
     }
-    let settings = videojs.mergeOptions(videojs.options.hls, options);
-
     // public properties
     this.state = 'INIT';
     this.bandwidth = settings.bandwidth;
@@ -113,7 +111,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     // ...for determining the fetch location
     this.fetchAtBuffer_ = false;
 
-    if (settings.debug) {
+    if (options.debug) {
       this.logger_ = videojs.log.bind(videojs, 'segment-loader', this.loaderType_, '->');
     }
   }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -51,7 +51,7 @@ const detectEndOfStream = function(playlist, mediaSource, segmentIndex) {
  * @extends videojs.EventTarget
  */
 export default class SegmentLoader extends videojs.EventTarget {
-  constructor(settings, options) {
+  constructor(settings, options = {}) {
     super();
     // check pre-conditions
     if (!settings) {

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -136,7 +136,7 @@ export const syncPointStrategies = [
 ];
 
 export default class SyncController extends videojs.EventTarget {
-  constructor(options) {
+  constructor(options = {}) {
     super();
     // Segment Loader state variables...
     // ...for synching across variants
@@ -147,7 +147,7 @@ export default class SyncController extends videojs.EventTarget {
     this.discontinuities = [];
     this.datetimeToDisplayTime = null;
 
-    if (options && options.debug) {
+    if (options.debug) {
       this.logger_ = videojs.log.bind(videojs, 'sync-controller ->');
     }
   }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -136,7 +136,7 @@ export const syncPointStrategies = [
 ];
 
 export default class SyncController extends videojs.EventTarget {
-  constructor() {
+  constructor(options) {
     super();
     // Segment Loader state variables...
     // ...for synching across variants
@@ -147,7 +147,7 @@ export default class SyncController extends videojs.EventTarget {
     this.discontinuities = [];
     this.datetimeToDisplayTime = null;
 
-    if (videojs.options.hls && videojs.options.hls.debug) {
+    if (options && options.debug) {
       this.logger_ = videojs.log.bind(videojs, 'sync-controller ->');
     }
   }

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -566,20 +566,20 @@ class HlsHandler extends Component {
  */
 const HlsSourceHandler = function(mode) {
   return {
-    canHandleSource(srcObj, options) {
-      let settings = videojs.mergeOptions(videojs.options, options);
+    canHandleSource(srcObj, options = {}) {
+      let localOptions = videojs.mergeOptions(videojs.options, options);
 
       // this forces video.js to skip this tech/mode if its not the one we have been
       // overriden to use, by returing that we cannot handle the source.
-      if (settings.hls &&
-          settings.hls.mode &&
-          settings.hls.mode !== mode) {
+      if (localOptions.hls &&
+          localOptions.hls.mode &&
+          localOptions.hls.mode !== mode) {
         return false;
       }
-      return HlsSourceHandler.canPlayType(srcObj.type, settings);
+      return HlsSourceHandler.canPlayType(srcObj.type, localOptions);
     },
-    handleSource(source, tech, options) {
-      let settings = videojs.mergeOptions(videojs.options, options, {hls: {mode}});
+    handleSource(source, tech, options = {}) {
+      let localOptions = videojs.mergeOptions(videojs.options, options, {hls: {mode}});
 
       if (mode === 'flash') {
         // We need to trigger this asynchronously to give others the chance
@@ -589,16 +589,16 @@ const HlsSourceHandler = function(mode) {
         }, 1);
       }
 
-      tech.hls = new HlsHandler(source, tech, settings);
+      tech.hls = new HlsHandler(source, tech, localOptions);
       tech.hls.xhr = xhrFactory();
 
       tech.hls.src(source.src);
       return tech.hls;
     },
-    canPlayType(type, options) {
-      let settings = videojs.mergeOptions(videojs.options, options);
+    canPlayType(type, options = {}) {
+      let localOptions = videojs.mergeOptions(videojs.options, options);
 
-      if (HlsSourceHandler.canPlayType(type, settings)) {
+      if (HlsSourceHandler.canPlayType(type, localOptions)) {
         return 'maybe';
       }
       return '';

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -214,22 +214,22 @@ class HlsHandler extends Component {
       }
     }
 
-    // overriding native HLS only works if audio tracks have been emulated
-    // error early if we're misconfigured:
-    if (videojs.options.hls.overrideNative &&
-        (tech.featuresNativeVideoTracks || tech.featuresNativeAudioTracks)) {
-      throw new Error('Overriding native HLS requires emulated tracks. ' +
-                      'See https://git.io/vMpjB');
-    }
-
     this.tech_ = tech;
     this.source_ = source;
     this.stats = {};
     this.ignoreNextSeekingEvent_ = false;
 
     // handle global & Source Handler level options
-    this.options_ = videojs.mergeOptions(videojs.options.hls || {}, options.hls);
+    this.options_ = options.hls;
     this.setOptions_();
+
+    // overriding native HLS only works if audio tracks have been emulated
+    // error early if we're misconfigured:
+    if (this.options_.overrideNative &&
+        (tech.featuresNativeVideoTracks || tech.featuresNativeAudioTracks)) {
+      throw new Error('Overriding native HLS requires emulated tracks. ' +
+                      'See https://git.io/vMpjB');
+    }
 
     // listen for fullscreenchange events for this player so that we
     // can adjust our quality selection quickly
@@ -569,17 +569,21 @@ class HlsHandler extends Component {
  */
 const HlsSourceHandler = function(mode) {
   return {
-    canHandleSource(srcObj) {
+    canHandleSource(srcObj, options) {
+      let settings = videojs.mergeOptions(videojs.options, options);
+
       // this forces video.js to skip this tech/mode if its not the one we have been
       // overriden to use, by returing that we cannot handle the source.
-      if (videojs.options.hls &&
-          videojs.options.hls.mode &&
-          videojs.options.hls.mode !== mode) {
+      if (settings.hls &&
+          settings.hls.mode &&
+          settings.hls.mode !== mode) {
         return false;
       }
-      return HlsSourceHandler.canPlayType(srcObj.type);
+      return HlsSourceHandler.canPlayType(srcObj.type, settings);
     },
     handleSource(source, tech, options) {
+      let settings = videojs.mergeOptions(videojs.options, options, {hls: {mode}});
+
       if (mode === 'flash') {
         // We need to trigger this asynchronously to give others the chance
         // to bind to the event when a source is set at player creation
@@ -588,16 +592,16 @@ const HlsSourceHandler = function(mode) {
         }, 1);
       }
 
-      let settings = videojs.mergeOptions(options, {hls: {mode}});
-
       tech.hls = new HlsHandler(source, tech, settings);
       tech.hls.xhr = xhrFactory();
 
       tech.hls.src(source.src);
       return tech.hls;
     },
-    canPlayType(type) {
-      if (HlsSourceHandler.canPlayType(type)) {
+    canPlayType(type, options) {
+      let settings = videojs.mergeOptions(videojs.options, options);
+
+      if (HlsSourceHandler.canPlayType(type, settings)) {
         return 'maybe';
       }
       return '';
@@ -605,7 +609,7 @@ const HlsSourceHandler = function(mode) {
   };
 };
 
-HlsSourceHandler.canPlayType = function(type) {
+HlsSourceHandler.canPlayType = function(type, options) {
   // No support for IE 10 or below
   if (videojs.browser.IE_VERSION && videojs.browser.IE_VERSION <= 10) {
     return false;
@@ -614,7 +618,7 @@ HlsSourceHandler.canPlayType = function(type) {
   let mpegurlRE = /^(audio|video|application)\/(x-|vnd\.apple\.)?mpegurl/i;
 
   // favor native HLS support if it's available
-  if (!videojs.options.hls.overrideNative && Hls.supportsNativeHls) {
+  if (!options.hls.overrideNative && Hls.supportsNativeHls) {
     return false;
   }
   return mpegurlRE.test(type);

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -197,7 +197,7 @@ const Component = videojs.getComponent('Component');
  */
 class HlsHandler extends Component {
   constructor(source, tech, options) {
-    super(tech);
+    super(tech, options.hls);
 
     // tech.player() is deprecated but setup a reference to HLS for
     // backwards-compatibility
@@ -218,9 +218,6 @@ class HlsHandler extends Component {
     this.source_ = source;
     this.stats = {};
     this.ignoreNextSeekingEvent_ = false;
-
-    // handle global & Source Handler level options
-    this.options_ = options.hls;
     this.setOptions_();
 
     // overriding native HLS only works if audio tracks have been emulated

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -23,8 +23,8 @@ const uintToString = function(uintArray) {
  * @extends videojs.EventTarget
  */
 export default class VTTSegmentLoader extends SegmentLoader {
-  constructor(options) {
-    super(options);
+  constructor(settings, options) {
+    super(settings, options);
 
     // SegmentLoader requires a MediaSource be specified or it will throw an error;
     // however, VTTSegmentLoader has no need of a media source, so delete the reference

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -23,7 +23,7 @@ const uintToString = function(uintArray) {
  * @extends videojs.EventTarget
  */
 export default class VTTSegmentLoader extends SegmentLoader {
-  constructor(settings, options) {
+  constructor(settings, options = {}) {
     super(settings, options);
 
     // SegmentLoader requires a MediaSource be specified or it will throw an error;

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -87,7 +87,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
     hooks.beforeEach(function(assert) {
       // Assume this module is nested and the parent module uses CommonHooks.beforeEach
 
-      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderSettings));
+      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderSettings), {});
 
       loaderBeforeEach(loader);
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -43,17 +43,17 @@ export const LoaderCommonHooks = {
 };
 
 /**
- * Returns a settings object containing the custom options provided merged with defaults
+ * Returns a settings object containing the custom settings provided merged with defaults
  * for use in constructing a segment loader. This function should be called with the QUnit
  * test environment the loader will be constructed in for proper this reference.
  *
- * @param {Object} options
- *        custom options for the loader
+ * @param {Object} settings
+ *        custom settings for the loader
  * @return {Object}
- *         Options object contiaing custom options merged with defaults
+ *         settings object contiaing custom settings merged with defaults
  */
-export const LoaderCommonSettings = function(options) {
-  let settings = {
+export const LoaderCommonSettings = function(settings) {
+  let commonSettings = {
     hls: this.fakeHls,
     currentTime: () => this.currentTime,
     seekable: () => this.seekable,
@@ -65,7 +65,7 @@ export const LoaderCommonSettings = function(options) {
     decrypter: this.decrypter
   };
 
-  return videojs.mergeOptions(settings, options);
+  return videojs.mergeOptions(commonSettings, settings);
 };
 
 /**
@@ -73,15 +73,15 @@ export const LoaderCommonSettings = function(options) {
  * Currently only two types, SegmentLoader and VTTSegmentLoader.
  *
  * @param {function(new:SegmentLoader|VTTLoader, Object)} LoaderConstructor
- *        Constructor for segment loader. Takes one parameter, an options object
- * @param {Object} loaderOptions
- *        Custom options to merge with defaults for the provided loader constructor
+ *        Constructor for segment loader. Takes one parameter, an settings object
+ * @param {Object} loaderSettings
+ *        Custom settings to merge with defaults for the provided loader constructor
  * @param {function(SegmentLoader|VTTLoader)} loaderBeforeEach
  *        Function to be run in the beforeEach after loader creation. Takes one parameter,
  *        the loader for custom modifications to the loader object.
  */
 export const LoaderCommonFactory = (LoaderConstructor,
-                                    loaderOptions,
+                                    loaderSettings,
                                     loaderBeforeEach) => {
   let loader;
 
@@ -89,7 +89,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
     hooks.beforeEach(function(assert) {
       // Assume this module is nested and the parent module uses CommonHooks.beforeEach
 
-      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderOptions), {});
+      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderSettings));
 
       loaderBeforeEach(loader);
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -89,7 +89,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
     hooks.beforeEach(function(assert) {
       // Assume this module is nested and the parent module uses CommonHooks.beforeEach
 
-      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderOptions));
+      loader = new LoaderConstructor(LoaderCommonSettings.call(this, loaderOptions), {});
 
       loaderBeforeEach(loader);
 

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -50,10 +50,10 @@ export const LoaderCommonHooks = {
  * @param {Object} settings
  *        custom settings for the loader
  * @return {Object}
- *         settings object contiaing custom settings merged with defaults
+ *         Settings object containing custom settings merged with defaults
  */
 export const LoaderCommonSettings = function(settings) {
-  let commonSettings = {
+  return videojs.mergeOptions({
     hls: this.fakeHls,
     currentTime: () => this.currentTime,
     seekable: () => this.seekable,
@@ -63,9 +63,7 @@ export const LoaderCommonSettings = function(settings) {
     mediaSource: this.mediaSource,
     syncController: this.syncController,
     decrypter: this.decrypter
-  };
-
-  return videojs.mergeOptions(commonSettings, settings);
+  }, settings);
 };
 
 /**
@@ -73,7 +71,7 @@ export const LoaderCommonSettings = function(settings) {
  * Currently only two types, SegmentLoader and VTTSegmentLoader.
  *
  * @param {function(new:SegmentLoader|VTTLoader, Object)} LoaderConstructor
- *        Constructor for segment loader. Takes one parameter, an settings object
+ *        Constructor for segment loader. Takes one parameter, a settings object
  * @param {Object} loaderSettings
  *        Custom settings to merge with defaults for the provided loader constructor
  * @param {function(SegmentLoader|VTTLoader)} loaderBeforeEach

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -40,7 +40,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'main',
         segmentMetadataTrack: this.segmentMetadataTrack
-      }), {});
+      }));
 
       // shim updateend trigger to be a noop if the loader has no media source
       this.updateend = function() {

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -40,7 +40,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       loader = new SegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'main',
         segmentMetadataTrack: this.segmentMetadataTrack
-      }));
+      }), {});
 
       // shim updateend trigger to be a noop if the loader has no media source
       this.updateend = function() {

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1768,7 +1768,33 @@ QUnit.test('has no effect if native HLS is available', function(assert) {
   player.dispose();
 });
 
-QUnit.test('loads if native HLS is available and override is set', function(assert) {
+QUnit.test('loads if native HLS is available and override is set globally', function(assert) {
+  let player;
+
+  Hls.supportsNativeHls = true;
+  player = createPlayer({html5: {hls: {overrideNative: true}}});
+  player.tech_.featuresNativeVideoTracks = true;
+  assert.throws(function() {
+    player.src({
+      src: 'http://example.com/manifest/master.m3u8',
+      type: 'application/x-mpegURL'
+    });
+  }, 'errors if native tracks are enabled');
+  player.dispose();
+
+  player = createPlayer({html5: {hls: {overrideNative: true}}});
+  player.tech_.featuresNativeVideoTracks = false;
+  player.tech_.featuresNativeAudioTracks = false;
+  player.src({
+    src: 'http://example.com/manifest/master.m3u8',
+    type: 'application/x-mpegURL'
+  });
+
+  assert.ok(player.tech_.hls, 'did load hls tech');
+  player.dispose();
+});
+
+QUnit.test('loads if native HLS is available and override is set locally', function(assert) {
   videojs.options.hls.overrideNative = true;
   let player;
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1768,7 +1768,7 @@ QUnit.test('has no effect if native HLS is available', function(assert) {
   player.dispose();
 });
 
-QUnit.test('loads if native HLS is available and override is set globally', function(assert) {
+QUnit.test('loads if native HLS is available and override is set locally', function(assert) {
   let player;
 
   Hls.supportsNativeHls = true;
@@ -1794,7 +1794,7 @@ QUnit.test('loads if native HLS is available and override is set globally', func
   player.dispose();
 });
 
-QUnit.test('loads if native HLS is available and override is set locally', function(assert) {
+QUnit.test('loads if native HLS is available and override is set globally', function(assert) {
   videojs.options.hls.overrideNative = true;
   let player;
 

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -57,7 +57,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
     nestedHooks.beforeEach(function(assert) {
       loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'vtt'
-      }), {});
+      }));
 
       this.track = new MockTextTrack();
     });

--- a/test/vtt-segment-loader.test.js
+++ b/test/vtt-segment-loader.test.js
@@ -57,7 +57,7 @@ QUnit.module('VTTSegmentLoader', function(hooks) {
     nestedHooks.beforeEach(function(assert) {
       loader = new VTTSegmentLoader(LoaderCommonSettings.call(this, {
         loaderType: 'vtt'
-      }));
+      }), {});
 
       this.track = new MockTextTrack();
     });


### PR DESCRIPTION
## Description
Right now, `overrideNative` must be set globally on the `videojs.options` object. This is especially dangerous because of https://github.com/videojs/video.js/issues/4391. This PR lets set the `overrideNative` property as a player option so that you never touch the global videojs options again (which is probably for the best)!

## Specific Changes proposed
* Merge options earlier so that we can use them in the `canPlayType` and `canHandleSource` functions

