### PR TITLE
Blacklist playlist for 2 minutes on early abort to prevent cache loop

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -654,11 +654,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('earlyabort', () => {
-      // skip playlist selection since a bandwidthupdate will trigger
       this.blacklistCurrentPlaylist({
-        message: 'Aborted early because we don\'t have the bandwidth to complete the ' +
+        message: 'Aborted early because there isn\'t enough bandwidth to complete the ' +
           'request without rebuffering.'
-      }, ABORT_EARLY_BLACKLIST_SECONDS, true);
+      }, ABORT_EARLY_BLACKLIST_SECONDS);
     });
 
     this.audioSegmentLoader_.on('ended', () => {
@@ -1308,10 +1307,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * to blacklist
    * @param {Number=} blacklistDuration an optional number of seconds to blacklist the
    * playlist
-   * @param {Boolean=} skipPlaylistSelection an optional boolean to skip playlist
-   * selection
    */
-  blacklistCurrentPlaylist(error = {}, blacklistDuration, skipPlaylistSelection = false) {
+  blacklistCurrentPlaylist(error = {}, blacklistDuration) {
     let currentPlaylist;
     let nextPlaylist;
 
@@ -1348,12 +1345,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
       (blacklistDuration ? blacklistDuration : this.blacklistDuration) * 1000;
     this.tech_.trigger('blacklistplaylist');
     this.tech_.trigger({type: 'usage', name: 'hls-rendition-blacklisted'});
-
-    if (skipPlaylistSelection) {
-      videojs.log.warn('Problem encountered with the current HLS playlist.' +
-                       (error.message ? ' ' + error.message : ''));
-      return;
-    }
 
     // Select a new playlist
     nextPlaylist = this.selectPlaylist();

--- a/src/playlist-selectors.js
+++ b/src/playlist-selectors.js
@@ -126,7 +126,10 @@ export const comparePlaylistResolution = function(left, right) {
  * currently detected bandwidth, accounting for some amount of
  * bandwidth variance
  */
-const simpleSelector = function(master, playerBandwidth, playerWidth, playerHeight) {
+export const simpleSelector = function(master,
+                                       playerBandwidth,
+                                       playerWidth,
+                                       playerHeight) {
   // convert the playlists to an intermediary representation to make comparisons easier
   let sortedPlaylistReps = master.playlists.map((playlist) => {
     let width;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1029,7 +1029,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     return segment.lastRequest &&
       // last request for this segment was within the last 2 minutes
       Date.now() - segment.lastRequest.time < 60 * 2 * 1000 &&
-      // new bandwidth does not seem too high (double last bandwidth chosen arbitrarily)
+      // new bandwidth seems too high (double last bandwidth chosen arbitrarily)
       bandwidth > segment.lastRequest.bandwidth * 2;
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -823,11 +823,11 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     // set the bandwidth to that of the desired playlist being sure to scale by
     // BANDWIDTH_VARIANCE and add one so the playlist selector does not exclude it
+    // don't trigger a bandwidthupdate as the bandwidth is artifial
     this.bandwidth =
       switchCandidate.playlist.attributes.BANDWIDTH * Config.BANDWIDTH_VARIANCE + 1;
     this.abort();
     this.trigger('earlyabort');
-    this.trigger('bandwidthupdate');
     return true;
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -15,7 +15,6 @@ import { minRebufferMaxBandwidthSelector } from './playlist-selectors';
 
 // in ms
 const CHECK_BUFFER_DELAY = 500;
-const ABORT_EARLY_BLACKLIST_MILLIS = 1000 * 60 * 2;
 
 /**
  * Determines if we should call endOfStream on the media source based
@@ -826,8 +825,8 @@ export default class SegmentLoader extends videojs.EventTarget {
     // BANDWIDTH_VARIANCE and add one so the playlist selector does not exclude it
     this.bandwidth =
       switchCandidate.playlist.attributes.BANDWIDTH * Config.BANDWIDTH_VARIANCE + 1;
-    this.playlist_.excludeUntil = Date.now() + ABORT_EARLY_BLACKLIST_MILLIS;
     this.abort();
+    this.trigger('earlyabort');
     this.trigger('bandwidthupdate');
     return true;
   }

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -326,6 +326,10 @@ export const LoaderCommonFactory = (LoaderConstructor,
         oldHandleProgress(event, simpleSegment);
       };
 
+      let earlyAborts = 0;
+
+      loader.on('earlyabort', () => earlyAborts++);
+
       loader.on('bandwidthupdate', () => bandwidthupdates++);
       loader.playlist(playlist1, xhrOptions);
       loader.load();
@@ -340,7 +344,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 0, 'no bandwidth updates yet');
       assert.notOk(this.requests[0].aborted, 'request not prematurely aborted');
-      assert.notOk(playlist1.excludeUntil, 'playlist not blacklisted');
+      assert.equal(earlyAborts, 0, 'no earlyabort events');
 
       this.clock.tick(999);
 
@@ -352,7 +356,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 0, 'no bandwidth updates yet');
       assert.notOk(this.requests[0].aborted, 'request not prematurely aborted');
-      assert.notOk(playlist1.excludeUntil, 'playlist not blacklisted');
+      assert.equal(earlyAborts, 0, 'no earlyabort events');
 
       this.clock.tick(2);
 
@@ -364,7 +368,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 1, 'bandwidth updated');
       assert.ok(this.requests[0].aborted, 'request aborted');
-      assert.ok(playlist1.excludeUntil, 'playlist blacklisted');
+      assert.equal(earlyAborts, 1, 'earlyabort event triggered');
     });
 
     QUnit.test(

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -340,6 +340,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 0, 'no bandwidth updates yet');
       assert.notOk(this.requests[0].aborted, 'request not prematurely aborted');
+      assert.notOk(playlist1.excludeUntil, 'playlist not blacklisted');
 
       this.clock.tick(999);
 
@@ -351,6 +352,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 0, 'no bandwidth updates yet');
       assert.notOk(this.requests[0].aborted, 'request not prematurely aborted');
+      assert.notOk(playlist1.excludeUntil, 'playlist not blacklisted');
 
       this.clock.tick(2);
 
@@ -362,6 +364,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
 
       assert.equal(bandwidthupdates, 1, 'bandwidth updated');
       assert.ok(this.requests[0].aborted, 'request aborted');
+      assert.ok(playlist1.excludeUntil, 'playlist blacklisted');
     });
 
     QUnit.test(

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -366,7 +366,7 @@ export const LoaderCommonFactory = (LoaderConstructor,
         loaded: 2001
       });
 
-      assert.equal(bandwidthupdates, 1, 'bandwidth updated');
+      assert.equal(bandwidthupdates, 0, 'bandwidth not updated');
       assert.ok(this.requests[0].aborted, 'request aborted');
       assert.equal(earlyAborts, 1, 'earlyabort event triggered');
     });

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1110,7 +1110,9 @@ QUnit.test('blacklists playlist on earlyabort', function(assert) {
 QUnit.test('does not get stuck in a loop due to inconsistent network/caching',
 function(assert) {
   /*
-   * This test is a long one, but it is meant to follow a true path to a possible loop
+   * This test is a long one, but it is meant to follow a true path to a possible loop.
+   * The reason for the loop is due to inconsistent network bandwidth, often caused or
+   * amplified by caching at the browser or edge server level.
    * The steps are as follows:
    *
    * 1) Request segment 0 from low bandwidth playlist

--- a/test/playlist-selectors.test.js
+++ b/test/playlist-selectors.test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import {
+  simpleSelector,
   movingAverageBandwidthSelector,
   minRebufferMaxBandwidthSelector
 } from '../src/playlist-selectors';
@@ -120,4 +121,17 @@ function(assert) {
 
   assert.equal(result.playlist, master.playlists[0], 'selected the correct playlist');
   assert.equal(result.rebufferingImpact, 1, 'impact on rebuffering is 1 second');
+});
+
+test('simpleSelector switches up even without resolution information', function(assert) {
+  let master = this.hls.playlists.master;
+
+  master.playlists = [
+    { attributes: { BANDWIDTH: 100 } },
+    { attributes: { BANDWIDTH: 1000 } }
+  ];
+
+  const selectedPlaylist = simpleSelector(master, 2000, 1, 1);
+
+  assert.equal(selectedPlaylist, master.playlists[1], 'selected the correct playlist');
 });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -603,31 +603,5 @@ QUnit.module('SegmentLoader', function(hooks) {
       assert.ok(!playlistUpdated.segments[0].end,
                 'no end info for first segment of new playlist');
     });
-
-    QUnit.test('tracks segment bandwidth and request times', function(assert) {
-      let playlist = playlistWithDuration(20);
-
-      loader.syncController_.probeTsSegment_ = function(segmentInfo) {
-        return { start: 0, end: 10 };
-      };
-
-      loader.playlist(playlist);
-      loader.mimeType(this.mimeType);
-      loader.load();
-      this.clock.tick(1);
-
-      this.clock.tick(1000);
-      this.requests[0].response = new Uint8Array(10).buffer;
-      this.requests.shift().respond(200, null, '');
-
-      this.updateend();
-      this.clock.tick(1);
-
-      const segment = playlist.segments[0];
-
-      assert.ok(segment.lastRequest, 'added lastRequest');
-      assert.equal(typeof segment.lastRequest.time, 'number', 'set time');
-      assert.equal(segment.lastRequest.bandwidth, 80, 'set bandwidth');
-    });
   });
 });

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -603,5 +603,31 @@ QUnit.module('SegmentLoader', function(hooks) {
       assert.ok(!playlistUpdated.segments[0].end,
                 'no end info for first segment of new playlist');
     });
+
+    QUnit.test('tracks segment bandwidth and request times', function(assert) {
+      let playlist = playlistWithDuration(20);
+
+      loader.syncController_.probeTsSegment_ = function(segmentInfo) {
+        return { start: 0, end: 10 };
+      };
+
+      loader.playlist(playlist);
+      loader.mimeType(this.mimeType);
+      loader.load();
+      this.clock.tick(1);
+
+      this.clock.tick(1000);
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      this.updateend();
+      this.clock.tick(1);
+
+      const segment = playlist.segments[0];
+
+      assert.ok(segment.lastRequest, 'added lastRequest');
+      assert.equal(typeof segment.lastRequest.time, 'number', 'set time');
+      assert.equal(segment.lastRequest.bandwidth, 80, 'set bandwidth');
+    });
   });
 });

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -187,6 +187,12 @@ export const useFakeEnvironment = function(assert) {
     this.readyState = 0;
   };
 
+  XMLHttpRequest.prototype.downloadProgress = function downloadProgress(rawEventData) {
+    this.dispatchEvent(new sinon.ProgressEvent('progress',
+                                               rawEventData,
+                                               rawEventData.target));
+  };
+
   fakeEnvironment.requests.length = 0;
   fakeEnvironment.xhr.onCreate = function(xhr) {
     fakeEnvironment.requests.push(xhr);


### PR DESCRIPTION
## Description
This is a simpler, more reliable, and overall better fix for loops due to inconsistent network/caching than https://github.com/videojs/videojs-contrib-hls/pull/1211

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
