### PR TITLE
[ABR] Handle "no playlist enabled" state in simple selector gracefully

### DIFF
--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -129,6 +129,7 @@ export const comparePlaylistResolution = function(left, right) {
  * bandwidth variance
  */
 const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeight) {
+  let fallbackPlaylistRep = null;
   // convert the playlists to an intermediary representation to make comparisons easier
   let sortedPlaylistReps = master.playlists.map((playlist) => {
     let width;
@@ -152,6 +153,9 @@ const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeig
   });
 
   stableSort(sortedPlaylistReps, (left, right) => left.bandwidth - right.bandwidth);
+
+  // in case all playlists are disabled we are keeping this as an ultimate fallback
+  fallbackPlaylistRep = sortedPlaylistReps[0];
 
   // filter out any playlists that have been excluded due to
   // incompatible configurations or playback errors
@@ -222,7 +226,8 @@ const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeig
     resolutionPlusOneRep ||
     resolutionBestRep ||
     bandwidthBestRep ||
-    sortedPlaylistReps[0]
+    sortedPlaylistReps[0] ||
+    fallbackPlaylistRep
   ).playlist;
 };
 


### PR DESCRIPTION
## Description

When we have no playlist enabled, currently this causes undefined behavior and an exception.

When enforcing a single playlist (setting all to disabled and enabling one) currently
we might have a moment where no playlist is enabled.

But also the user may cause this state for various reasons on the API.
We should be able to handle this gracefully (while eventually logging a warning)

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
