### PR TITLE
Add videojs-flash to demo page for video.js 6

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,7 @@ player.play();
       -->
 
     <script src="https://unpkg.com/video.js/dist/video.js"></script>
+    <script src="https://unpkg.com/videojs-flash/dist/videojs-flash.js"></script>
     <script src="https://unpkg.com/videojs-contrib-hls/dist/videojs-contrib-hls.js"></script>
 
     <!--


### PR DESCRIPTION
Video.js 6 does not come with the Flash tech by default, this adds the
tech to the demo page.

Closes #1050