### PR TITLE
make sure text tracks added by hls are properly disposed

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -326,7 +326,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.segmentMetadataTrack_ = tech.addRemoteTextTrack({
       kind: 'metadata',
       label: 'segment-metadata'
-    }, true).track;
+    }, false).track;
 
     this.decrypter_ = worker(Decrypter);
 
@@ -804,7 +804,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
               enabled: false,
               language: properties.language,
               label
-            }, true).track;
+            }, false).track;
 
             this.subtitleGroups_.tracks[label] = track;
           }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -1631,6 +1631,16 @@ QUnit.test('adds subtitle tracks when a media playlist is loaded', function(asse
   assert.equal(textTracks[1].mode, 'disabled', 'track starts disabled');
   assert.equal(textTracks[2].mode, 'disabled', 'track starts disabled');
   assert.equal(hlsWebvttEvents, 1, 'there is webvtt detected in the rendition');
+
+  // change source to make sure tracks are cleaned up
+  this.player.src({
+    src: 'http://example.com/media.mp4',
+    type: 'video/mp4'
+  });
+
+  this.clock.tick(1);
+
+  assert.equal(this.player.textTracks().length, 0, 'text tracks cleaned');
 });
 
 QUnit.test('switches off subtitles on subtitle errors', function(assert) {


### PR DESCRIPTION
True for the second parameter for `addRemoteTextTrack` means you must manually cleanup the track, and false is for auto cleanup. These tracks were mistakenly using the api in the opposite way
