### PR TITLE
[ABR] Smooth manual switching, Quality switch history, Map buffered quality by playhead position

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,24 +46,97 @@
     <li><a href="/examples">Browse Examples</a></li>
   </ul>
 
+  <select id="quality-picker"></select>
+
+  <p>
+    Current quality attributes:
+    <br>
+    <pre id="current-quality-attr"></pre>
+  </p>
+
+  <script src="/node_modules/jquery/dist/jquery.js"></script>
   <script src="/node_modules/video.js/dist/video.js"></script>
+  <script src="/node_modules/videojs-contrib-quality-levels/dist/videojs-contrib-quality-levels.js"></script>
   <script src="/dist/videojs-contrib-hls.js"></script>
   <script>
     (function(window, videojs) {
-      var player = window.player = videojs('videojs-contrib-hls-player');
+
+      var videojsHlsDemo = {
+        player: null,
+        url: null
+      };
+
+      var playerOptions = {
+        //
+      };
+
+      var player = videojs('videojs-contrib-hls-player', playerOptions);
 
       // hook up the video switcher
       var loadUrl = document.getElementById('load-url');
       var url = document.getElementById('url');
       loadUrl.addEventListener('submit', function(event) {
         event.preventDefault();
+        videojsHlsDemo.url = url.value;
         player.src({
           src: url.value,
           type: 'application/x-mpegURL'
         });
         return false;
       });
+
+      videojsHlsDemo.player = player;
+
+      window.videojsContribHlsDemo = videojsHlsDemo;
+
     }(window, window.videojs));
+  </script>
+
+  <script type="text/javascript">
+    
+      var videojsHlsDemo = window.videojsContribHlsDemo;
+      var player = window.videojsContribHlsDemo.player;
+
+      player.on('loadedmetadata', function() {
+
+        videojsHlsDemo.hlsHandler = player.tech_.hls;
+
+        var qualityLevels = player.qualityLevels()
+        for (var i = 0; i < qualityLevels.length; i++) {
+          var level = qualityLevels[i];
+          var description = level.width + ' x ' + level.height + ' - (' + level.bitrate + ' [bits/sec])';
+          $('#quality-picker')
+            .append('<option value="' + i + '">' + description + '</option>');
+        }
+
+        $('#quality-picker').change(function(e) {
+          // Disable ALL quality levels
+          // Enable ONLY selected quality level
+          var qualityLevels = player.qualityLevels()
+          for (var i = 0; i < qualityLevels.length; i++) {
+            var level = qualityLevels[i];
+            if (i === Number(e.target.value)) {
+              console.log('enabled:', level);
+              level.enabled = true;
+            } else {
+              level.enabled = false;
+            }
+          }
+        });
+
+      });
+
+      player.on('timeupdate', function() {
+        var hlsHandler = videojsHlsDemo.hlsHandler;
+        if (hlsHandler) {
+          var attr = hlsHandler.findRepresentationAttributesAtBufferPosition(player.currentTime());
+          if (attr) {
+            $('#current-quality-attr').html(JSON.stringify(attr, null, 2));
+          }
+        }
+
+      });
+
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <li><a href="/examples">Browse Examples</a></li>
   </ul>
 
-  <select id="quality-picker"></select>
+  Select variant playlist: <select id="quality-picker"></select>
 
   <p>
     Media attributes at playhead:
@@ -117,6 +117,9 @@
 
         videojsHlsDemo.hlsHandler = player.tech_.hls;
 
+        $('#quality-picker')
+          .append('<option value="-1">Auto</option>');
+
         var qualityLevels = player.qualityLevels()
         for (var i = 0; i < qualityLevels.length; i++) {
           var level = qualityLevels[i];
@@ -131,7 +134,7 @@
           var qualityLevels = player.qualityLevels()
           for (var i = 0; i < qualityLevels.length; i++) {
             var level = qualityLevels[i];
-            if (i === Number(e.target.value)) {
+            if (i === Number(e.target.value) || i === -1) {
               level.enabled = true;
             } else {
               level.enabled = false;

--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
       min-width: 450px;
       padding: 5px;
     }
+    #videojs-contrib-hls-player {
+      width:100%
+    }
+    #quality-graph {
+      width: 50%;
+    }
+    #current-quality-attr {
+      margin-left: 20px;
+    }
   </style>
 
 </head>
