### PR TITLE
Add redirect support for manifest and media requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,16 @@ is set to `true`.
 See html5rocks's [article](http://www.html5rocks.com/en/tutorials/cors/)
 for more info.
 
+##### handleManifestRedirects
+* Type: `boolean`
+* Default: `false`
+* can be used as a source option
+* can be used as an initialization option
+
+When the `handleManifestRedirects` property is set to `true`, manifest requests
+which are redirected will have their URL updated to the new URL for future
+requests.
+
 ##### useCueTags
 * Type: `boolean`
 * can be used as an initialization option

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -211,7 +211,7 @@ export const mimeTypesForPlaylist_ = function(master, media) {
 };
 
 /**
- * the master playlist controller controller all interactons
+ * the master playlist controller controls all interactons
  * between playlists and segmentloaders. At this time this mainly
  * involves a master playlist and a series of audio playlists
  * if they are available
@@ -225,6 +225,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     let {
       url,
+      handleManifestRedirects,
       withCredentials,
       mode,
       tech,
@@ -241,13 +242,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     Hls = externHls;
 
-    this.withCredentials = withCredentials;
     this.tech_ = tech;
     this.hls_ = tech.hls;
     this.mode_ = mode;
     this.useCueTags_ = useCueTags;
     this.blacklistDuration = blacklistDuration;
     this.enableLowInitialPlaylist = enableLowInitialPlaylist;
+
     if (this.useCueTags_) {
       this.cueTagsTrack_ = this.tech_.addTextTrack('metadata',
         'ad-cues');
@@ -255,7 +256,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
     }
 
     this.requestOptions_ = {
-      withCredentials: this.withCredentials,
+      withCredentials,
+      handleManifestRedirects,
       timeout: null
     };
 
@@ -292,7 +294,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     };
 
     // setup playlist loaders
-    this.masterPlaylistLoader_ = new PlaylistLoader(url, this.hls_, this.withCredentials);
+    this.masterPlaylistLoader_ = new PlaylistLoader(url, this.hls_, this.requestOptions_);
     this.setupMasterPlaylistLoaderListeners_();
 
     // setup segment loaders

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -352,7 +352,7 @@ export const initialize = {
       mode,
       hls,
       segmentLoaders: { [type]: segmentLoader },
-      requestOptions: { withCredentials },
+      requestOptions,
       master: { mediaGroups },
       mediaTypes: {
         [type]: {
@@ -383,7 +383,7 @@ export const initialize = {
         if (properties.resolvedUri) {
           playlistLoader = new PlaylistLoader(properties.resolvedUri,
                                               hls,
-                                              withCredentials);
+                                              requestOptions);
         } else {
           // no resolvedUri means the audio is muxed with the video when using this
           // audio track
@@ -429,7 +429,7 @@ export const initialize = {
       tech,
       hls,
       segmentLoaders: { [type]: segmentLoader },
-      requestOptions: { withCredentials },
+      requestOptions,
       master: { mediaGroups },
       mediaTypes: {
         [type]: {
@@ -463,7 +463,7 @@ export const initialize = {
           id: variantLabel,
           playlistLoader: new PlaylistLoader(properties.resolvedUri,
                                              hls,
-                                             withCredentials)
+                                             requestOptions)
         }, properties);
 
         setupListeners[type](type, properties.playlistLoader, settings);

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -260,7 +260,7 @@ class HlsHandler extends Component {
        this.options_.bandwidth === INITIAL_BANDWIDTH;
 
     // grab options passed to player.src
-    ['withCredentials', 'bandwidth'].forEach((option) => {
+    ['withCredentials', 'bandwidth', 'handleManifestRedirects'].forEach((option) => {
       if (typeof this.source_[option] !== 'undefined') {
         this.options_[option] = this.source_[option];
       }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -136,6 +136,26 @@ QUnit.test('obeys none preload option', function(assert) {
   assert.equal(this.player.tech_.hls.stats.bandwidth, 4194304, 'default bandwidth');
 });
 
+QUnit.test('passes options to PlaylistLoader', function(assert) {
+  const options = {
+    url: 'test',
+    tech: this.player.tech_
+  };
+
+  let controller = new MasterPlaylistController(options);
+
+  assert.notOk(controller.masterPlaylistLoader_.withCredentials, 'credentials wont be sent by default');
+  assert.notOk(controller.masterPlaylistLoader_.handleManifestRedirects, 'redirects are ignored by default');
+
+  controller = new MasterPlaylistController(Object.assign({
+    withCredentials: true,
+    handleManifestRedirects: true
+  }, options));
+
+  assert.ok(controller.masterPlaylistLoader_.withCredentials, 'withCredentials enabled');
+  assert.ok(controller.masterPlaylistLoader_.handleManifestRedirects, 'handleManifestRedirects enabled');
+});
+
 QUnit.test('obeys auto preload option', function(assert) {
   this.player.preload('auto');
   // master

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -957,7 +957,9 @@ QUnit.test('recognizes domain-relative URLs', function(assert) {
 });
 
 QUnit.test('recognizes redirect, when manifest requested', function(assert) {
-  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls, {
+    handleManifestRedirects: true
+  });
 
   loader.load();
 
@@ -986,7 +988,9 @@ QUnit.test('recognizes redirect, when manifest requested', function(assert) {
 });
 
 QUnit.test('recognizes redirect, when media requested', function(assert) {
-  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls, {
+    handleManifestRedirects: true
+  });
 
   loader.load();
 
@@ -1012,32 +1016,6 @@ QUnit.test('recognizes redirect, when media requested', function(assert) {
               window.location.protocol + '//' +
               'foo-bar.com/00001.ts',
               'resolved segment URI');
-});
-
-QUnit.test('it warn, when browser does not support redirects', function(assert) {
-  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
-
-  loader.load();
-
-  const manifestRequest = this.requests.shift();
-
-  // emulate IE11's xhr
-  delete manifestRequest.responseURL;
-
-  manifestRequest.respond(200, null,
-                          '#EXTM3U\n' +
-                          '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
-                          '/media.m3u8\n');
-  assert.equal(loader.master.playlists[0].resolvedUri,
-              window.location.protocol + '//' +
-              window.location.host + '/media.m3u8',
-              'resolved media URI');
-
-  this.requests.shift().respond(404);
-
-  assert.equal(this.env.log.warn.calls, 1, 'warning logged');
-  assert.equal(this.env.log.warn.firstCall.args[0],
-               'Current browser does not support redirects for playlist requests.');
 });
 
 QUnit.test('recognizes key URLs relative to master and playlist', function(assert) {

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -956,6 +956,90 @@ QUnit.test('recognizes domain-relative URLs', function(assert) {
               'resolved segment URI');
 });
 
+QUnit.test('recognizes redirect, when manifest requested', function(assert) {
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+
+  loader.load();
+
+  const manifestRequest = this.requests.shift();
+
+  manifestRequest.responseURL = window.location.protocol + '//' +
+                                'foo-bar.com/manifest/media.m3u8';
+  manifestRequest.respond(200, null,
+                          '#EXTM3U\n' +
+                          '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
+                          '/media.m3u8\n');
+  assert.equal(loader.master.playlists[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/media.m3u8',
+              'resolved media URI');
+
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXTINF:10,\n' +
+                                '/00001.ts\n' +
+                                '#EXT-X-ENDLIST\n');
+  assert.equal(loader.media().segments[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/00001.ts',
+              'resolved segment URI');
+});
+
+QUnit.test('recognizes redirect, when media requested', function(assert) {
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+
+  loader.load();
+
+  this.requests.shift().respond(200, null,
+                                '#EXTM3U\n' +
+                                '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
+                                '/media.m3u8\n');
+  assert.equal(loader.master.playlists[0].resolvedUri,
+              window.location.protocol + '//' +
+              window.location.host + '/media.m3u8',
+              'resolved media URI');
+
+  const mediaRequest = this.requests.shift();
+
+  mediaRequest.responseURL = window.location.protocol + '//' +
+                             'foo-bar.com/media.m3u8';
+  mediaRequest.respond(200, null,
+                       '#EXTM3U\n' +
+                       '#EXTINF:10,\n' +
+                       '/00001.ts\n' +
+                       '#EXT-X-ENDLIST\n');
+  assert.equal(loader.media().segments[0].resolvedUri,
+              window.location.protocol + '//' +
+              'foo-bar.com/00001.ts',
+              'resolved segment URI');
+});
+
+QUnit.test('it warn, when browser does not support redirects', function(assert) {
+  let loader = new PlaylistLoader('manifest/media.m3u8', this.fakeHls);
+
+  loader.load();
+
+  const manifestRequest = this.requests.shift();
+
+  // emulate IE11's xhr
+  delete manifestRequest.responseURL;
+
+  manifestRequest.respond(200, null,
+                          '#EXTM3U\n' +
+                          '#EXT-X-STREAM-INF:BANDWIDTH=1\n' +
+                          '/media.m3u8\n');
+  assert.equal(loader.master.playlists[0].resolvedUri,
+              window.location.protocol + '//' +
+              window.location.host + '/media.m3u8',
+              'resolved media URI');
+
+  this.requests.shift().respond(404);
+
+  assert.equal(this.env.log.warn.calls, 1, 'warning logged');
+  assert.equal(this.env.log.warn.firstCall.args[0],
+               'Current browser does not support redirects for playlist requests.');
+});
+
 QUnit.test('recognizes key URLs relative to master and playlist', function(assert) {
   let loader = new PlaylistLoader('/video/media-encrypted.m3u8', this.fakeHls);
 

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -1696,6 +1696,47 @@ QUnit.test('the withCredentials option overrides the global default', function(a
   videojs.options.hls = hlsOptions;
 });
 
+QUnit.test('if handleManifestRedirects global option is used, it should be passed to PlaylistLoader', function(assert) {
+  let hlsOptions = videojs.options.hls;
+
+  this.player.dispose();
+  videojs.options.hls = {
+    handleManifestRedirects: true
+  };
+  this.player = createPlayer();
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl'
+  });
+
+  this.clock.tick(1);
+
+  assert.ok(this.player.tech_.hls.masterPlaylistController_.masterPlaylistLoader_.handleManifestRedirects);
+
+  videojs.options.hls = hlsOptions;
+});
+
+QUnit.test('the handleManifestRedirects option overrides the global default', function(assert) {
+  let hlsOptions = videojs.options.hls;
+
+  this.player.dispose();
+  videojs.options.hls = {
+    handleManifestRedirects: true
+  };
+  this.player = createPlayer();
+  this.player.src({
+    src: 'http://example.com/media.m3u8',
+    type: 'application/vnd.apple.mpegurl',
+    handleManifestRedirects: false
+  });
+
+  this.clock.tick(1);
+
+  assert.notOk(this.player.tech_.hls.masterPlaylistController_.masterPlaylistLoader_.handleManifestRedirects);
+
+  videojs.options.hls = hlsOptions;
+});
+
 QUnit.test('playlist blacklisting duration is set through options', function(assert) {
   let hlsOptions = videojs.options.hls;
   let url;


### PR DESCRIPTION
## Description

This PR is an attempt to continue the work started in #912

Regarding IE11 support: the redirects won't be supported, so the plugin will work exactly the same as it was working in IE11 before my PR. Also we will detect, whether the browser supports redirects and if no, we will warn the developer that current browser does not support redirects.