### PR TITLE
fix: processing segments when mediaSource is closed

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "mux.js": "4.1.5",
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.4.7",
+    "videojs-contrib-media-sources": "4.4.8",
     "webworkify": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
This fixes a bug to guard against processing segments when mediaSource is closed

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