@@ -29,7 +38,7 @@
     <p>The video below is an <a href="https://developer.apple.com/library/ios/documentation/networkinginternet/conceptual/streamingmediaguide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40008332-CH1-SW1">HTTP Live Stream</a>. On desktop browsers other than Safari, the HLS plugin will polyfill support for the format on top of the video.js Flash tech.</p>
     <p>Due to security restrictions in Flash, you will have to load this page over HTTP(S) to see the example in action.</p>
   </div>
-  <video id="videojs-contrib-hls-player" class="video-js vjs-default-skin" controls>
+  <video id="videojs-contrib-hls-player" class="video-js vjs-default-skin vjs-big-play-centered" controls>
     <source src="https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8" type="application/x-mpegURL">
   </video>
 
@@ -46,14 +55,18 @@
     <li><a href="/examples">Browse Examples</a></li>
   </ul>
 
-  Select variant playlist: <select id="quality-picker"></select>
-
   <p>
-    Media attributes at playhead:
-    <p><pre id="current-quality-attr">{}</pre></p>
+  Select variant playlist:
+    <p><select id="quality-picker"></select></p>
   </p>
 
   <p>
+    Attributes of media at played:
+    <p><pre id="current-quality-attr">{}</pre></p>
+  </p>
+
+  <p id="quality-graph-container">
+    Buffered media bitrate plot:
     <ul>
       <li>Trace 0: Recommended BANDWIDTHs of playlists selected</li>
       <li>Trace 1: Effective bitrates of segments loaded</li>
@@ -61,6 +74,12 @@
     <div id="quality-graph"></div>
   </p>
 
+  <p id="bandwidth-graph-container">
+    Estimated bandwidth / transaction progress plot:
+    <ul>
+    </ul>
+    <div id="bandwidth-graph"></div>
+  </p>
 
   <script src="https://cdn.plot.ly/plotly-1.28.3.min.js"></script>
   <script src="/node_modules/jquery/dist/jquery.js"></script>

--- a/index.html
+++ b/index.html
@@ -49,11 +49,20 @@
   <select id="quality-picker"></select>
 
   <p>
-    Current quality attributes:
-    <br>
-    <pre id="current-quality-attr"></pre>
+    Media attributes at playhead:
+    <p><pre id="current-quality-attr">{}</pre></p>
   </p>
 
+  <p>
+    <ul>
+      <li>Trace 0: Recommended BANDWIDTHs of playlists selected</li>
+      <li>Trace 1: Effective bitrates of segments loaded</li>
+    </ul>
+    <div id="quality-graph"></div>
+  </p>
+
+
+  <script src="https://cdn.plot.ly/plotly-1.28.3.min.js"></script>
   <script src="/node_modules/jquery/dist/jquery.js"></script>
   <script src="/node_modules/video.js/dist/video.js"></script>
   <script src="/node_modules/videojs-contrib-quality-levels/dist/videojs-contrib-quality-levels.js"></script>
@@ -63,14 +72,23 @@
 
       var videojsHlsDemo = {
         player: null,
-        url: null
+        url: null,
+        hlsHandler: null
+      };
+
+      var hlsOptions = {
+        debug: true,
+        smoothQualitySwitch: true,
+        disableImmediateQualityChange: true
       };
 
       var playerOptions = {
-        //
+        html5: {
+          hls: hlsOptions
+        }
       };
 
-      var player = videojs('videojs-contrib-hls-player', playerOptions);
+      var player = videojsHlsDemo.player = videojs('videojs-contrib-hls-player', playerOptions);
 
       // hook up the video switcher
       var loadUrl = document.getElementById('load-url');
@@ -84,8 +102,6 @@
         });
         return false;
       });
-
-      videojsHlsDemo.player = player;
 
       window.videojsContribHlsDemo = videojsHlsDemo;
 
@@ -116,7 +132,6 @@
           for (var i = 0; i < qualityLevels.length; i++) {
             var level = qualityLevels[i];
             if (i === Number(e.target.value)) {
-              console.log('enabled:', level);
               level.enabled = true;
             } else {
               level.enabled = false;
@@ -136,6 +151,58 @@
         }
 
       });
