### PR TITLE
fix: audio only playlists

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mux.js": "4.1.5",
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1",
-    "videojs-contrib-media-sources": "4.4.6",
+    "videojs-contrib-media-sources": "4.4.7",
     "webworkify": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
* Fix disabled audio for a single audio only source buffer [#152](https://github.com/videojs/videojs-contrib-media-sources/pull/152)
  * disable audio based on codec info when only one source buffer
  * allow audio only source buffer creation for flash