### PR TITLE
don't crash when segment metadata cues can't be created

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -43,6 +43,8 @@ const detectEndOfStream = function(playlist, mediaSource, segmentIndex) {
     appendedLastSegment;
 };
 
+const finite = (num) => typeof num === 'number' && isFinite(num);
+
 /**
  * An object that manages segment loading and appending.
  *
@@ -1087,7 +1089,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     const end = segment.end;
 
     // Do not try adding the cue if the start and end times are invalid.
-    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    if (!finite(start) || !finite(end)) {
       return;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1086,6 +1086,11 @@ export default class SegmentLoader extends videojs.EventTarget {
     const start = segment.start;
     const end = segment.end;
 
+    // Do not try adding the cue if the start and end times are invalid.
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      return;
+    }
+
     removeCuesFromTrack(start, end, this.segmentMetadataTrack_);
 
     const Cue = window.WebKitDataCue || window.VTTCue;

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -253,7 +253,7 @@ QUnit.module('SegmentLoader', function(hooks) {
                'as they are buffered',
       function(assert) {
         const track = loader.segmentMetadataTrack_;
-        let playlist = playlistWithDuration(40);
+        let playlist = playlistWithDuration(50);
         let probeResponse;
         let expectedCue;
 
@@ -328,6 +328,7 @@ QUnit.module('SegmentLoader', function(hooks) {
         this.requests[0].response = new Uint8Array(10).buffer;
         this.requests.shift().respond(200, null, '');
         this.updateend();
+        this.clock.tick(1);
         expectedCue = {
           uri: '3.ts',
           timeline: 0,
@@ -340,9 +341,18 @@ QUnit.module('SegmentLoader', function(hooks) {
         assert.deepEqual(track.cues[2].value, expectedCue,
           'added correct segment info to cue');
 
+        // does not add cue for invalid segment timing info
+        probeResponse = { start: 30, end: void 0 };
+        this.requests[0].response = new Uint8Array(10).buffer;
+        this.requests.shift().respond(200, null, '');
+        this.updateend();
+        this.clock.tick(1);
+
+        assert.equal(track.cues.length, 3, 'no cue added');
+
         // verify stats
-        assert.equal(loader.mediaBytesTransferred, 40, '40 bytes');
-        assert.equal(loader.mediaRequests, 4, '4 requests');
+        assert.equal(loader.mediaBytesTransferred, 50, '50 bytes');
+        assert.equal(loader.mediaRequests, 5, '5 requests');
       });
 
     QUnit.test('fires ended at the end of a playlist', function(assert) {


### PR DESCRIPTION
A bad segment might trip up our segment probe. When trying to create the metadata cue for that segment, the player can crash. We shouldn't disrupt playback for something non-essential to playback

#1165 