+
+      setInterval(function() {
+
+        var hlsHandler = videojsHlsDemo.hlsHandler;
+        if (hlsHandler) {
+          var bufferMap = hlsHandler.getMainBufferPayloadAttributesMap();
+
+          var startTimes = bufferMap.map(function(entry) {
+            return entry.startTime;
+          });
+          var bandwidths = bufferMap.map(function(entry) {
+            return entry.representationAttributes['BANDWIDTH'];
+          });
+          var effectiveBitrates = bufferMap.map(function(entry) {
+            return entry.effectiveBitrate;
+          });
+
+          var graphDiv = $('#quality-graph')[0];
+
+          if (!videojsHlsDemo.isPlotInitialized) {
+            Plotly.purge(graphDiv);
+            Plotly.newPlot(
+              graphDiv,
+              [],
+              {
+                title: 'Buffer state',
+                xaxis: {
+                  title: 'Time [s]'
+                },
+                yaxis: {
+                  title: 'Bitrate [b/s]',
+                }
+              }
+            );
+            videojsHlsDemo.isPlotInitialized = true;
+          }
+
+          videojsHlsDemo.isPlotFilled && Plotly.deleteTraces(graphDiv, 0);
+          videojsHlsDemo.isPlotFilled && Plotly.deleteTraces(graphDiv, 0);
+          Plotly.addTraces(
+            graphDiv,
+            [{
+              x: startTimes,
+              y: bandwidths
+            },{
+              x: startTimes,
+              y: effectiveBitrates
+            }]
+          );
+          videojsHlsDemo.isPlotFilled = true;
+        }
+      }, 1000);
 
   </script>
 </body>

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1141,6 +1141,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
     }
   }
 
+  smoothQualityChange_() {
+    let media = this.selectPlaylist();
+
+    if (media !== this.masterPlaylistLoader_.media()) {
+      this.masterPlaylistLoader_.media(media);
+    }
+  }
+
   /**
    * Begin playback.
    */

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -388,6 +388,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       time,
       media
     };
