### PR TITLE
Keep track of approximate total bytes in SourceBuffer / Prevent quota exceeded with 4K streams

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 export default {
+  BACK_BUFFER_LENGTH: 30,
   GOAL_BUFFER_LENGTH: 30,
   MAX_GOAL_BUFFER_LENGTH: 60,
   GOAL_BUFFER_LENGTH_RATE: 1,
@@ -8,5 +9,6 @@ export default {
   // How much of the buffer must be filled before we consider upswitching
   BUFFER_LOW_WATER_LINE: 0,
   MAX_BUFFER_LOW_WATER_LINE: 30,
-  BUFFER_LOW_WATER_LINE_RATE: 1
+  BUFFER_LOW_WATER_LINE_RATE: 1,
+  MAX_SOURCE_BUFFER_OCCUPATION_BYTES: 128 * 1e6 // per SegmentLoader / SourceUpdater
 };

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -602,7 +602,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       return null;
     }
 
-    console.log('Total Mbytes in SourceBuffer:', (bufferedBytes / 1e6).toFixed(2));
+    this.logger_('Total Mbytes in SourceBuffer:', (bufferedBytes / 1e6).toFixed(2));
 
     // With high-bitrate streams (like 4K etc, up to 16-20 Mbit/s)
     // we can reach a QuotaExceeded error easily within just 60 seconds

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1078,20 +1078,23 @@ export default class SegmentLoader extends videojs.EventTarget {
           this.activeInitSegmentId_ !== initId) {
         const initSegment = this.initSegment(segment.map);
 
-        this.sourceUpdater_.appendBuffer(initSegment.bytes, () => {
+        this.sourceUpdater_.appendBuffer(initSegment.bytes, null, () => {
           this.activeInitSegmentId_ = initId;
         });
       }
     }
 
     segmentInfo.byteLength = segmentInfo.bytes.byteLength;
+
+    let segmentDuration;
+
     if (typeof segment.start === 'number' && typeof segment.end === 'number') {
-      this.mediaSecondsLoaded += segment.end - segment.start;
+      this.mediaSecondsLoaded += segmentDuration = segment.end - segment.start;
     } else {
-      this.mediaSecondsLoaded += segment.duration;
+      this.mediaSecondsLoaded += segmentDuration = segment.duration;
     }
 
-    this.sourceUpdater_.appendBuffer(segmentInfo.bytes,
+    this.sourceUpdater_.appendBuffer(segmentInfo.bytes, segmentDuration,
                                      this.handleUpdateEnd_.bind(this));
   }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -610,9 +610,10 @@ export default class SegmentLoader extends videojs.EventTarget {
     // of bytes occupied in the buffer.
     // If we reach the limit, we are triming pre-emptively, enqueuing this action
     // to the source-updater before any further loading can happen.
-    // Even if the back-buffer is alrady trimmed
+    // Even if the back-buffer is alrady trimmed, we should wait before
+    // we append more data if the buffer is still too occupied.
     //
-    // We also monitor the bytes in buffer (see checkBuffer_())
+    // We monitor the bytes in buffer (see checkBuffer_())
     // and drive the loading / triming actively
     // to make sure we do not reach this limit.
     if (bufferedBytes >= Config.MAX_SOURCE_BUFFER_OCCUPATION_BYTES) {

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -122,8 +122,12 @@ export default class SourceUpdater {
 
     this.queueCallback_(() => {
 
-      this.appendToBufferInfoQueue_(this.sourceBuffer_.timestampOffset,
-        duration, bytes.byteLength);
+      // we don't want to track initialization segments
+      // only payload with actual media duration
+      if (duration !== null) {
+        this.appendToBufferInfoQueue_(this.sourceBuffer_.timestampOffset,
+          duration, bytes.byteLength);
+      }
 
       this.sourceBuffer_.appendBuffer(bytes);
 


### PR DESCRIPTION
## Description

    // With high-bitrate streams (like 4K etc, up to 16-20 Mbit/s)
    // we can reach a QuotaExceeded error easily within just 60 seconds
    // of buffer. Therefore we need to actively check the exact number
    // of bytes occupied in the buffer.
    // If we reach the limit, we are triming pre-emptively, enqueuing this action
    // to the source-updater before any further loading can happen.
    // Even if the back-buffer is alrady trimmed, we should wait before
    // we append more data if the buffer is still too occupied.
    //
    // We monitor the bytes in buffer (see checkBuffer_())
    // and drive the loading / triming actively
    // to make sure we do not reach this limit.

## Specific Changes proposed

* add method `totalBytesInBuffer` to `SourceBuffer`
* modifiy slightly `SourceBuffer` interface to pass `duration`
* use above method to limit loading in `SegmentLoader` when limit is exceeded
* move significant constants in `Config` module
* `trimBackBuffer_` improvements

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
