### PR TITLE
adding videojs 6 as a valid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "m3u8-parser": "2.1.0",
     "mux.js": "4.1.5",
     "url-toolkit": "1.0.9",
-    "video.js": "^5.19.1",
+    "video.js": "^5.19.1 || ^6.2.0",
     "videojs-contrib-media-sources": "4.4.7",
     "webworkify": "1.0.2"
   },


### PR DESCRIPTION
## Description
Adds Video.js 6 as a valid dependency version

## Specific Changes proposed
Adds v6.2.0 as a valid version in `package.json`

## Note:
The tests are still failing when run with Video.js 6, which will now be the default installed version.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