+
     this.switchPlaylistHistory_.push(switchPlaylistEntry);
   }
 

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -377,6 +377,18 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.masterPlaylistLoader_.load();
+
+    this.switchPlaylistHistory_ = [];
+  }
+
+  addToSwitchPlaylistHistory_(media, isFromQualityChangeFunction = false) {
+    const time = Date.now();
+    const switchPlaylistEntry = {
+      isFromQualityChangeFunction,
+      time,
+      media
+    };
+    this.switchPlaylistHistory_.push(switchPlaylistEntry);
   }
 
   /**
@@ -431,6 +443,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       if (!updatedPlaylist) {
         // select the initial variant
         this.initialMedia_ = this.selectPlaylist();
+        this.addToSwitchPlaylistHistory_(this.initialMedia_);
         this.masterPlaylistLoader_.media(this.initialMedia_);
         return;
       }
@@ -623,6 +636,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
           // ensure we have some buffer before we switch up to prevent us running out of
           // buffer while loading a higher rendition.
           forwardBuffer >= bufferLowWaterLine) {
+        this.addToSwitchPlaylistHistory_(nextPlaylist);
         this.masterPlaylistLoader_.media(nextPlaylist);
       }
 
@@ -1134,6 +1148,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
     let media = this.selectPlaylist();
 
     if (media !== this.masterPlaylistLoader_.media()) {
+
+      this.addToSwitchPlaylistHistory_(media, true);
       this.masterPlaylistLoader_.media(media);
 
       this.mainSegmentLoader_.resetLoader();
@@ -1145,6 +1161,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
     let media = this.selectPlaylist();
 
     if (media !== this.masterPlaylistLoader_.media()) {
+
+      this.addToSwitchPlaylistHistory_(media, true);
       this.masterPlaylistLoader_.media(media);
     }
   }

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -129,6 +129,7 @@ export const comparePlaylistResolution = function(left, right) {
  * bandwidth variance
  */
 const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeight) {
+  let fallbackPlaylistRep = null;
   // convert the playlists to an intermediary representation to make comparisons easier
   let sortedPlaylistReps = master.playlists.map((playlist) => {
     let width;
@@ -152,6 +153,9 @@ const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeig
   });
 
   stableSort(sortedPlaylistReps, (left, right) => left.bandwidth - right.bandwidth);
+
+  // in case all playlists are disabled we are keeping this as an ultimate fallback
+  fallbackPlaylistRep = sortedPlaylistReps[0];
 
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
@@ -222,7 +226,8 @@ const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeig
     resolutionPlusOneRep ||
     resolutionBestRep ||
     bandwidthBestRep ||
-    sortedPlaylistReps[0]
+    sortedPlaylistReps[0] ||
+    fallbackPlaylistRep
   ).playlist;
 };
 

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -62,10 +62,10 @@ class Representation {
                               .bind(hlsHandler.masterPlaylistController_);
 
     // Select transition function for quality switch
-    let changeFunc = hlsHandler.options_.smoothQualitySwitch ? smoothChangeFunction : fastChangeFunction; 
+    let changePlaylistFunc = hlsHandler.options_.smoothQualitySwitch ? smoothChangeFunction : fastChangeFunction;
 
     if (hlsHandler.options_.disableImmediateQualityChange) {
-      changeFunc = null;
+      changePlaylistFunc = null;
     }
 
     // Carefully descend into the playlist's attributes since most
@@ -92,7 +92,7 @@ class Representation {
     this.enabled = enableFunction.bind(this,
                                        hlsHandler.playlists,
                                        playlist.uri,
-                                       fastChangeFunction);
+                                       changePlaylistFunc);
   }
 }
 

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -30,7 +30,7 @@ const enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
   if (enable !== currentlyEnabled && !blacklisted) {
     // Ensure the outside world knows about our changes
     if (changePlaylistFn) {
-      changePlaylistFn();      
+      changePlaylistFn();
     }
     if (enable) {
       loader.trigger('renditionenabled');
@@ -62,7 +62,8 @@ class Representation {
                               .bind(hlsHandler.masterPlaylistController_);
 
     // Select transition function for quality switch
-    let changePlaylistFunc = hlsHandler.options_.smoothQualitySwitch ? smoothChangeFunction : fastChangeFunction;
+    let changePlaylistFunc = hlsHandler.options_.smoothQualitySwitch ?
+        smoothChangeFunction : fastChangeFunction;
 
     if (hlsHandler.options_.disableImmediateQualityChange) {
       changePlaylistFunc = null;

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -29,7 +29,9 @@ const enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
 
   if (enable !== currentlyEnabled && !blacklisted) {
     // Ensure the outside world knows about our changes
-    changePlaylistFn();
+    if (changePlaylistFn) {
+      changePlaylistFn();      
+    }
     if (enable) {
       loader.trigger('renditionenabled');
     } else {
@@ -53,6 +55,18 @@ class Representation {
                               .masterPlaylistController_
                               .fastQualityChange_
                               .bind(hlsHandler.masterPlaylistController_);
+
+    let smoothChangeFunction = hlsHandler
+                              .masterPlaylistController_
+                              .smoothQualityChange_
+                              .bind(hlsHandler.masterPlaylistController_);
+
+    // Select transition function for quality switch
+    let changeFunc = hlsHandler.options_.smoothQualitySwitch ? smoothChangeFunction : fastChangeFunction; 
+
+    if (hlsHandler.options_.disableImmediateQualityChange) {
+      changeFunc = null;
+    }
 
     // Carefully descend into the playlist's attributes since most
     // properties are optional

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1105,7 +1105,7 @@ export default class SegmentLoader extends videojs.EventTarget {
   addToBufferQualityMap_(segmentInfo) {
 
     const duration = (segmentInfo.segment.end - segmentInfo.segment.start);
-    const effectiveBitrate = 8 *segmentInfo.bytes.byteLength / duration;
+    const effectiveBitrate = 8 * segmentInfo.bytes.byteLength / duration;
 
     const entry = {
       representationAttributes: segmentInfo.playlist.attributes,
@@ -1116,21 +1116,23 @@ export default class SegmentLoader extends videojs.EventTarget {
       duration
     };
 
-    this.bufferQualityMap_.push(entry)
+    this.bufferQualityMap_.push(entry);
   }
 
   removeFromBufferQualityMap(startTime, endTime) {
     this.bufferQualityMap_ = this.bufferQualityMap_.filter((entry) => {
-      var remove = (entry.startTime >= startTime && entry.endTime <= endTime);
+      let remove = (entry.startTime >= startTime && entry.endTime <= endTime);
+
       return (!remove);
     });
   }
 
   findRepresentationAttributesAtBufferPosition(playheadTime) {
     let attributes = null;
+
     this.bufferQualityMap_.forEach((entry) => {
-      if (playheadTime <= entry.endTime 
-        && playheadTime >= entry.startTime) {
+      if (playheadTime <= entry.endTime &&
+        playheadTime >= entry.startTime) {
 
         if (attributes !== null) {
           videojs.log.warn('There are two overlapping buffer-quality-map entries');

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1104,11 +1104,16 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   addToBufferQualityMap_(segmentInfo) {
 
+    const duration = (segmentInfo.segment.end - segmentInfo.segment.start);
+    const effectiveBitrate = 8 *segmentInfo.bytes.byteLength / duration;
+
     const entry = {
       representationAttributes: segmentInfo.playlist.attributes,
       startTime: segmentInfo.segment.start,
       endTime: segmentInfo.segment.end,
-      timestampOffset: segmentInfo.timestampOffset
+      timestampOffset: segmentInfo.timestampOffset,
+      effectiveBitrate,
+      duration
     };
 
     this.bufferQualityMap_.push(entry)
@@ -1116,8 +1121,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
   removeFromBufferQualityMap(startTime, endTime) {
     this.bufferQualityMap_ = this.bufferQualityMap_.filter((entry) => {
-      var remove = !(entry.startTime >= startTime && entry.endTime <= endTime);
-      return remove;
+      var remove = (entry.startTime >= startTime && entry.endTime <= endTime);
+      return (!remove);
     });
   }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -503,7 +503,8 @@ class HlsHandler extends Component {
   }
 
   findRepresentationAttributesAtBufferPosition(playheadTime) {
-    return this.masterPlaylistController_.mainSegmentLoader_.findRepresentationAttributesAtBufferPosition(playheadTime);
+    return this.masterPlaylistController_.mainSegmentLoader_
+      .findRepresentationAttributesAtBufferPosition(playheadTime);
   }
 
   getMainBufferPayloadAttributesMap() {

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -502,6 +502,12 @@ class HlsHandler extends Component {
     }
   }
 
+  findRepresentationAttributesAtBufferPosition(playheadTime) {
+
+    return this.masterPlaylistController_.mainSegmentLoader_.findRepresentationAttributesAtBufferPosition(playheadTime);
+
+  }
+
   /**
    * a helper for grabbing the active audio group from MasterPlaylistController
    *

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -503,9 +503,11 @@ class HlsHandler extends Component {
   }
 
   findRepresentationAttributesAtBufferPosition(playheadTime) {
-
     return this.masterPlaylistController_.mainSegmentLoader_.findRepresentationAttributesAtBufferPosition(playheadTime);
+  }
 
+  getMainBufferPayloadAttributesMap() {
+    return this.masterPlaylistController_.mainSegmentLoader_.bufferQualityMap_;
   }
 
   /**


### PR DESCRIPTION
## Description

We have several requirements:

* Switch quality "manuall"y without flushing. In our case application business logic will drive the quality for the user, but we want it to be non-flushing even if driven through the Representations interface
* Display the history of quality switches (manual and automatical ones)
* Display the currently played quality at any point
* Display the effective bitrate (average per segment) of the stream at any point 

-> Therefore 

## Specific Changes proposed

* We add an option to use a `smoothQualityChangeFn` instead of the default `fastQualityChangeFn`.
* We add a history of quality switches
* We add a map of the buffer vs representation attributes that allows to lookup a playhead time in buffer and returns the quality attributes
* We add a manual quality switching menu to the demo page
* We add displaying current quality in the demo page
* We fix a bug in `playlist-selector` where when all playlists happen to be disabled there is no fallback. We use the first element in the sorted unfiltered list of reps as an ultimate fallback.

* For debugging, we add a plot to the demo page which displays the buffered quality (playlist bandwidth & effective bitrate):

![videojs-hls-buffer-state-graph](https://user-images.githubusercontent.com/1480052/28290543-1460621a-6b47-11e7-8525-abbe24b94be7.png)

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
