### PR TITLE
MediaGroups: various bug fixes and refactor

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -13,6 +13,7 @@ import worker from 'webworkify';
 import Decrypter from './decrypter-worker';
 import Config from './config';
 import { parseCodecs } from './util/codecs.js';
+import initializeMediaGroups from './media-groups';
 
 const ABORT_EARLY_BLACKLIST_SECONDS = 60 * 2;
 
@@ -284,13 +285,17 @@ export class MasterPlaylistController extends videojs.EventTarget {
       timeout: null
     };
 
-    this.audioGroups_ = { groups: {}, tracks: {} };
-    this.subtitleGroups_ = { groups: {}, tracks: {} };
-    this.closedCaptionGroups_ = { groups: {}, tracks: {} };
+    this.mediaGroups_ = {};
+
+    ['AUDIO', 'SUBTITLES', 'CLOSED-CAPTIONS'].forEach((type) => {
+      this.mediaGroups_[type] = {
+        groups: {},
+        tracks: {},
+        activePlaylistLoader: null
+      };
+    });
 
     this.mediaSource = new videojs.MediaSource({ mode });
-    this.audioinfo_ = null;
-    this.mediaSource.on('audioinfo', this.handleAudioinfoUpdate_.bind(this));
 
     // load the media source into the player
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_.bind(this));
@@ -323,8 +328,6 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // setup playlist loaders
     this.masterPlaylistLoader_ = new PlaylistLoader(url, this.hls_, this.withCredentials);
     this.setupMasterPlaylistLoaderListeners_();
-    this.audioPlaylistLoader_ = null;
-    this.subtitlePlaylistLoader_ = null;
 
     // setup segment loaders
     // combined audio/video or just video when alternate audio track is selected
@@ -381,14 +384,30 @@ export class MasterPlaylistController extends videojs.EventTarget {
         this.mainSegmentLoader_.load();
       }
 
-      this.fillAudioTracks_();
-      this.setupAudio();
+      const mediaGroupSettings = {
+        segmentLoaders: {
+          AUDIO: this.audioSegmentLoader_,
+          SUBTITLES: this.subtitleSegmentLoader_,
+          main: this.mainSegmentLoader_
+        },
+        tech: this.tech_,
+        requestOptions: this.requestOptions_,
+        masterPlaylistLoader: this.masterPlaylistLoader_,
+        mode: this.mode_,
+        hls: this.hls_,
+        master: this.master(),
+        mediaGroups: this.mediaGroups_
+      };
 
-      this.fillSubtitleTracks_();
-      this.setupSubtitles();
+      initializeMediaGroups(mediaGroupSettings);
+
+      // let audioGroup = this.activeAudioGroup();
+      // let groupId = (audioGroup.filter(group => group.default)[0] || audioGroup[0]).id;
+
+      // this.audioGroups_.tracks[groupId].enabled = true;
+      this.audioTrackChanged();
 
       this.triggerPresenceUsage_(this.master(), media);
-      this.fillClosedCaptionTracks_();
 
       try {
         this.setupSourceBuffers_();
@@ -496,12 +515,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
       // if the audio group has changed, a new audio track has to be
       // enabled
-      activeAudioGroup = this.activeAudioGroup();
-      activeTrack = activeAudioGroup.filter((track) => track.enabled)[0];
-      if (!activeTrack) {
-        this.mediaGroupChanged();
-        this.trigger('audioupdate');
-      }
+      this.audioGroupChanged();
       this.setupSubtitles();
 
       this.tech_.trigger({
@@ -656,53 +670,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
       videojs.log.warn('Problem encountered with the current alternate audio track' +
                        '. Switching back to default.');
       this.audioSegmentLoader_.abort();
-      this.audioPlaylistLoader_ = null;
-      this.setupAudio();
+      this.audioTrackChanged();
     });
 
     this.subtitleSegmentLoader_.on('error', this.handleSubtitleError_.bind(this));
-  }
-
-  handleAudioinfoUpdate_(event) {
-    if (Hls.supportsAudioInfoChange_() ||
-        !this.audioInfo_ ||
-        !objectChanged(this.audioInfo_, event.info)) {
-      this.audioInfo_ = event.info;
-      return;
-    }
-
-    let error = 'had different audio properties (channels, sample rate, etc.) ' +
-        'or changed in some other way.  This behavior is currently ' +
-        'unsupported in Firefox 48 and below due to an issue: \n\n' +
-        'https://bugzilla.mozilla.org/show_bug.cgi?id=1247138\n\n';
-
-    let enabledIndex =
-        this.activeAudioGroup()
-          .map((track) => track.enabled)
-          .indexOf(true);
-    let enabledTrack = this.activeAudioGroup()[enabledIndex];
-    let defaultTrack = this.activeAudioGroup().filter((track) => {
-      return track.properties_ && track.properties_.default;
-    })[0];
-
-    // they did not switch audiotracks
-    // blacklist the current playlist
-    if (!this.audioPlaylistLoader_) {
-      error = `The rendition that we tried to switch to ${error}` +
-        'Unfortunately that means we will have to blacklist ' +
-        'the current playlist and switch to another. Sorry!';
-      this.blacklistCurrentPlaylist();
-    } else {
-      error = `The audio track '${enabledTrack.label}' that we tried to ` +
-        `switch to ${error} Unfortunately this means we will have to ` +
-        `return you to the main track '${defaultTrack.label}'. Sorry!`;
-      defaultTrack.enabled = true;
-      this.activeAudioGroup().splice(enabledIndex, 1);
-      this.trigger('audioupdate');
-    }
-
-    videojs.log.warn(error);
-    this.setupAudio();
   }
 
   mediaSecondsLoaded_() {
@@ -711,171 +682,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
   }
 
   /**
-   * fill our internal list of HlsAudioTracks with data from
-   * the master playlist or use a default
-   *
-   * @private
-   */
-  fillAudioTracks_() {
-    let master = this.master();
-    let mediaGroups = master.mediaGroups || {};
-
-    // force a default if we have none or we are not
-    // in html5 mode (the only mode to support more than one
-    // audio track)
-    if (!mediaGroups ||
-        !mediaGroups.AUDIO ||
-        Object.keys(mediaGroups.AUDIO).length === 0 ||
-        this.mode_ !== 'html5') {
-      // "main" audio group, track name "default"
-      mediaGroups.AUDIO = { main: { default: { default: true }}};
-    }
-
-    for (let mediaGroup in mediaGroups.AUDIO) {
-      if (!this.audioGroups_.groups[mediaGroup]) {
-        this.audioGroups_.groups[mediaGroup] = [];
-      }
-
-      for (let label in mediaGroups.AUDIO[mediaGroup]) {
-        let properties = videojs.mergeOptions(
-          {
-            id: label,
-            playlistLoader: new PlaylistLoader(properties.resolvedUri,
-                                               this.hls_,
-                                               this.withCredentials)
-          },
-          mediaGroups.AUDIO[mediaGroup][label]
-        );
-
-        this.audioGroups_.groups[mediaGroup].push(properties);
-
-        if (typeof this.audioGroups_.tracks[label] === 'undefined') {
-          let track = new videojs.AudioTrack({
-            id: label,
-            kind: this.audioTrackKind_(properties),
-            enabled: false,
-            language: properties.language,
-            label
-          });
-
-          this.audioGroups_.tracks[label] = (track);
-        }
-      }
-    }
-
-    // enable the default active track
-    (this.activeAudioGroup().filter((audioTrack) => {
-      return audioTrack.properties_.default;
-    })[0] || this.activeAudioGroup()[0]).enabled = true;
-  }
-
-  /**
-   * Convert the properties of an HLS track into an audioTrackKind.
-   *
-   * @private
-   */
-  audioTrackKind_(properties) {
-    let kind = properties.default ? 'main' : 'alternative';
-
-    if (properties.characteristics &&
-        properties.characteristics.indexOf('public.accessibility.describes-video') >= 0) {
-      kind = 'main-desc';
-    }
-
-    return kind;
-  }
-  /**
-   * fill our internal list of Subtitle Tracks with data from
-   * the master playlist or use a default
-   *
-   * @private
-   */
-  fillSubtitleTracks_() {
-    let master = this.master();
-    let mediaGroups = master.mediaGroups || {};
-
-    for (let mediaGroup in mediaGroups.SUBTITLES) {
-      if (!this.subtitleGroups_.groups[mediaGroup]) {
-        this.subtitleGroups_.groups[mediaGroup] = [];
-      }
-
-      for (let label in mediaGroups.SUBTITLES[mediaGroup]) {
-        let properties = mediaGroups.SUBTITLES[mediaGroup][label];
-
-        if (!properties.forced) {
-          this.subtitleGroups_.groups[mediaGroup].push(
-            videojs.mergeOptions({ id: label }, properties));
-
-          if (typeof this.subtitleGroups_.tracks[label] === 'undefined') {
-            let track = this.tech_.addRemoteTextTrack({
-              id: label,
-              kind: 'subtitles',
-              enabled: false,
-              language: properties.language,
-              label
-            }, false).track;
-
-            this.subtitleGroups_.tracks[label] = track;
-          }
-        }
-      }
-    }
-
-    // Do not enable a default subtitle track. Wait for user interaction instead.
-  }
-
-  /**
-   * fill our internal list of Captions Tracks with data from
-   * the master playlist or use a default
-   *
-   * @private
-   */
-  fillClosedCaptionTracks_() {
-    let master = this.master();
-    let mediaGroups = master.mediaGroups || {};
-
-    for (let mediaGroup in mediaGroups['CLOSED-CAPTIONS']) {
-      if (!this.closedCaptionGroups_.groups[mediaGroup]) {
-        this.closedCaptionGroups_.groups[mediaGroup] = [];
-      }
-
-      for (let label in mediaGroups['CLOSED-CAPTIONS'][mediaGroup]) {
-        let properties = mediaGroups['CLOSED-CAPTIONS'][mediaGroup][label];
-
-        // We only support CEA608 captions for now, so ignore anything that
-        // doesn't use a CCx INSTREAM-ID
-        if (!properties.instreamId.match(/CC\d/)) {
-          continue;
-        }
-
-        this.closedCaptionGroups_.groups[mediaGroup].push(
-          videojs.mergeOptions({ id: label }, properties));
-
-        if (typeof this.closedCaptionGroups_.tracks[label] === 'undefined') {
-          let track = this.tech_.addRemoteTextTrack({
-            id: properties.instreamId,
-            kind: 'captions',
-            enabled: false,
-            language: properties.language,
-            label
-          }, false).track;
-
-          this.closedCaptionGroups_.tracks[label] = track;
-        }
-      }
-    }
-
-  }
-
-  /**
    * Call load on our SegmentLoaders
    */
   load() {
     this.mainSegmentLoader_.load();
-    if (this.audioPlaylistLoader_) {
+    if (this.audioGroups_.activePlaylistLoader) {
       this.audioSegmentLoader_.load();
     }
-    if (this.subtitlePlaylistLoader_) {
+    if (this.subtitleGroups_.activePlaylistLoader) {
       this.subtitleSegmentLoader_.load();
     }
   }
@@ -884,7 +698,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * Returns the audio group for the currently active primary
    * media playlist.
    */
-  activeAudioGroup() {
+  activeAudioGroup(activeTrack) {
     let videoPlaylist = this.masterPlaylistLoader_.media();
     let result;
 
@@ -896,14 +710,22 @@ export class MasterPlaylistController extends videojs.EventTarget {
       result = this.audioGroups_.groups[videoPlaylist.attributes.AUDIO];
     }
 
-    return result || this.audioGroups_.groups.main;
+    result = result || this.audioGroups_.groups.main;
+
+    if (!activeTrack) {
+      return result
+    }
+
+    return result.reduce((final, props) => {
+      return props.id === activeTrack.id ? props : final;
+    }, null);
   }
 
   /**
    * Returns the subtitle group for the currently active primary
    * media playlist.
    */
-  activeSubtitleGroup_() {
+  activeSubtitleGroup_(activeTrack) {
     let videoPlaylist = this.masterPlaylistLoader_.media();
     let result;
 
@@ -915,7 +737,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       result = this.subtitleGroups_.groups[videoPlaylist.attributes.SUBTITLES];
     }
 
-    return result || this.subtitleGroups_.groups.main;
+    result = result || this.subtitleGroups_.groups.main;
   }
 
   activeSubtitleTrack_() {
@@ -950,11 +772,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * and performs non-destructive 'resync' of the SegmentLoader(s) since
    * the playlist has likely changed
    */
-  mediaGroupChanged() {
-    let track = this.getActiveAudioTrack_();
-
+  audioGroupChanged() {
     this.stopAudioLoaders_();
-    this.resyncAudioLoaders_(track);
+    this.resyncAudioLoaders_();
   }
 
   /**
@@ -966,11 +786,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * on the SegmentLoaders(s) to ensure we start loading audio as
    * close to currentTime as possible
    */
-  setupAudio() {
-    let track = this.getActiveAudioTrack_();
-
+  audioTrackChanged() {
     this.stopAudioLoaders_();
-    this.resetAudioLoaders_(track);
+    this.resetAudioLoaders_();
   }
 
   /**
@@ -987,6 +805,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
         track = this.audioGroups_.tracks[trackName];
         break;
       }
+    }
+
+    if (!track) {
+      return null;
     }
 
     if (!track) {
@@ -1010,11 +832,12 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   stopAudioLoaders_() {
     // stop playlist and segment loading for audio
-    if (this.audioPlaylistLoader_) {
-      this.audioPlaylistLoader_.dispose();
-      this.audioPlaylistLoader_ = null;
-    }
     this.audioSegmentLoader_.pause();
+
+    if (this.audioGroups_.activePlaylistLoader) {
+      this.audioGroups_.activePlaylistLoader.pause();
+      this.audioGroups_.activePlaylistLoader = null;
+    }
   }
 
   /**
@@ -1022,14 +845,26 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * or audioSegmentLoader (when audio is demuxed) to prepare them
    * to start loading new data right at currentTime
    */
-  resetAudioLoaders_(track) {
-    if (!track.properties_.resolvedUri) {
+  resetAudioLoaders_() {
+    const activeTrack = this.getActiveAudioTrack_();
+
+    if (!activeTrack) {
+      // There should always be an enabled audio track, but because the `change` event is
+      // triggered multiple times when selecting a new audio track, we want to wait until
+      // a track is enabled before continuing.
+      return
+    }
+
+    const activeGroup = this.activeAudioGroup(activeTrack);
+
+
+    if (!activeGroup.resolvedUri) {
       this.mainSegmentLoader_.resetEverything();
       return;
     }
 
     this.audioSegmentLoader_.resetEverything();
-    this.setupAudioPlaylistLoader_(track);
+    this.setupAudioPlaylistLoader_(activeGroup.playlistLoader);
   }
 
   /**
@@ -1037,63 +872,36 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * is demuxed) to prepare to continue appending new audio data
    * at the end of the current buffered region
    */
-  resyncAudioLoaders_(track) {
-    if (!track.properties_.resolvedUri) {
+  resyncAudioLoaders_() {
+    const activeTrack = this.getActiveAudioTrack_();
+    const activeGroup = this.activeAudioGroup(activeTrack);
+
+    if (!activeGroup.resolvedUri) {
       return;
     }
 
     this.audioSegmentLoader_.resyncLoader();
-    this.setupAudioPlaylistLoader_(track);
+    this.setupAudioPlaylistLoader_(activeGroup.playlistLoader);
   }
 
   /**
    * Setup a new audioPlaylistLoader and start the audioSegmentLoader
    * to begin loading demuxed audio
    */
-  setupAudioPlaylistLoader_(track) {
-    // startup playlist and segment loaders for the enabled audio
-    // track
-    this.audioPlaylistLoader_ = new PlaylistLoader(track.properties_.resolvedUri,
-                                                   this.hls_,
-                                                   this.withCredentials);
-    this.audioPlaylistLoader_.load();
+  setupAudioPlaylistLoader_(newPlaylistLoader) {
+    this.audioGroups_.activePlaylistLoader = newPlaylistLoader;
 
-    this.audioPlaylistLoader_.on('loadedmetadata', () => {
-      let audioPlaylist = this.audioPlaylistLoader_.media();
+    if (!newPlaylistLoader) {
+      // audio is muxed with video
+      return;
+    }
 
-      this.audioSegmentLoader_.playlist(audioPlaylist, this.requestOptions_);
+    if (newPlaylistLoader.media()) {
+      // only begin segment loader loading if the playlistloader has loaded a media
+      this.audioSegmentLoader_.load();
+    }
 
-      // if the video is already playing, or if this isn't a live video and preload
-      // permits, start downloading segments
-      if (!this.tech_.paused() ||
-          (audioPlaylist.endList && this.tech_.preload() !== 'none')) {
-        this.audioSegmentLoader_.load();
-      }
-    });
-
-    this.audioPlaylistLoader_.on('loadedplaylist', () => {
-      let updatedPlaylist;
-
-      if (this.audioPlaylistLoader_) {
-        updatedPlaylist = this.audioPlaylistLoader_.media();
-      }
-
-      if (!updatedPlaylist) {
-        // only one playlist to select
-        this.audioPlaylistLoader_.media(
-          this.audioPlaylistLoader_.playlists.master.playlists[0]);
-        return;
-      }
-
-      this.audioSegmentLoader_.playlist(updatedPlaylist, this.requestOptions_);
-    });
-
-    this.audioPlaylistLoader_.on('error', () => {
-      videojs.log.warn('Problem encountered loading the alternate audio track' +
-                       '. Switching back to default.');
-      this.audioSegmentLoader_.abort();
-      this.setupAudio();
-    });
+    newPlaylistLoader.load();
   }
 
   /**
@@ -1104,17 +912,18 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * invoked again if the track is changed.
    */
   setupSubtitles() {
-    let subtitleGroup = this.activeSubtitleGroup_();
-    let track = this.activeSubtitleTrack_();
+    const activePlaylistLoader = this.subtitleGroups_.activePlaylistLoader;
+    const subtitleGroup = this.activeSubtitleGroup_();
+    const track = this.activeSubtitleTrack_();
 
     this.subtitleSegmentLoader_.pause();
 
+    if (activePlaylistLoader) {
+      activePlaylistLoader.pause();
+    }
+
     if (!track) {
-      // stop playlist and segment loading for subtitles
-      if (this.subtitlePlaylistLoader_) {
-        this.subtitlePlaylistLoader_.dispose();
-        this.subtitlePlaylistLoader_ = null;
-      }
+      this.subtitleGroups_.activePlaylistLoader = null;
       return;
     }
 
@@ -1122,65 +931,21 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return subtitleProperties.id === track.id;
     })[0];
 
-    // startup playlist and segment loaders for the enabled subtitle track
-    if (!this.subtitlePlaylistLoader_ ||
-        // if the media hasn't loaded yet, we don't have the URI to check, so it is
-        // easiest to simply recreate the playlist loader
-        !this.subtitlePlaylistLoader_.media() ||
-        this.subtitlePlaylistLoader_.media().resolvedUri !== properties.resolvedUri) {
+    const newPlaylistLoader = properties.playlistLoader;
 
-      if (this.subtitlePlaylistLoader_) {
-        this.subtitlePlaylistLoader_.dispose();
-      }
+    this.subtitleGroups_.activePlaylistLoader = newPlaylistLoader;
+
+    if (!newPlaylistLoader.media() ||
+        newPlaylistLoader.media().resolvedUri !== properties.resolvedUri) {
 
       // reset the segment loader only when the subtitle playlist is changed instead of
       // every time setupSubtitles is called since switching subtitle tracks fires
       // multiple `change` events on the TextTrackList
       this.subtitleSegmentLoader_.resetEverything();
-
-      // can't reuse playlistloader because we're only using single renditions and not a
-      // proper master
-      this.subtitlePlaylistLoader_ = new PlaylistLoader(properties.resolvedUri,
-                                                        this.hls_,
-                                                        this.withCredentials);
-
-      this.subtitlePlaylistLoader_.on('loadedmetadata', () => {
-        let subtitlePlaylist = this.subtitlePlaylistLoader_.media();
-
-        this.subtitleSegmentLoader_.playlist(subtitlePlaylist, this.requestOptions_);
-        this.subtitleSegmentLoader_.track(this.activeSubtitleTrack_());
-
-        // if the video is already playing, or if this isn't a live video and preload
-        // permits, start downloading segments
-        if (!this.tech_.paused() ||
-            (subtitlePlaylist.endList && this.tech_.preload() !== 'none')) {
-          this.subtitleSegmentLoader_.load();
-        }
-      });
-
-      this.subtitlePlaylistLoader_.on('loadedplaylist', () => {
-        let updatedPlaylist;
-
-        if (this.subtitlePlaylistLoader_) {
-          updatedPlaylist = this.subtitlePlaylistLoader_.media();
-        }
-
-        if (!updatedPlaylist) {
-          return;
-        }
-
-        this.subtitleSegmentLoader_.playlist(updatedPlaylist, this.requestOptions_);
-      });
-
-      this.subtitlePlaylistLoader_.on('error', this.handleSubtitleError_.bind(this));
     }
 
-    if (this.subtitlePlaylistLoader_.media() &&
-        this.subtitlePlaylistLoader_.media().resolvedUri === properties.resolvedUri) {
-      this.subtitleSegmentLoader_.load();
-    } else {
-      this.subtitlePlaylistLoader_.load();
-    }
+    this.subtitleSegmentLoader_.load();
+    newPlaylistLoader.load();
   }
 
   /**
@@ -1301,7 +1066,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
   onEndOfStream() {
     let isEndOfStream = this.mainSegmentLoader_.ended_;
 
-    if (this.audioPlaylistLoader_) {
+    if (this.audioGroups_.activePlaylistLoader) {
       // if the audio playlist loader exists, then alternate audio is active, so we need
       // to wait for both the main and audio segment loaders to call endOfStream
       isEndOfStream = isEndOfStream && this.audioSegmentLoader_.ended_;
@@ -1412,10 +1177,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   pauseLoading() {
     this.mainSegmentLoader_.pause();
-    if (this.audioPlaylistLoader_) {
+    if (this.audioGroups_.activePlaylistLoader) {
       this.audioSegmentLoader_.pause();
     }
-    if (this.subtitlePlaylistLoader_) {
+    if (this.subtitleGroups_.activePlaylistLoader) {
       this.subtitleSegmentLoader_.pause();
     }
   }
@@ -1456,11 +1221,11 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // location
     this.mainSegmentLoader_.resetEverything();
     this.mainSegmentLoader_.abort();
-    if (this.audioPlaylistLoader_) {
+    if (this.audioGroups_.activePlaylistLoader) {
       this.audioSegmentLoader_.resetEverything();
       this.audioSegmentLoader_.abort();
     }
-    if (this.subtitlePlaylistLoader_) {
+    if (this.subtitleGroups_.activePlaylistLoader) {
       this.subtitleSegmentLoader_.resetEverything();
       this.subtitleSegmentLoader_.abort();
     }
@@ -1522,8 +1287,8 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return;
     }
 
-    if (this.audioPlaylistLoader_) {
-      media = this.audioPlaylistLoader_.media();
+    if (this.audioGroups_.activePlaylistLoader) {
+      media = this.audioGroups_.activePlaylistLoader.media();
       expired = this.syncController_.getExpiredTime(media, this.mediaSource.duration);
 
       if (expired === null) {
@@ -1595,11 +1360,16 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.masterPlaylistLoader_.dispose();
     this.mainSegmentLoader_.dispose();
 
-    if (this.audioPlaylistLoader_) {
-      this.audioPlaylistLoader_.dispose();
+    for (let groupLabel in this.audioGroups_.groups) {
+      if (this.audioGroups_.groups[groupLabel].playlistLoader) {
+        this.audioGroups_.groups[groupLabel].playlistLoader.dispose();
+      }
     }
-    if (this.subtitlePlaylistLoader_) {
-      this.subtitlePlaylistLoader_.dispose();
+
+    for (let groupLabel in this.subtitleGroups_.groups) {
+      if (this.subtitleGroups_.groups[groupLabel].playlistLoader) {
+        this.subtitleGroups_.groups[groupLabel].playlistLoader.dispose();
+      }
     }
     this.audioSegmentLoader_.dispose();
     this.subtitleSegmentLoader_.dispose();

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -41,24 +41,16 @@ export const stopLoaders = (segmentLoader, mediaType) => {
 /**
  * Start loading provided segment loader and playlist loader
  *
- * @param {SegmentLoader} segmentLoader
- *        SegmentLoader to start loading
  * @param {PlaylistLoader} playlistLoader
  *        PlaylistLoader to start loading
  * @param {Object} mediaType
  *        Active media type
  * @function startLoaders
  */
-export const startLoaders = (segmentLoader, playlistLoader, mediaType) => {
+export const startLoaders = (playlistLoader, mediaType) => {
+  // Segment loader will be started after `loadedmetadata` or `loadedplaylist` from the
+  // playlist loader
   mediaType.activePlaylistLoader = playlistLoader;
-
-  if (playlistLoader.media()) {
-    // only begin loading in the segment loader if the playlist loader has loaded its
-    // media
-    segmentLoader.playlist(playlistLoader.media());
-    segmentLoader.load();
-  }
-
   playlistLoader.load();
 };
 
@@ -110,7 +102,7 @@ export const onGroupChanged = (type, settings) => () => {
   // Non-destructive resync
   segmentLoader.resyncLoader();
 
-  startLoaders(segmentLoader, activeGroup.playlistLoader, mediaType);
+  startLoaders(activeGroup.playlistLoader, mediaType);
 };
 
 /**
@@ -158,7 +150,7 @@ export const onTrackChanged = (type, settings) => () => {
     // Nothing has actually changed. This can happen because track change events can fire
     // multiple times for a "single" change. One for enabling the new active track, and
     // one for disabling the track that was active
-    startLoaders(segmentLoader, activeGroup.playlistLoader, mediaType);
+    startLoaders(activeGroup.playlistLoader, mediaType);
     return;
   }
 
@@ -170,7 +162,7 @@ export const onTrackChanged = (type, settings) => () => {
   // destructive reset
   segmentLoader.resetEverything();
 
-  startLoaders(segmentLoader, activeGroup.playlistLoader, mediaType);
+  startLoaders(activeGroup.playlistLoader, mediaType);
 };
 
 export const onError = {
@@ -292,9 +284,7 @@ export const setupListeners = {
     playlistLoader.on('loadedplaylist', () => {
       segmentLoader.playlist(playlistLoader.media(), requestOptions);
 
-      // If the player isn't paused, ensure that the segment loader is running,
-      // as it is possible that it was temporarily stopped while waiting for
-      // a playlist (e.g., in case the playlist errored and we re-requested it).
+      // If the player isn't paused, ensure that the segment loader is running
       if (!tech.paused()) {
         segmentLoader.load();
       }
@@ -337,9 +327,7 @@ export const setupListeners = {
     playlistLoader.on('loadedplaylist', () => {
       segmentLoader.playlist(playlistLoader.media(), requestOptions);
 
-      // If the player isn't paused, ensure that the segment loader is running,
-      // as it is possible that it was temporarily stopped while waiting for
-      // a playlist (e.g., in case the playlist errored and we re-requested it).
+      // If the player isn't paused, ensure that the segment loader is running
       if (!tech.paused()) {
         segmentLoader.load();
       }

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -1,0 +1,178 @@
+import videojs from 'video.js';
+import PlaylistLoader from './playlist-loader';
+
+const setupListeners = {
+  /**
+   * Setup event listeners for audio playlist loader
+   */
+  AUDIO: (playlistLoader, masterPlaylistController) => {
+    const segmentLoader = masterPlaylistController.audioSegmentLoader_;
+    const tech = masterPlaylistController.tech_;
+    const options = masterPlaylistController.requestOptions_;
+
+    playlistLoader.on('loadedmetadata', () => {
+      const media = playlistLoader.media();
+
+      segmentLoader.playlist(media, options);
+
+      // if the video is already playing, or if this isn't a live video and preload
+      // permits, start downloading segments
+      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
+        segmentLoader.load();
+      }
+    });
+
+    playlistLoader.on('loadedplaylist', () => {
+      segmentLoader.playlist(playlistLoader.media(), options);
+    });
+
+    playlistLoader.on('error', () => {
+      videojs.log.warn('Problem encountered loading the alternate audio track' +
+                         '. Switching back to default.');
+      segmentLoader.abort();
+    });
+  },
+  /**
+   * Setup event listeners for subtitle playlist loader
+   */
+  SUBTITLES: (playlistLoader, masterPlaylistController) => {
+    const segmentLoader = masterPlaylistController.subtitleSegmentLoader_;
+    const tech = masterPlaylistController.tech_;
+    const options = masterPlaylistController.requestOptions_;
+
+    playlistLoader.on('loadedmetadata', () => {
+      const media = playlistLoader.media();
+
+      segmentLoader.playlist(media, options);
+      segmentLoader.track(masterPlaylistController.activeSubtitleTrack_());
+
+      // if the video is already playing, or if this isn't a live video and preload
+      // permits, start downloading segments
+      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
+        segmentLoader.load();
+      }
+    });
+
+    playlistLoader.on('loadedplaylist', () => {
+      segmentLoader.playlist(playlistLoader.media(), options);
+    });
+
+    playlistLoader.on('error', () => {
+      masterPlaylistController.handleSubtitleError_();
+    });
+  }
+};
+
+/**
+ * Convert the properties of an HLS track into an audioTrackKind.
+ *
+ * @private
+ */
+const audioTrackKind_ = (properties) => {
+  let kind = properties.default ? 'main' : 'alternative';
+
+  if (properties.characteristics &&
+      properties.characteristics.indexOf('public.accessibility.describes-video') >= 0) {
+    kind = 'main-desc';
+  }
+
+  return kind;
+};
+
+const initialize = {
+  /**
+   * Setup playlist loaders and tracks for audio groups
+   */
+  AUDIO: (masterGroups, mediaGroups, mediaTracks, masterPlaylistController) => {
+    // force a default if we have none or we are not
+    // in html5 mode (the only mode to support more than one
+    // audio track)
+    if (!masterGroups.AUDIO ||
+        Object.keys(masterGroups.AUDIO).length ==== 0 ||
+        mode !== 'html5') {
+      masterGroups.AUDIO = { main: { default: { defualt: true } } };
+    }
+
+    for (let masterGroup in masterGroups.AUDIO) {
+      if (!mediaGroups[masterGroup]) {
+        mediaGroups[masterGroup] = [];
+      }
+
+      for (let label in masterGroups.AUDIO[masterGroup]) {
+        const properties = videojs.mergeOptions({
+          id: label,
+          playlistLoader: new PlaylistLoader(properties.resolvedUri,
+                                             masterPlaylistController.hls_,
+                                             masterPlaylistController.withCredentials)
+        }, masterGroups.AUDIO[masterGroup][label]);
+
+        setupListeners.AUDIO(properties.playlistLoader, masterPlaylistController);
+
+        mediaGroups[masterGroup].push(properties);
+
+        if (typeof mediaTracks[label] === 'undefined') {
+          const track = new videojs.AudioTrack({
+            id: label,
+            kind: audioTrackKind_(properties),
+            enabled: false,
+            language: properties.language,
+            label
+          });
+
+          mediaTracks[label] = track;
+        }
+      }
+    }
+  },
+  /**
+   * Setup playlist loaders and tracks for subtitle groups
+   */
+  SUBTITLES: (masterGroups, mediaGroups, mediaTracks, masterPlaylistController) => {
+    for (let masterGroup in masterGroups.SUBTITLES) {
+      if (!mediaGroups[masterGroup]) {
+        mediaGroups[masterGroup] = [];
+      }
+
+      for (let label in masterGroups.SUBTITLES[masterGroup]) {
+        if (masterGroups.SUBTITLES[masterGroup][label].forced) {
+          continue;
+        }
+
+        const properties = videojs.mergeOptions({
+          id: label,
+          playlistLoader: new PlaylistLoader(properties.resolvedUri,
+                                             masterPlaylistController.hls_,
+                                             masterPlaylistController.withCredentials)
+        }, masterGroups.SUBTITLES[masterGroup][label]);
+
+        setupListeners.SUBTITLES(properties.playlistLoader, masterPlaylistController);
+
+        if (typeof mediaTracks[label] === 'undefined') {
+          const track = masterPlaylistController.tech_.addRemoteTextTrack({
+            id: label,
+            kind: 'subtitles',
+            enabled: false,
+            language: properties.language,
+            label
+          }, false).track;
+
+          mediaTracks[label] = track;
+        }
+      }
+    }
+  }
+};
+
+export const initializeMediaGroup = (
+  type,
+  master,
+  mediaGroup,
+  masterPlaylistController
+) => {
+  const masterGroups = master.mediaGroups || {};
+
+  return initialize[type](masterGroups,
+                          mediaGroup.groups,
+                          mediaGroup.tracks,
+                          masterPlaylistController);
+};

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -31,7 +31,6 @@ const stopLoaders = (segmentLoader, mediaGroup) => {
   segmentLoader.pause();
 
   if (mediaGroup && mediaGroup.activePlaylistLoader) {
-    console.log('>>> stopping loader for', mediaGroup.activePlaylistLoader.media().resolvedUri);
     mediaGroup.activePlaylistLoader.pause();
     mediaGroup.activePlaylistLoader = null;
   }
@@ -56,7 +55,6 @@ const startLoaders = (segmentLoader, playlistLoader, mediaGroup) => {
     // media
     segmentLoader.playlist(playlistLoader.media());
     segmentLoader.load();
-    console.log('>>> starting loader for', playlistLoader.media().resolvedUri);
   }
 
   playlistLoader.load();
@@ -83,17 +81,12 @@ const onGroupChanged = (type, settings) => () => {
   const activeTrack = mediaGroup.activeTrack();
   const activeGroup = mediaGroup.activeGroup(activeTrack);
 
-  console.log('>>> onGroupChanged', type);
-
   stopLoaders(segmentLoader, mediaGroup);
 
   if (!activeGroup) {
     // there is no group active so we do not want to restart loaders
     return;
   }
-
-  console.log('>>> activeTrack', activeTrack.id);
-  console.log('>>> activeGroup', activeGroup.id);
 
   // Non-destructive resync
   segmentLoader.resyncLoader();
@@ -126,8 +119,6 @@ const onTrackChanged = (type, settings) => () => {
   const activeTrack = mediaGroup.activeTrack();
   const activeGroup = mediaGroup.activeGroup(activeTrack);
   const previousActiveLoader = mediaGroup.activePlaylistLoader;
-
-  console.log('>>> onTrackChanged', type);
 
   stopLoaders(segmentLoader, mediaGroup);
 

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -31,7 +31,7 @@ const audioTrackKind_ = (properties) => {
  *        Active media group
  * @function stopLoaders
  */
-const stopLoaders = (segmentLoader, mediaGroup) => {
+export const stopLoaders = (segmentLoader, mediaGroup) => {
   segmentLoader.abort();
   segmentLoader.pause();
 
@@ -52,7 +52,7 @@ const stopLoaders = (segmentLoader, mediaGroup) => {
  *        Active media group
  * @function startLoaders
  */
-const startLoaders = (segmentLoader, playlistLoader, mediaGroup) => {
+export const startLoaders = (segmentLoader, playlistLoader, mediaGroup) => {
   mediaGroup.activePlaylistLoader = playlistLoader;
 
   if (playlistLoader.media()) {
@@ -78,7 +78,7 @@ const startLoaders = (segmentLoader, playlistLoader, mediaGroup) => {
  *         group changes.
  * @function onGroupChanged
  */
-const onGroupChanged = (type, settings) => () => {
+export const onGroupChanged = (type, settings) => () => {
   const {
     segmentLoaders: {
       [type]: segmentLoader,
@@ -128,7 +128,7 @@ const onGroupChanged = (type, settings) => () => {
  *         track changes.
  * @function onTrackChanged
  */
-const onTrackChanged = (type, settings) => () => {
+export const onTrackChanged = (type, settings) => () => {
   const {
     segmentLoaders: {
       [type]: segmentLoader,
@@ -160,6 +160,7 @@ const onTrackChanged = (type, settings) => () => {
     // multiple times for a "single" change. One for enabling the new active track, and
     // one for disabling the track that was active
     startLoaders(segmentLoader, activeGroup.playlistLoader, mediaGroup);
+    return;
   }
 
   if (segmentLoader.track) {
@@ -173,7 +174,7 @@ const onTrackChanged = (type, settings) => () => {
   startLoaders(segmentLoader, activeGroup.playlistLoader, mediaGroup);
 };
 
-const onError = {
+export const onError = {
   /**
    * Returns a function to be called when a SegmentLoader or PlaylistLoader encounters
    * an error.
@@ -193,8 +194,6 @@ const onError = {
       mediaGroups: { [type]: mediaGroup },
       blacklistCurrentPlaylist
     } = settings;
-
-    segmentLoader.abort();
 
     stopLoaders(segmentLoader, mediaGroup);
 
@@ -242,7 +241,6 @@ const onError = {
 
     videojs.log.warn('Problem encountered loading the subtitle track.' +
                      'Disabling subtitle track.');
-    segmentLoader.abort();
 
     stopLoaders(segmentLoader, mediaGroup);
 
@@ -256,7 +254,7 @@ const onError = {
   }
 };
 
-const setupListeners = {
+export const setupListeners = {
   /**
    * Setup event listeners for audio playlist loader
    *
@@ -352,7 +350,7 @@ const setupListeners = {
   }
 };
 
-const initialize = {
+export const initialize = {
   /**
    * Setup PlaylistLoaders and AudioTracks for the audio groups
    *
@@ -383,7 +381,7 @@ const initialize = {
     if (!masterGroups[type] ||
         Object.keys(masterGroups[type]).length === 0 ||
         mode !== 'html5') {
-      masterGroups[type] = { main: { default: { defualt: true } } };
+      masterGroups[type] = { main: { default: { default: true } } };
     }
 
     for (let masterGroup in masterGroups[type]) {
@@ -562,7 +560,7 @@ const initialize = {
  *         track is returned.
  * @function activeGroup
  */
-const activeGroup = (type, settings) => (track) => {
+export const activeGroup = (type, settings) => (track) => {
   const {
     masterPlaylistLoader,
     mediaGroups: { [type]: { groups } }
@@ -574,7 +572,7 @@ const activeGroup = (type, settings) => (track) => {
     return null;
   }
 
-  let result;
+  let result = null;
 
   if (media.attributes[type]) {
     result = groups[media.attributes[type]];
@@ -595,7 +593,7 @@ const activeGroup = (type, settings) => (track) => {
   return result.reduce((final, props) => props.id === track.id ? props : final, null);
 };
 
-const activeTrack = {
+export const activeTrack = {
   /**
    * Returns a function used to get the active track of type provided
    *
@@ -674,7 +672,7 @@ const activeTrack = {
  *        Blacklists the current rendition and forces a rendition switch.
  * @function setupMediaGroups
  */
-const setupMediaGroups = (settings) => {
+export const setupMediaGroups = (settings) => {
   ['AUDIO', 'SUBTITLES', 'CLOSED-CAPTIONS'].forEach((type) => {
     initialize[type](type, settings);
   });
@@ -739,7 +737,7 @@ const setupMediaGroups = (settings) => {
  *         Object to store the loaders, tracks, and utility methods for each media group
  * @function createMediaGroups
  */
-const createMediaGroups = () => {
+export const createMediaGroups = () => {
   const mediaGroups = {};
 
   ['AUDIO', 'SUBTITLES', 'CLOSED-CAPTIONS'].forEach((type) => {
@@ -755,9 +753,4 @@ const createMediaGroups = () => {
   });
 
   return mediaGroups;
-};
-
-export default {
-  createMediaGroups,
-  setupMediaGroups
 };

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -1,68 +1,6 @@
 import videojs from 'video.js';
 import PlaylistLoader from './playlist-loader';
 
-const setupListeners = {
-  /**
-   * Setup event listeners for audio playlist loader
-   */
-  AUDIO: (playlistLoader, masterPlaylistController) => {
-    const segmentLoader = masterPlaylistController.audioSegmentLoader_;
-    const tech = masterPlaylistController.tech_;
-    const options = masterPlaylistController.requestOptions_;
-
-    playlistLoader.on('loadedmetadata', () => {
-      const media = playlistLoader.media();
-
-      segmentLoader.playlist(media, options);
-
-      // if the video is already playing, or if this isn't a live video and preload
-      // permits, start downloading segments
-      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
-        segmentLoader.load();
-      }
-    });
-
-    playlistLoader.on('loadedplaylist', () => {
-      segmentLoader.playlist(playlistLoader.media(), options);
-    });
-
-    playlistLoader.on('error', () => {
-      videojs.log.warn('Problem encountered loading the alternate audio track' +
-                         '. Switching back to default.');
-      segmentLoader.abort();
-    });
-  },
-  /**
-   * Setup event listeners for subtitle playlist loader
-   */
-  SUBTITLES: (playlistLoader, masterPlaylistController) => {
-    const segmentLoader = masterPlaylistController.subtitleSegmentLoader_;
-    const tech = masterPlaylistController.tech_;
-    const options = masterPlaylistController.requestOptions_;
-
-    playlistLoader.on('loadedmetadata', () => {
-      const media = playlistLoader.media();
-
-      segmentLoader.playlist(media, options);
-      segmentLoader.track(masterPlaylistController.activeSubtitleTrack_());
-
-      // if the video is already playing, or if this isn't a live video and preload
-      // permits, start downloading segments
-      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
-        segmentLoader.load();
-      }
-    });
-
-    playlistLoader.on('loadedplaylist', () => {
-      segmentLoader.playlist(playlistLoader.media(), options);
-    });
-
-    playlistLoader.on('error', () => {
-      masterPlaylistController.handleSubtitleError_();
-    });
-  }
-};
-
 /**
  * Convert the properties of an HLS track into an audioTrackKind.
  *
@@ -79,47 +17,140 @@ const audioTrackKind_ = (properties) => {
   return kind;
 };
 
+const setupListeners = {
+  /**
+   * Setup event listeners for audio playlist loader
+   */
+  AUDIO: (type, playlistLoader, settings) => {
+    if (!playlistLoader) {
+      // no playlist loader means audio will be muxed with the video
+      return;
+    }
+
+    const {
+      tech,
+      requestOptions,
+      segmentLoaders: { [type]: segmentLoader }
+    } = settings;
+
+    playlistLoader.on('loadedmetadata', () => {
+      const media = playlistLoader.media();
+
+      segmentLoader.playlist(media, requestOptions);
+
+      // if the video is already playing, or if this isn't a live video and preload
+      // permits, start downloading segments
+      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
+        segmentLoader.load();
+      }
+    });
+
+    playlistLoader.on('loadedplaylist', () => {
+      segmentLoader.playlist(playlistLoader.media(), requestOptions);
+    });
+
+    playlistLoader.on('error', () => {
+      videojs.log.warn('Problem encountered loading the alternate audio track' +
+                         '. Switching back to default.');
+      segmentLoader.abort();
+    });
+  },
+  /**
+   * Setup event listeners for subtitle playlist loader
+   */
+  SUBTITLES: (type, playlistLoader, settings) => {
+    const {
+      tech,
+      requestOptions,
+      segmentLoaders: { [type]: segmentLoader }
+    } = settings;
+
+    playlistLoader.on('loadedmetadata', () => {
+      const media = playlistLoader.media();
+
+      segmentLoader.playlist(media, requestOptions);
+      segmentLoader.track(masterPlaylistController.activeSubtitleTrack_());
+
+      // if the video is already playing, or if this isn't a live video and preload
+      // permits, start downloading segments
+      if (!tech.paused() || (media.endList && tech.preload() !== 'none')) {
+        segmentLoader.load();
+      }
+    });
+
+    playlistLoader.on('loadedplaylist', () => {
+      segmentLoader.playlist(playlistLoader.media(), requestOptions);
+    });
+
+    playlistLoader.on('error', () => {
+      // masterPlaylistController.handleSubtitleError_();
+    });
+  }
+};
+
 const initialize = {
   /**
    * Setup playlist loaders and tracks for audio groups
    */
-  AUDIO: (masterGroups, mediaGroups, mediaTracks, masterPlaylistController) => {
+  AUDIO: (type, settings) => {
+    const {
+      mode,
+      hls,
+      requestOptions: { withCredentials },
+      master: { mediaGroups: masterGroups},
+      mediaGroups: {
+        [type]: {
+          groups,
+          tracks
+        }
+      }
+    } = settings;
+
     // force a default if we have none or we are not
     // in html5 mode (the only mode to support more than one
     // audio track)
-    if (!masterGroups.AUDIO ||
-        Object.keys(masterGroups.AUDIO).length ==== 0 ||
+    if (!masterGroups[type] ||
+        Object.keys(masterGroups[type]).length === 0 ||
         mode !== 'html5') {
-      masterGroups.AUDIO = { main: { default: { defualt: true } } };
+      masterGroups[type] = { main: { default: { defualt: true } } };
     }
 
-    for (let masterGroup in masterGroups.AUDIO) {
-      if (!mediaGroups[masterGroup]) {
-        mediaGroups[masterGroup] = [];
+    for (let masterGroup in masterGroups[type]) {
+      if (!groups[masterGroup]) {
+        groups[masterGroup] = [];
       }
 
-      for (let label in masterGroups.AUDIO[masterGroup]) {
-        const properties = videojs.mergeOptions({
-          id: label,
-          playlistLoader: new PlaylistLoader(properties.resolvedUri,
-                                             masterPlaylistController.hls_,
-                                             masterPlaylistController.withCredentials)
-        }, masterGroups.AUDIO[masterGroup][label]);
+      for (let label in masterGroups[type][masterGroup]) {
+        let properties = masterGroups[type][masterGroup][label];
+        let playlistLoader;
 
-        setupListeners.AUDIO(properties.playlistLoader, masterPlaylistController);
+        if (properties.resolvedUri) {
+          playlistLoader = new PlaylistLoader(properties.resolvedUri,
+                                              hls,
+                                              withCredentials);
+        } else {
+          // no resolvedUri means the audio is muxed with the video when using this
+          // audio track
+          playlistLoader = null;
+        }
 
-        mediaGroups[masterGroup].push(properties);
+        properties = videojs.mergeOptions({ id: label, playlistLoader }, properties);
 
-        if (typeof mediaTracks[label] === 'undefined') {
+        setupListeners[type](type, properties.playlistLoader, settings);
+
+        groups[masterGroup].push(properties);
+
+        if (typeof tracks[label] === 'undefined') {
           const track = new videojs.AudioTrack({
             id: label,
             kind: audioTrackKind_(properties),
             enabled: false,
             language: properties.language,
+            default: properties.default,
             label
           });
 
-          mediaTracks[label] = track;
+          tracks[label] = track;
         }
       }
     }
@@ -127,28 +158,45 @@ const initialize = {
   /**
    * Setup playlist loaders and tracks for subtitle groups
    */
-  SUBTITLES: (masterGroups, mediaGroups, mediaTracks, masterPlaylistController) => {
-    for (let masterGroup in masterGroups.SUBTITLES) {
-      if (!mediaGroups[masterGroup]) {
-        mediaGroups[masterGroup] = [];
+  SUBTITLES: (type, settings) => {
+    const {
+      tech,
+      hls,
+      requestOptions: { withCredentials },
+      master: { mediaGroups: masterGroups},
+      mediaGroups: {
+        [type]: {
+          groups,
+          tracks
+        }
+      }
+    } = settings;
+
+    for (let masterGroup in masterGroups[type]) {
+      if (!groups[masterGroup]) {
+        groups[masterGroup] = [];
       }
 
-      for (let label in masterGroups.SUBTITLES[masterGroup]) {
-        if (masterGroups.SUBTITLES[masterGroup][label].forced) {
+      for (let label in masterGroups[type][masterGroup]) {
+        if (masterGroups[type][masterGroup][label].forced) {
           continue;
         }
 
-        const properties = videojs.mergeOptions({
+        let properties = masterGroups[type][masterGroup][label];
+
+        properties = videojs.mergeOptions({
           id: label,
           playlistLoader: new PlaylistLoader(properties.resolvedUri,
-                                             masterPlaylistController.hls_,
-                                             masterPlaylistController.withCredentials)
-        }, masterGroups.SUBTITLES[masterGroup][label]);
+                                             hls,
+                                             withCredentials)
+        }, properties);
 
-        setupListeners.SUBTITLES(properties.playlistLoader, masterPlaylistController);
+        setupListeners[type](type, properties.playlistLoader, settings);
 
-        if (typeof mediaTracks[label] === 'undefined') {
-          const track = masterPlaylistController.tech_.addRemoteTextTrack({
+        groups[masterGroup].push(properties);
+
+        if (typeof tracks[label] === 'undefined') {
+          const track = tech.addRemoteTextTrack({
             id: label,
             kind: 'subtitles',
             enabled: false,
@@ -156,23 +204,258 @@ const initialize = {
             label
           }, false).track;
 
-          mediaTracks[label] = track;
+          tracks[label] = track;
+        }
+      }
+    }
+  },
+  /**
+   * Setup tracks for closed-caption groups
+   */
+  'CLOSED-CAPTIONS': (type, settings) => {
+    const {
+      tech,
+      master: { mediaGroups: masterGroups},
+      mediaGroups: {
+        [type]: {
+          groups,
+          tracks
+        }
+      }
+    } = settings;
+
+    for (let masterGroup in masterGroups[type]) {
+      if (!groups[masterGroup]) {
+        groups[masterGroup] = [];
+      }
+
+      for (let label in masterGroups[type][masterGroup]) {
+        let properties = masterGroups[type][masterGroup][label];
+
+        // We only support CEA608 captions for now, so ignore anything that
+        // doesn't use a CCx INSTREAM-ID
+        if (properties.instreamId.match(/CC\d/)) {
+          continue;
+        }
+
+        groups[masterGroup].push(videojs.mergeOptions({ id: label }, properties));
+
+        if (typeof tracks[label] === 'undefined') {
+          const track = tech.addRemoteTextTrack({
+            id: properties.instreamId,
+            kind: 'captions',
+            enabled: false,
+            language: properties.language,
+            label
+          }, false).track;
+
+          tracks[label] = track;
         }
       }
     }
   }
 };
 
-export const initializeMediaGroup = (
-  type,
-  master,
-  mediaGroup,
-  masterPlaylistController
-) => {
-  const masterGroups = master.mediaGroups || {};
+/**
+ * Returns a function used to get the active group of type provided
+ */
+const activeGroup = (type, settings) => (track) => {
+  const {
+    masterPlaylistLoader,
+    mediaGroups: { [type]: { groups } }
+  } = settings;
 
-  return initialize[type](masterGroups,
-                          mediaGroup.groups,
-                          mediaGroup.tracks,
-                          masterPlaylistController);
+  const media = masterPlaylistLoader.media();
+
+  if (!media) {
+    return null;
+  }
+
+  let result;
+
+  if (media.attributes[type]) {
+    result = groups[media.attributes[type]];
+  }
+
+  result = result || groups.main;
+
+  if (typeof track === 'undefined') {
+    return result;
+  }
+
+  if (track === null) {
+    // An active track was specified so a corresponding group is expected. track === null
+    // means no track is currently active so there is no corresponding group
+    return null;
+  }
+
+  return result.reduce((final, props) => props.id === track.id ? props : final, null);
 };
+
+const activeTrack = {
+  /**
+   * Returns a function used to get the active audio track
+   */
+  AUDIO: (type, settings) => () => {
+    const { mediaGroups: [type]: { tracks } } = settings;
+
+    for (let id in tracks) {
+      if (tracks[id].enabled) {
+        return tracks[id];
+      }
+    }
+
+    return null;
+  },
+  /**
+   * Returns a function used to get the active audio track
+   */
+  SUBTITLES: (type, settings) => () => {
+    const { mediaGroups: { [type]: { tracks } } = settings;
+
+    for (let id in tracks) {
+      if (tracks[id].mode === 'showing') {
+        return tracks[id];
+      }
+    }
+
+    return null;
+  }
+};
+
+const stopLoaders = (segmentLoader, mediaGroup) => {
+  segmentLoader.pause();
+
+  if (mediaGroup && mediaGroup.activePlaylistLoader) {
+    mediaGroup.activePlaylistLoader.pause();
+    mediaGroup.activePlaylistLoader = null;
+  }
+};
+
+const startLoaders = (segmentLoader, playlistLoader, mediaGroup) => {
+  mediaGroup.activePlaylistLoader = playlistLoader;
+
+  if (playlistLoader.media()) {
+    // only begin loading in the segment loader if the playlist loader has loaded its
+    // media
+    segmentLoader.load();
+  }
+
+  playlistLoader.load();
+}
+
+/**
+ * Non-destructive resync of the segmentLoaders to prepare to continue appending new
+ * audio data at the end of the current buffered region
+ */
+const onGroupChanged = (type, settings) => () => {
+  const {
+    segmentLoaders: { [type]: segmentLoader },
+    mediaGroups: { [type]: mediaGroup }
+  } = settings;
+  const activeTrack = mediaGroup.activeTrack();
+  const activeGroup = mediaGroup.activeGroup(activeTrack);
+
+  stopLoaders(segmentLoader, mediaGroup);
+
+  if (!activeGroup) {
+    // there is no group active so we do not want to restart loaders
+    return;
+  }
+
+  // Non-destructive resync
+  segmentLoader.resyncLoader();
+
+  startLoaders(segmentLoader, activeGroup.playlistLoader, mediaGroup);
+};
+
+const onTrackChanged = (type, settings) => () => {
+  const {
+    segmentLoaders: {
+      [type]: segmentLoader,
+      main: mainSegmentLoader
+    },
+    mediaGroups: { [type]: mediaGroup }
+  } = settings;
+  const activeTrack = mediaGroup.activeTrack();
+  const activeGroup = mediaGroup.activeGroup(activeTrack);
+
+  stopLoaders(segmentLoader, mediaGroup);
+
+  if (!activeGroup) {
+    // there is no group active so we do not want to restart loaders
+    return;
+  }
+
+  if (!activeGroup.playlistLoader) {
+    // when switching from demuxed audio/video to muxed audio/video (noted by no playlist
+    // loader for the audio group), we want to do a destructive reset of the main segment
+    // loader and not restart the audio loaders
+    mainSegmentLoader.resetEverything();
+    return;
+  }
+
+  // destructive reset
+  segmentLoader.resetEverything();
+
+  startLoaders(segmentLoader, activeGroup.playlistLoader, mediaGroup);
+};
+
+const initializeMediaGroups = (settings) => {
+  ['AUDIO', 'SUBTITLES', 'CLOSED-CAPTIONS'].forEach((type) => {
+    initialize[type](type, settings)
+  });
+
+  const {
+    mediaGroups,
+    masterPlaylistLoader,
+    tech,
+    hls
+  } = settings;
+
+  // setup active group and track getters and change event handlers
+
+  ['AUDIO', 'SUBTITLES'].forEach((type) => {
+    mediaGroups[type].activeGroup = activeGroup(type, settings);
+    mediaGroups[type].activeTrack = activeTrack[type](type, settings);
+    mediaGroups[type].onGroupChanged = onGroupChanged(type, settings);
+    mediaGroups[type].onTrackChanged = onTrackChanged(type, settings);
+  });
+
+  // DO NOT enable the default subtitle or caption track.
+  // DO enable the default audio track
+  const audioGroup = mediaGroups.AUDIO.activeGroup();
+  const groupId = (audioGroup.filter(group => group.default)[0] || audioGroup[0]).id;
+
+  mediaGroups.AUDIO.tracks[groupId].enabled = true;
+  mediaGroups.AUDIO.onTrackChanged();
+
+  masterPlaylistLoader.on('mediachange', () => {
+    ['AUDIO', 'SUBTITLES'].forEach(type => mediaGroups[type].onGroupChanged());
+  });
+
+  // custom audio track change event handler for usage event
+  const onAudioTrackChanged = () => {
+    mediaGroups.AUDIO.onTrackChanged();
+    tech.trigger({ type: 'usage', name: 'hls-audio-change' });
+  };
+
+  tech.audioTracks().addEventListener('change', onAudioTrackChanged);
+  tech.remoteTextTracks().addEventListener('change',
+    mediaGroups.SUBTITLES.onTrackChanged);
+
+  hls.on('dispose', () => {
+    tech.audioTracks().removeEventListener('change', onAudioTrackChanged);
+    tech.remoteTextTracks().removeEventListener('change',
+      mediaGroups.SUBTITLES.onTrackChanged);
+  });
+
+  // clear existing audio tracks and add the ones we just created
+  tech.clearTracks('audio');
+
+  for (let id in mediaGroups.AUDIO.tracks) {
+    tech.audioTracks().addTrack(mediaGroups.AUDIO.tracks[id]);
+  }
+};
+
+export default initializeMediaGroups;

--- a/src/media-groups.js
+++ b/src/media-groups.js
@@ -83,8 +83,9 @@ const onGroupChanged = (type, settings) => () => {
 
   stopLoaders(segmentLoader, mediaGroup);
 
-  if (!activeGroup) {
-    // there is no group active so we do not want to restart loaders
+  if (!activeGroup || !activeGroup.playlistLoader) {
+    // there is no group active or the group does not have a PlaylistLoader (e.g. audio
+    // muxed with video) so we do not want to restart loaders
     return;
   }
 

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -123,7 +123,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
   let mediaUpdateTimeout;
   let request;
   let playlistRequestError;
-  let currentRequestId;
   let haveMetadata;
 
   PlaylistLoader.prototype.constructor.call(this);
@@ -222,7 +221,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       oldRequest.onreadystatechange = null;
       oldRequest.abort();
     }
-    currentRequestId = null;
   };
 
   /**
@@ -463,8 +461,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
    * start loading of the playlist
    */
   loader.start = () => {
-    var startingState = loader.state;
-
     loader.started = true;
 
     // request the specified URL

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -401,18 +401,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
     });
   });
 
-  // setup initial sync info
-  loader.on('firstplay', function() {
-    let playlist = loader.media();
-
-    if (playlist) {
-      playlist.syncInfo = {
-        mediaSequence: playlist.mediaSequence,
-        time: 0
-      };
-    }
-  });
-
   /**
    * pause loading of the playlist
    */

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -40,10 +40,6 @@ const updateSegments = function(original, update, offset) {
   return result;
 };
 
-const RID = function() {
-  return 'playlist-loader-request-' + Math.random();
-};
-
 /**
   * Returns a new master playlist that is the result of merging an
   * updated media playlist into the original version. If the
@@ -353,8 +349,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       this.trigger('mediachanging');
     }
 
-    let requestId = currentRequestId = RID();
-
     request = this.hls_.xhr({
       uri: resolveUrl(loader.master.uri, playlist.uri),
       withCredentials
@@ -362,10 +356,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       // disposed
       if (!request) {
         return;
-      }
-
-      if (requestId !== currentRequestId) {
-        console.log('new request started before this returned');
       }
 
       if (error) {
@@ -394,13 +384,10 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
   loader.on('mediaupdatetimeout', function() {
     if (loader.state !== 'HAVE_METADATA') {
       // only refresh the media playlist if no other activity is going on
-      console.log('>>> not refreshing playlist. other activity happening')
       return;
     }
 
     loader.state = 'HAVE_CURRENT_METADATA';
-
-    let requestId = currentRequestId = RID();
 
     request = this.hls_.xhr({
       uri: resolveUrl(loader.master.uri, loader.media().uri),
@@ -411,13 +398,10 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
         return;
       }
 
-      if (requestId !== currentRequestId) {
-        console.log('new request started before this returned');
-      }
-
       if (error) {
         return playlistRequestError(request, loader.media().uri, 'HAVE_METADATA');
       }
+
       haveMetadata(request, loader.media().uri);
     });
   });
@@ -483,8 +467,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
 
     loader.started = true;
 
-    let requestId = currentRequestId = RID();
-
     // request the specified URL
     request = this.hls_.xhr({
       uri: srcUrl,
@@ -497,10 +479,6 @@ const PlaylistLoader = function(srcUrl, hls, withCredentials) {
       // disposed
       if (!request) {
         return;
-      }
-
-      if (requestId !== currentRequestId) {
-        console.log('new request started before this returned');
       }
 
       // clear the loader's request reference

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -358,7 +358,8 @@ export default class SyncController extends videojs.EventTarget {
    * @param {SegmentInfo} segmentInfo - The current active request information
    */
   probeSegmentInfo(segmentInfo) {
-    let segment = segmentInfo.segment;
+    const segment = segmentInfo.segment;
+    const playlist = segmentInfo.playlist;
     let timingInfo;
 
     if (segment.map) {
@@ -370,6 +371,15 @@ export default class SyncController extends videojs.EventTarget {
     if (timingInfo) {
       if (this.calculateSegmentTimeMapping_(segmentInfo, timingInfo)) {
         this.saveDiscontinuitySyncInfo_(segmentInfo);
+
+        // If the playlist does not have sync information yet, record that information
+        // now with segment timing information
+        if (!playlist.syncInfo) {
+          playlist.syncInfo = {
+            mediaSequence: playlist.mediaSequence + segmentInfo.mediaIndex,
+            time: segment.start
+          };
+        }
       }
     }
   }

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -257,7 +257,7 @@ class HlsHandler extends Component {
     });
 
     this.audioTrackChange_ = () => {
-      this.masterPlaylistController_.setupAudio();
+      this.masterPlaylistController_.audioTrackChanged();
       this.tech_.trigger({type: 'usage', name: 'hls-audio-change'});
     };
 
@@ -452,14 +452,6 @@ class HlsHandler extends Component {
     this.masterPlaylistController_.on('selectedinitialmedia', () => {
       // Add the manual rendition mix-in to HlsHandler
       renditionSelectionMixin(this);
-    });
-
-    this.masterPlaylistController_.on('audioupdate', () => {
-      // clear current audioTracks
-      this.tech_.clearTracks('audio');
-      this.masterPlaylistController_.activeAudioGroup().forEach((audioTrack) => {
-        this.tech_.audioTracks().addTrack(audioTrack);
-      });
     });
 
     // the bandwidth of the primary segment loader is our best

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -130,11 +130,6 @@ export default class VTTSegmentLoader extends SegmentLoader {
 
     this.subtitlesTrack_ = track;
 
-    console.log('*******');
-    console.log('>>> setting subtitle track', track);
-    console.trace();
-    console.log('*******');
-
     // if we were unpaused but waiting for a sourceUpdater, start
     // buffering now
     if (this.state === 'INIT' && this.couldBeginLoading_()) {

--- a/src/vtt-segment-loader.js
+++ b/src/vtt-segment-loader.js
@@ -118,17 +118,30 @@ export default class VTTSegmentLoader extends SegmentLoader {
   /**
    * Set a subtitle track on the segment loader to add subtitles to
    *
-   * @param {TextTrack} track
+   * @param {TextTrack=} track
    *        The text track to add loaded subtitles to
+   * @return {TextTrack}
+   *        Returns the subtitles track
    */
   track(track) {
+    if (typeof track === 'undefined') {
+      return this.subtitlesTrack_;
+    }
+
     this.subtitlesTrack_ = track;
+
+    console.log('*******');
+    console.log('>>> setting subtitle track', track);
+    console.trace();
+    console.log('*******');
 
     // if we were unpaused but waiting for a sourceUpdater, start
     // buffering now
     if (this.state === 'INIT' && this.couldBeginLoading_()) {
       this.init_();
     }
+
+    return this.subtitlesTrack_;
   }
 
   /**
@@ -217,7 +230,7 @@ export default class VTTSegmentLoader extends SegmentLoader {
    * @private
    */
   handleSegment_() {
-    if (!this.pendingSegment_) {
+    if (!this.pendingSegment_ || !this.subtitlesTrack_) {
       this.state = 'READY';
       return;
     }

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2227,65 +2227,6 @@ QUnit.test('subtitle segment loader resets on seeks', function(assert) {
   assert.equal(loadCount, 1, 'called load on subtitle segment loader');
 });
 
-QUnit.test('can get active subtitle group', function(assert) {
-  this.requests.length = 0;
-  this.player = createPlayer();
-  this.player.src({
-    src: 'manifest/master-subtitles.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-
-  this.clock.tick(1);
-
-  const masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
-
-  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
-               'no active subtitle group');
-
-  // master, contains media groups for subtitles
-  this.standardXHRResponse(this.requests.shift());
-
-  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
-               'no active subtitle group');
-
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  assert.ok(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
-    'active subtitle group');
-});
-
-QUnit.test('can get active subtitle track', function(assert) {
-  this.requests.length = 0;
-  this.player = createPlayer();
-  this.player.src({
-    src: 'manifest/master-subtitles.m3u8',
-    type: 'application/vnd.apple.mpegurl'
-  });
-
-  this.clock.tick(1);
-
-  // master, contains media groups for subtitles
-  this.standardXHRResponse(this.requests.shift());
-  // media
-  this.standardXHRResponse(this.requests.shift());
-
-  const masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
-
-  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeTrack(),
-               'no active subtitle track');
-
-  const textTracks = this.player.textTracks();
-
-  // enable first subtitle text track
-  assert.notEqual(textTracks[0].kind, 'subtitles', 'kind is not subtitles');
-  assert.equal(textTracks[1].kind, 'subtitles', 'kind is subtitles');
-  textTracks[1].mode = 'showing';
-
-  assert.ok(masterPlaylistController.mediaTypes_.SUBTITLES.activeTrack(),
-    'active subtitle track');
-});
-
 QUnit.test('calculates dynamic GOAL_BUFFER_LENGTH', function(assert) {
   const configOld = {
     GOAL_BUFFER_LENGTH: Config.GOAL_BUFFER_LENGTH,

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -566,7 +566,7 @@ function(assert) {
   let mpc = this.masterPlaylistController;
   let combinedPlaylist = mpc.master().playlists[0];
 
-  assert.ok(mpc.mediaGroups_.AUDIO.activePlaylistLoader,
+  assert.ok(mpc.mediaTypes_.AUDIO.activePlaylistLoader,
     'starts with an active playlist loader');
 
   mpc.masterPlaylistLoader_.media(combinedPlaylist);
@@ -577,7 +577,7 @@ function(assert) {
                                 '0.ts\n' +
                                 '#EXT-X-ENDLIST\n');
 
-  assert.notOk(mpc.mediaGroups_.AUDIO.activePlaylistLoader,
+  assert.notOk(mpc.mediaTypes_.AUDIO.activePlaylistLoader,
     'enabled a track in the new audio group');
 });
 
@@ -1533,7 +1533,7 @@ function(assert) {
                         videojs.createTimeRanges([[0, 10]]),
                         'main when no audio');
 
-  mpc.mediaGroups_.AUDIO.activePlaylistLoader = {
+  mpc.mediaTypes_.AUDIO.activePlaylistLoader = {
     media: () => audioMedia,
     dispose() {},
     expired_: 0
@@ -1905,7 +1905,7 @@ function(assert) {
   const master = masterPlaylistController.masterPlaylistLoader_.master;
   const caps = master.mediaGroups['CLOSED-CAPTIONS'].CCs;
   const capsArr = Object.keys(caps).map(key => Object.assign({name: key}, caps[key]));
-  const addedCaps = masterPlaylistController.mediaGroups_['CLOSED-CAPTIONS'].groups.CCs
+  const addedCaps = masterPlaylistController.mediaTypes_['CLOSED-CAPTIONS'].groups.CCs
     .map(cap => Object.assign({name: cap.id}, cap));
 
   assert.equal(capsArr.length, 4, '4 closed-caption tracks defined in playlist');
@@ -2114,7 +2114,7 @@ QUnit.test('disposes subtitle loaders on dispose', function(assert) {
 
   let masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
 
-  assert.notOk(masterPlaylistController.mediaGroups_.SUBTITLES.activePlaylistLoader,
+  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activePlaylistLoader,
                'does not start with a subtitle playlist loader');
   assert.ok(masterPlaylistController.subtitleSegmentLoader_,
             'starts with a subtitle segment loader');
@@ -2154,7 +2154,7 @@ QUnit.test('disposes subtitle loaders on dispose', function(assert) {
   assert.equal(textTracks[1].kind, 'subtitles', 'kind is subtitles');
   textTracks[1].mode = 'showing';
 
-  assert.ok(masterPlaylistController.mediaGroups_.SUBTITLES.activePlaylistLoader,
+  assert.ok(masterPlaylistController.mediaTypes_.SUBTITLES.activePlaylistLoader,
             'has a subtitle playlist loader');
   assert.ok(masterPlaylistController.subtitleSegmentLoader_,
             'has a subtitle segment loader');
@@ -2163,7 +2163,7 @@ QUnit.test('disposes subtitle loaders on dispose', function(assert) {
 
   segmentLoaderDisposeCount = 0;
 
-  masterPlaylistController.mediaGroups_.SUBTITLES.activePlaylistLoader.dispose =
+  masterPlaylistController.mediaTypes_.SUBTITLES.activePlaylistLoader.dispose =
     () => playlistLoaderDisposeCount++;
   masterPlaylistController.subtitleSegmentLoader_.dispose =
     () => segmentLoaderDisposeCount++;
@@ -2239,19 +2239,19 @@ QUnit.test('can get active subtitle group', function(assert) {
 
   const masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
 
-  assert.notOk(masterPlaylistController.mediaGroups_.SUBTITLES.activeGroup(),
+  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
                'no active subtitle group');
 
   // master, contains media groups for subtitles
   this.standardXHRResponse(this.requests.shift());
 
-  assert.notOk(masterPlaylistController.mediaGroups_.SUBTITLES.activeGroup(),
+  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
                'no active subtitle group');
 
   // media
   this.standardXHRResponse(this.requests.shift());
 
-  assert.ok(masterPlaylistController.mediaGroups_.SUBTITLES.activeGroup(),
+  assert.ok(masterPlaylistController.mediaTypes_.SUBTITLES.activeGroup(),
     'active subtitle group');
 });
 
@@ -2272,7 +2272,7 @@ QUnit.test('can get active subtitle track', function(assert) {
 
   const masterPlaylistController = this.player.tech_.hls.masterPlaylistController_;
 
-  assert.notOk(masterPlaylistController.mediaGroups_.SUBTITLES.activeTrack(),
+  assert.notOk(masterPlaylistController.mediaTypes_.SUBTITLES.activeTrack(),
                'no active subtitle track');
 
   const textTracks = this.player.textTracks();
@@ -2282,7 +2282,7 @@ QUnit.test('can get active subtitle track', function(assert) {
   assert.equal(textTracks[1].kind, 'subtitles', 'kind is subtitles');
   textTracks[1].mode = 'showing';
 
-  assert.ok(masterPlaylistController.mediaGroups_.SUBTITLES.activeTrack(),
+  assert.ok(masterPlaylistController.mediaTypes_.SUBTITLES.activeTrack(),
     'active subtitle track');
 });
 

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -1,0 +1,719 @@
+import QUnit from 'qunit';
+import {
+  useFakeEnvironment
+} from './test-helpers.js';
+import * as MediaGroups from '../src/media-groups';
+
+QUnit.module('MediaGroups', {
+  beforeEach(assert) {
+    this.env = useFakeEnvironment(assert);
+    this.clock = this.env.clock;
+    this.requests = this.env.requests;
+  },
+  afterEach(assert) {
+    this.env.restore();
+  }
+});
+
+QUnit.test('createMediaGroups creates skeleton object for all supported media groups',
+function(assert) {
+  const noopToString = 'function noop() {}';
+  const result = MediaGroups.createMediaGroups();
+
+  assert.ok(result.AUDIO, 'created AUDIO media group object');
+  assert.equal(JSON.stringify(result.AUDIO.groups), '{}',
+    'created empty object for AUDIO groups');
+  assert.equal(JSON.stringify(result.AUDIO.tracks), '{}',
+    'created empty object for AUDIO tracks');
+  assert.equal(result.AUDIO.activePlaylistLoader, null,
+    'AUDIO activePlaylistLoader is null');
+  assert.equal(result.AUDIO.activeGroup.toString(), noopToString,
+    'created noop function for AUDIO activeGroup');
+  assert.equal(result.AUDIO.activeTrack.toString(), noopToString,
+    'created noop function for AUDIO activeTrack');
+  assert.equal(result.AUDIO.onGroupChanged.toString(), noopToString,
+    'created noop function for AUDIO onGroupChanged');
+  assert.equal(result.AUDIO.onTrackChanged.toString(), noopToString,
+    'created noop function for AUDIO onTrackChanged');
+
+  assert.ok(result.SUBTITLES, 'created SUBTITLES media group object');
+  assert.equal(JSON.stringify(result.SUBTITLES.groups), '{}',
+    'created empty object for SUBTITLES groups');
+  assert.equal(JSON.stringify(result.SUBTITLES.tracks), '{}',
+    'created empty object for SUBTITLES tracks');
+  assert.equal(result.SUBTITLES.activePlaylistLoader, null,
+    'SUBTITLES activePlaylistLoader is null');
+  assert.equal(result.SUBTITLES.activeGroup.toString(), noopToString,
+    'created noop function for SUBTITLES activeGroup');
+  assert.equal(result.SUBTITLES.activeTrack.toString(), noopToString,
+    'created noop function for SUBTITLES activeTrack');
+  assert.equal(result.SUBTITLES.onGroupChanged.toString(), noopToString,
+    'created noop function for SUBTITLES onGroupChanged');
+  assert.equal(result.SUBTITLES.onTrackChanged.toString(), noopToString,
+    'created noop function for SUBTITLES onTrackChanged');
+
+  assert.ok(result['CLOSED-CAPTIONS'], 'created CLOSED-CAPTIONS media group object');
+  assert.equal(JSON.stringify(result['CLOSED-CAPTIONS'].groups), '{}',
+    'created empty object for CLOSED-CAPTIONS groups');
+  assert.equal(JSON.stringify(result['CLOSED-CAPTIONS'].tracks), '{}',
+    'created empty object for CLOSED-CAPTIONS tracks');
+  assert.equal(result['CLOSED-CAPTIONS'].activePlaylistLoader, null,
+    'CLOSED-CAPTIONS activePlaylistLoader is null');
+  assert.equal(result['CLOSED-CAPTIONS'].activeGroup.toString(), noopToString,
+    'created noop function for CLOSED-CAPTIONS activeGroup');
+  assert.equal(result['CLOSED-CAPTIONS'].activeTrack.toString(), noopToString,
+    'created noop function for CLOSED-CAPTIONS activeTrack');
+  assert.equal(result['CLOSED-CAPTIONS'].onGroupChanged.toString(), noopToString,
+    'created noop function for CLOSED-CAPTIONS onGroupChanged');
+  assert.equal(result['CLOSED-CAPTIONS'].onTrackChanged.toString(), noopToString,
+    'created noop function for CLOSED-CAPTIONS onTrackChanged');
+});
+
+QUnit.test('stopLoaders pauses segment loader and playlist loader when available',
+function(assert) {
+  let segmentLoaderAbortCalls = 0;
+  let segmentLoaderPauseCalls = 0;
+  let playlistLoaderPauseCalls = 0;
+
+  const segmentLoader = {
+    abort: () => segmentLoaderAbortCalls++,
+    pause: () => segmentLoaderPauseCalls++
+  };
+  const playlistLoader = {
+    pause: () => playlistLoaderPauseCalls++
+  };
+  const mediaGroup = { activePlaylistLoader: null };
+
+  MediaGroups.stopLoaders(segmentLoader, mediaGroup);
+
+  assert.equal(segmentLoaderAbortCalls, 1, 'aborted segment loader');
+  assert.equal(segmentLoaderPauseCalls, 1, 'paused segment loader');
+  assert.equal(playlistLoaderPauseCalls, 0, 'no pause when no active playlist loader');
+
+  mediaGroup.activePlaylistLoader = playlistLoader;
+
+  MediaGroups.stopLoaders(segmentLoader, mediaGroup);
+
+  assert.equal(segmentLoaderAbortCalls, 2, 'aborted segment loader');
+  assert.equal(segmentLoaderPauseCalls, 2, 'paused segment loader');
+  assert.equal(playlistLoaderPauseCalls, 1, 'pause active playlist loader');
+  assert.equal(mediaGroup.activePlaylistLoader, null,
+    'clears active playlist loader for media group');
+});
+
+QUnit.test('startLoaders starts playlist loader and segment loader when appropriate',
+function(assert) {
+  let segmentLoaderLoadCalls = 0;
+  let playlistLoaderLoadCalls = 0;
+  let media = null;
+  let segmentLoaderPlaylist;
+
+  const segmentLoader = {
+    playlist: (playlist) => segmentLoaderPlaylist = playlist,
+    load: () => segmentLoaderLoadCalls++
+  };
+  const playlistLoader = {
+    load: () => playlistLoaderLoadCalls++,
+    media: () => media
+  };
+  const mediaGroup = { activePlaylistLoader: null };
+
+  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaGroup);
+
+  assert.equal(playlistLoaderLoadCalls, 1, 'called load on playlist loader');
+  assert.equal(segmentLoaderLoadCalls, 0,
+    'did not call load on segment loader when no media yet on playlist loader');
+  assert.equal(typeof segmentLoaderPlaylist, 'undefined',
+    'no playlist set on segment loader when no media yet on playlist loader');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, playlistLoader,
+    'set active playlist loader for media group');
+
+  mediaGroup.activePlaylistLoader = null;
+  media = { uri: 'index.m3u8' };
+
+  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaGroup);
+
+  assert.equal(playlistLoaderLoadCalls, 2, 'called load on playlist loader');
+  assert.equal(segmentLoaderLoadCalls, 1, 'called load on segment loader');
+  assert.strictEqual(segmentLoaderPlaylist, media, 'set playlist on segment loader');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, playlistLoader,
+    'set active playlist loader for media group');
+});
+
+QUnit.test('activeTrack returns the correct audio track', function(assert) {
+  const type = 'AUDIO';
+  const settings = { mediaGroups: MediaGroups.createMediaGroups() };
+  const tracks = settings.mediaGroups[type].tracks;
+  const activeTrack = MediaGroups.activeTrack[type](type, settings);
+
+  assert.equal(activeTrack(), null, 'returns null when empty track list');
+
+  tracks.track1 = { id: 'track1', enabled: false };
+  tracks.track2 = { id: 'track2', enabled: false };
+  tracks.track3 = { id: 'track3', enabled: false };
+
+  assert.equal(activeTrack(), null, 'returns null when no active tracks');
+
+  tracks.track3.enabled = true;
+
+  assert.strictEqual(activeTrack(), tracks.track3, 'returns active track');
+
+  tracks.track1.enabled = true;
+
+  // video.js treats the first enabled track in the track list as the active track
+  // so we want the same behavior here
+  assert.strictEqual(activeTrack(), tracks.track1, 'returns first active track');
+});
+
+QUnit.test('activeTrack returns the correct subtitle track', function(assert) {
+  const type = 'SUBTITLES';
+  const settings = { mediaGroups: MediaGroups.createMediaGroups() };
+  const tracks = settings.mediaGroups[type].tracks;
+  const activeTrack = MediaGroups.activeTrack[type](type, settings);
+
+  assert.equal(activeTrack(), null, 'returns null when empty track list');
+
+  tracks.track1 = { id: 'track1', mode: 'disabled' };
+  tracks.track2 = { id: 'track2', mode: 'hidden' };
+  tracks.track3 = { id: 'track3', mode: 'disabled' };
+
+  assert.equal(activeTrack(), null, 'returns null when no active tracks');
+
+  tracks.track3.mode = 'showing';
+
+  assert.strictEqual(activeTrack(), tracks.track3, 'returns active track');
+
+  tracks.track1.mode = 'showing';
+
+  // video.js treats the first enabled track in the track list as the active track
+  // so we want the same behavior here
+  assert.strictEqual(activeTrack(), tracks.track1, 'returns first active track');
+});
+
+QUnit.test('activeGroup returns the correct audio group', function(assert) {
+  const type = 'AUDIO';
+  let media = null;
+  const settings = {
+    mediaGroups: MediaGroups.createMediaGroups(),
+    masterPlaylistLoader: {
+      media: () => media
+    }
+  };
+  const groups = settings.mediaGroups[type].groups;
+  const tracks = settings.mediaGroups[type].tracks;
+  const activeTrack = MediaGroups.activeTrack[type](type, settings);
+  const activeGroup = MediaGroups.activeGroup(type, settings);
+
+  assert.equal(activeGroup(), null, 'returns null when no media in masterPlaylistLoader');
+
+  media = { attributes: { } };
+  groups.main = [{ id: 'en' }, { id: 'fr' }];
+
+  assert.strictEqual(activeGroup(), groups.main,
+    'defaults to main audio group when media does not specify audio group');
+
+  groups.audio = [{ id: 'en'}, { id: 'fr' }];
+  media.attributes.AUDIO = 'audio';
+
+  assert.strictEqual(activeGroup(), groups.audio,
+    'returns list of variants in active audio group');
+
+  tracks.en = { id: 'en', enabled: false };
+  tracks.fr = { id: 'fr', enabled: false };
+
+  assert.equal(activeGroup(activeTrack()), null,
+    'returns null when an active track is specified, but there is no active track');
+
+  tracks.fr.enabled = true;
+
+  assert.strictEqual(activeGroup(activeTrack()), groups.audio[1],
+    'returned the active group corresponding to the active track');
+});
+
+QUnit.test('activeGroup returns the correct subtitle group', function(assert) {
+  const type = 'SUBTITLES';
+  let media = null;
+  const settings = {
+    mediaGroups: MediaGroups.createMediaGroups(),
+    masterPlaylistLoader: {
+      media: () => media
+    }
+  };
+  const groups = settings.mediaGroups[type].groups;
+  const tracks = settings.mediaGroups[type].tracks;
+  const activeTrack = MediaGroups.activeTrack[type](type, settings);
+  const activeGroup = MediaGroups.activeGroup(type, settings);
+
+  assert.equal(activeGroup(), null, 'returns null when no media in masterPlaylistLoader');
+
+  media = { attributes: { } };
+
+  // there is no default `main` group for subtitles like there is for audio
+  assert.notOk(activeGroup(), 'returns null when media does not specify subtitle group');
+
+  groups.subs = [{ id: 'en'}, { id: 'fr' }];
+  media.attributes.SUBTITLES = 'subs';
+
+  assert.strictEqual(activeGroup(), groups.subs,
+    'returns list of variants in active subtitle group');
+
+  tracks.en = { id: 'en', mode: 'disabled' };
+  tracks.fr = { id: 'fr', mode: 'disabled' };
+
+  assert.equal(activeGroup(activeTrack()), null,
+    'returns null when an active track is specified, but there is no active track');
+
+  tracks.fr.mode = 'showing';
+
+  assert.strictEqual(activeGroup(activeTrack()), groups.subs[1],
+    'returned the active group corresponding to the active track');
+});
+
+QUnit.test('onGroupChanged updates active playlist loader and resyncs segment loader',
+function(assert) {
+  let mainSegmentLoaderResetCalls = 0;
+  let segmentLoaderResyncCalls = 0;
+  let segmentLoaderPauseCalls = 0;
+
+  const type = 'AUDIO';
+  const media = { attributes: { AUDIO: 'main' } };
+  const mainSegmentLoader = { resetEverything: () => mainSegmentLoaderResetCalls++ };
+  const segmentLoader = {
+    abort() {},
+    pause: () => segmentLoaderPauseCalls++,
+    load() {},
+    playlist() {},
+    resyncLoader: () => segmentLoaderResyncCalls++
+  };
+  const mockPlaylistLoader = () => {
+    return {
+      media: () => media,
+      load() {},
+      pause() {}
+    };
+  };
+  const masterPlaylistLoader = mockPlaylistLoader();
+  const settings = {
+    segmentLoaders: {
+      AUDIO: segmentLoader,
+      main: mainSegmentLoader
+    },
+    mediaGroups: MediaGroups.createMediaGroups(),
+    masterPlaylistLoader
+  };
+  const mediaGroup = settings.mediaGroups[type];
+  const groups = mediaGroup.groups;
+  const tracks = mediaGroup.tracks;
+
+  groups.main = [
+    { id: 'en', playlistLoader: null },
+    { id: 'fr', playlistLoader: mockPlaylistLoader() },
+    { id: 'es', playlistLoader: mockPlaylistLoader() }
+  ];
+  tracks.en = { id: 'en', enabled: false };
+  tracks.fr = { id: 'fr', enabled: false };
+  tracks.es = { id: 'es', enabled: false };
+  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
+
+  const onGroupChanged = MediaGroups.onGroupChanged(type, settings);
+
+  onGroupChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 1, 'loaders paused on group change');
+  assert.equal(mainSegmentLoaderResetCalls, 0, 'no reset when no active group');
+  assert.equal(segmentLoaderResyncCalls, 0, 'no resync when no active group');
+
+  tracks.en.enabled = true;
+
+  onGroupChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 2, 'loaders paused on group change');
+  assert.equal(mainSegmentLoaderResetCalls, 0,
+    'no reset changing from no active playlist loader to group with no playlist loader');
+  assert.equal(segmentLoaderResyncCalls, 0,
+    'no resync changing to group with no playlist loader');
+
+  mediaGroup.activePlaylistLoader = groups.main[1].playlistLoader;
+
+  onGroupChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 3, 'loaders paused on group change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'reset changing from active playlist loader to group with no playlist loader');
+  assert.equal(segmentLoaderResyncCalls, 0,
+    'no resync changing to group with no playlist loader');
+
+  tracks.en.enabled = false;
+  tracks.fr.enabled = true;
+  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+
+  onGroupChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 4, 'loaders paused on group change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'no reset changing to group with playlist loader');
+  assert.equal(segmentLoaderResyncCalls, 1,
+    'resync changing to group with playlist loader');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+    'sets the correct active playlist loader');
+});
+
+QUnit.test('onTrackChanged updates active playlist loader and resets segment loader',
+function(assert) {
+  let mainSegmentLoaderResetCalls = 0;
+  let segmentLoaderResetCalls = 0;
+  let segmentLoaderPauseCalls = 0;
+  let segmentLoaderLoadCalls = 0;
+  let segmentLoaderTrack;
+
+  const type = 'AUDIO';
+  const media = { attributes: { AUDIO: 'main' } };
+  const mainSegmentLoader = { resetEverything: () => mainSegmentLoaderResetCalls++ };
+  const segmentLoader = {
+    abort() {},
+    pause: () => segmentLoaderPauseCalls++,
+    load: () => segmentLoaderLoadCalls++,
+    playlist() {},
+    resetEverything: () => segmentLoaderResetCalls++
+  };
+  const mockPlaylistLoader = () => {
+    return {
+      media: () => media,
+      load() {},
+      pause() {}
+    };
+  };
+  const masterPlaylistLoader = mockPlaylistLoader();
+  const settings = {
+    segmentLoaders: {
+      AUDIO: segmentLoader,
+      main: mainSegmentLoader
+    },
+    mediaGroups: MediaGroups.createMediaGroups(),
+    masterPlaylistLoader
+  };
+  const mediaGroup = settings.mediaGroups[type];
+  const groups = mediaGroup.groups;
+  const tracks = mediaGroup.tracks;
+
+  groups.main = [
+    { id: 'en', playlistLoader: null },
+    { id: 'fr', playlistLoader: mockPlaylistLoader() },
+    { id: 'es', playlistLoader: mockPlaylistLoader() }
+  ];
+  tracks.en = { id: 'en', enabled: false };
+  tracks.fr = { id: 'fr', enabled: false };
+  tracks.es = { id: 'es', enabled: false };
+  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
+
+  const onTrackChanged = MediaGroups.onTrackChanged(type, settings);
+
+  onTrackChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 1, 'loaders paused on track change');
+  assert.equal(mainSegmentLoaderResetCalls, 0, 'no main reset when no active group');
+  assert.equal(segmentLoaderResetCalls, 0, 'no reset when no active group');
+  assert.equal(segmentLoaderLoadCalls, 0, 'loaders not restarted');
+
+  tracks.en.enabled = true;
+
+  onTrackChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 2, 'loaders paused on track change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'main reset changing to group with no playlist loader');
+  assert.equal(segmentLoaderResetCalls, 0,
+    'no reset changing to group with no playlist loader');
+  assert.equal(segmentLoaderLoadCalls, 0, 'loaders not restarted');
+
+  tracks.en.enabled = false;
+  tracks.fr.enabled = true;
+  mediaGroup.activePlaylistLoader = groups.main[1].playlistLoader;
+
+  onTrackChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 3, 'loaders paused on track change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'no main reset changing to group with playlist loader');
+  assert.equal(segmentLoaderResetCalls, 0,
+    'no reset when active group hasnt changed');
+  assert.equal(segmentLoaderLoadCalls, 1, 'loaders restarted');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+    'sets the correct active playlist loader');
+
+  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+
+  onTrackChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 4, 'loaders paused on track change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'no main reset changing to group with playlist loader');
+  assert.equal(segmentLoaderResetCalls, 1,
+    'reset on track change');
+  assert.equal(segmentLoaderLoadCalls, 2, 'loaders restarted');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+    'sets the correct active playlist loader');
+
+  // setting the track on the segment loader only applies to the SUBTITLES case.
+  // even though this test is testing type AUDIO, aside from this difference of setting
+  // the track, the functionality between the types is the same.
+  segmentLoader.track = (track) => segmentLoaderTrack = track;
+  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+
+  onTrackChanged();
+
+  assert.equal(segmentLoaderPauseCalls, 5, 'loaders paused on track change');
+  assert.equal(mainSegmentLoaderResetCalls, 1,
+    'no main reset changing to group with playlist loader');
+  assert.equal(segmentLoaderResetCalls, 2,
+    'reset on track change');
+  assert.equal(segmentLoaderLoadCalls, 3, 'loaders restarted');
+  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+    'sets the correct active playlist loader');
+  assert.strictEqual(segmentLoaderTrack, tracks.fr,
+    'set the correct track on the segment loader');
+});
+
+QUnit.test('switches to default audio track when an error is encountered',
+function(assert) {
+  let blacklistCurrentPlaylistCalls = 0;
+  let onTrackChangedCalls = 0;
+
+  const type = 'AUDIO';
+  const segmentLoader = { abort() {}, pause() {} };
+  const masterPlaylistLoader = {
+    media() {
+      return { attributes: { AUDIO: 'main' } };
+    }
+  };
+  const settings = {
+    segmentLoaders: { AUDIO: segmentLoader },
+    mediaGroups: MediaGroups.createMediaGroups(),
+    blacklistCurrentPlaylist: () => blacklistCurrentPlaylistCalls++,
+    masterPlaylistLoader
+  };
+  const mediaGroup = settings.mediaGroups[type];
+  const groups = mediaGroup.groups;
+  const tracks = mediaGroup.tracks;
+
+  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
+  mediaGroup.onTrackChanged = () => onTrackChangedCalls++;
+
+  const onError = MediaGroups.onError[type](type, settings);
+
+  groups.main = [ { id: 'en', default: true }, { id: 'fr'}, { id: 'es'} ];
+  tracks.en = { id: 'en', enabed: false };
+  tracks.fr = { id: 'fr', enabed: true };
+  tracks.es = { id: 'es', enabed: false };
+
+  onError();
+
+  assert.equal(blacklistCurrentPlaylistCalls, 0, 'did not blacklist current playlist');
+  assert.equal(onTrackChangedCalls, 1, 'called onTrackChanged after chaging to default');
+  assert.equal(tracks.en.enabled, true, 'enabled default track');
+  assert.equal(tracks.fr.enabled, false, 'disabled active track');
+  assert.equal(tracks.es.enabled, false, 'disabled track still disabled');
+  assert.equal(this.env.log.warn.callCount, 1, 'logged a warning');
+  this.env.log.warn.callCount = 0;
+
+  onError();
+
+  assert.equal(blacklistCurrentPlaylistCalls, 1, 'blacklist current playlist');
+  assert.equal(onTrackChangedCalls, 1, 'did not call onTrackChanged after blacklist');
+  assert.equal(tracks.en.enabled, true, 'default track still enabled');
+  assert.equal(tracks.fr.enabled, false, 'disabled track still disabled');
+  assert.equal(tracks.es.enabled, false, 'disabled track still disabled');
+  assert.equal(this.env.log.warn.callCount, 0, 'no warning logged');
+});
+
+QUnit.test('disables subtitle track when an error is encountered', function(assert) {
+  let onTrackChangedCalls = 0;
+  const type = 'SUBTITLES';
+  const segmentLoader = { abort() {}, pause() {} };
+  const settings = {
+    segmentLoaders: { SUBTITLES: segmentLoader },
+    mediaGroups: MediaGroups.createMediaGroups()
+  };
+  const mediaGroup = settings.mediaGroups[type];
+  const tracks = mediaGroup.tracks;
+
+  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaGroup.onTrackChanged = () => onTrackChangedCalls++;
+
+  const onError = MediaGroups.onError[type](type, settings);
+
+  tracks.en = { id: 'en', mode: 'disabled' };
+  tracks.fr = { id: 'fr', mode: 'disabled' };
+  tracks.es = { id: 'es', mode: 'showing' };
+
+  onError();
+
+  assert.equal(onTrackChangedCalls, 1, 'called onTrackChanged after disabling track');
+  assert.equal(tracks.en.mode, 'disabled', 'disabled track still disabled');
+  assert.equal(tracks.fr.mode, 'disabled', 'disabled track still disabled');
+  assert.equal(tracks.es.mode, 'disabled', 'disabled active track');
+  assert.equal(this.env.log.warn.callCount, 1, 'logged a warning');
+  this.env.log.warn.callCount = 0;
+});
+
+QUnit.test('setupListeners adds correct playlist loader listeners', function(assert) {
+
+});
+
+QUnit.module('MediaGroups - initialize', {
+  beforeEach(assert) {
+    this.mediaGroups = MediaGroups.createMediaGroups();
+    this.master = {
+      mediaGroups: {
+        'AUDIO': {},
+        'SUBTITLES': {},
+        'CLOSED-CAPTIONS': {}
+      }
+    };
+    this.settings = {
+      mode: 'html5',
+      hls: {},
+      tech: {
+        addRemoteTextTrack(track) {
+          return { track };
+        }
+      },
+      segmentLoaders: {
+        AUDIO: { on() {} },
+        SUBTITLES: { on() {} }
+      },
+      requestOptions: { withCredentials: false, timeout: 10 },
+      master: this.master,
+      mediaGroups: this.mediaGroups,
+      blacklistCurrentPlaylist() {}
+    };
+  }
+});
+
+QUnit.test('initialize audio forces default track when no audio groups provided',
+function(assert) {
+  const type = 'AUDIO';
+
+  MediaGroups.initialize[type](type, this.settings);
+
+  assert.deepEqual(this.master.mediaGroups[type],
+    { main: { default: { default: true } } }, 'forced default audio group');
+  assert.deepEqual(this.mediaGroups[type].groups,
+    { main: [ { id: 'default', playlistLoader: null, default: true } ] },
+    'creates group properites and no playlist loader');
+  assert.ok(this.mediaGroups[type].tracks.default, 'created default track');
+});
+
+QUnit.test('initialize audio correctly generates tracks and playlist loaders',
+function(assert) {
+  const type = 'AUDIO';
+
+  this.master.mediaGroups[type].aud1 = {
+    en: { default: true, language: 'en' },
+    fr: { default: false, language: 'fr', resolvedUri: 'aud1/fr.m3u8' }
+  };
+  this.master.mediaGroups[type].aud2 = {
+    en: { default: true, language: 'en' },
+    fr: { default: false, language: 'fr', resolvedUri: 'aud2/fr.m3u8' }
+  };
+
+  MediaGroups.initialize[type](type, this.settings);
+
+  assert.notOk(this.master.mediaGroups[type].main, 'no default main group added');
+  assert.deepEqual(this.mediaGroups[type].groups,
+    {
+      aud1: [
+        { id: 'en', default: true, language: 'en', playlistLoader: null },
+        { id: 'fr', default: false, language: 'fr', resolvedUri: 'aud1/fr.m3u8',
+          // just so deepEqual passes since there is no other way to get the object
+          // reference for the playlist loader. Assertions below will confirm that this is
+          // not null.
+          playlistLoader: this.mediaGroups[type].groups.aud1[1].playlistLoader }
+      ],
+      aud2: [
+        { id: 'en', default: true, language: 'en', playlistLoader: null },
+        { id: 'fr', default: false, language: 'fr', resolvedUri: 'aud2/fr.m3u8',
+          // just so deepEqual passes since there is no other way to get the object
+          // reference for the playlist loader. Assertions below will confirm that this is
+          // not null.
+          playlistLoader: this.mediaGroups[type].groups.aud2[1].playlistLoader }
+      ]
+    }, 'creates group properites');
+  assert.ok(this.mediaGroups[type].groups.aud1[1].playlistLoader,
+    'playlistLoader created for non muxed audio group');
+  assert.ok(this.mediaGroups[type].groups.aud2[1].playlistLoader,
+    'playlistLoader created for non muxed audio group');
+  assert.ok(this.mediaGroups[type].tracks.en, 'created audio track');
+  assert.ok(this.mediaGroups[type].tracks.fr, 'created audio track');
+});
+
+QUnit.test('initialize subtitles correctly generates tracks and playlist loaders',
+function(assert) {
+  const type = 'SUBTITLES';
+
+  this.master.mediaGroups[type].sub1 = {
+    'en': { language: 'en', resolvedUri: 'sub1/en.m3u8' },
+    'en-forced': { language: 'en', resolvedUri: 'sub1/en-forced.m3u8', forced: true },
+    'fr': { language: 'fr', resolvedUri: 'sub1/fr.m3u8' }
+  };
+  this.master.mediaGroups[type].sub2 = {
+    'en': { language: 'en', resolvedUri: 'sub2/en.m3u8' },
+    'en-forced': { language: 'en', resolvedUri: 'sub2/en-forced.m3u8', forced: true },
+    'fr': { language: 'fr', resolvedUri: 'sub2/fr.m3u8' }
+  };
+
+  MediaGroups.initialize[type](type, this.settings);
+
+  assert.deepEqual(this.mediaGroups[type].groups,
+    {
+      sub1: [
+        { id: 'en', language: 'en', resolvedUri: 'sub1/en.m3u8',
+          playlistLoader: this.mediaGroups[type].groups.sub1[0].playlistLoader },
+        { id: 'fr', language: 'fr', resolvedUri: 'sub1/fr.m3u8',
+          playlistLoader: this.mediaGroups[type].groups.sub1[1].playlistLoader }
+      ],
+      sub2: [
+        { id: 'en', language: 'en', resolvedUri: 'sub2/en.m3u8',
+          playlistLoader: this.mediaGroups[type].groups.sub2[0].playlistLoader },
+        { id: 'fr', language: 'fr', resolvedUri: 'sub2/fr.m3u8',
+          playlistLoader: this.mediaGroups[type].groups.sub2[1].playlistLoader }
+      ]
+    }, 'creates group properites');
+  assert.ok(this.mediaGroups[type].groups.sub1[0].playlistLoader,
+    'playlistLoader created');
+  assert.ok(this.mediaGroups[type].groups.sub1[1].playlistLoader,
+    'playlistLoader created');
+  assert.ok(this.mediaGroups[type].groups.sub2[0].playlistLoader,
+    'playlistLoader created');
+  assert.ok(this.mediaGroups[type].groups.sub2[1].playlistLoader,
+    'playlistLoader created');
+  assert.ok(this.mediaGroups[type].tracks.en, 'created text track');
+  assert.ok(this.mediaGroups[type].tracks.fr, 'created text track');
+});
+
+QUnit.test('initialize closed-captions correctly generates tracks and NO laoders',
+function(assert) {
+  const type = 'CLOSED-CAPTIONS';
+
+  this.master.mediaGroups[type].CCs = {
+    en608: { language: 'en', instreamId: 'CC1' },
+    en708: { language: 'en', instreamId: 'SERVICE1' },
+    fr608: { language: 'fr', instreamId: 'CC3' },
+    fr708: { language: 'fr', instreamId: 'SERVICE3' }
+  };
+
+  MediaGroups.initialize[type](type, this.settings);
+
+  assert.deepEqual(this.mediaGroups[type].groups,
+    {
+      CCs: [
+        { id: 'en608', language: 'en', instreamId: 'CC1' },
+        { id: 'fr608', language: 'fr', instreamId: 'CC3' }
+      ]
+    }, 'creates group properites');
+  assert.ok(this.mediaGroups[type].tracks.en608, 'created text track');
+  assert.ok(this.mediaGroups[type].tracks.fr608, 'created text track');
+});

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -101,41 +101,20 @@ function(assert) {
     'clears active playlist loader for media group');
 });
 
-QUnit.test('startLoaders starts playlist loader and segment loader when appropriate',
+QUnit.test('startLoaders starts playlist loader when appropriate',
 function(assert) {
-  let segmentLoaderLoadCalls = 0;
   let playlistLoaderLoadCalls = 0;
   let media = null;
-  let segmentLoaderPlaylist;
 
-  const segmentLoader = {
-    playlist: (playlist) => segmentLoaderPlaylist = playlist,
-    load: () => segmentLoaderLoadCalls++
-  };
   const playlistLoader = {
     load: () => playlistLoaderLoadCalls++,
     media: () => media
   };
   const mediaType = { activePlaylistLoader: null };
 
-  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaType);
+  MediaGroups.startLoaders(playlistLoader, mediaType);
 
   assert.equal(playlistLoaderLoadCalls, 1, 'called load on playlist loader');
-  assert.equal(segmentLoaderLoadCalls, 0,
-    'did not call load on segment loader when no media yet on playlist loader');
-  assert.equal(typeof segmentLoaderPlaylist, 'undefined',
-    'no playlist set on segment loader when no media yet on playlist loader');
-  assert.strictEqual(mediaType.activePlaylistLoader, playlistLoader,
-    'set active playlist loader for media group');
-
-  mediaType.activePlaylistLoader = null;
-  media = { uri: 'index.m3u8' };
-
-  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaType);
-
-  assert.equal(playlistLoaderLoadCalls, 2, 'called load on playlist loader');
-  assert.equal(segmentLoaderLoadCalls, 1, 'called load on segment loader');
-  assert.strictEqual(segmentLoaderPlaylist, media, 'set playlist on segment loader');
   assert.strictEqual(mediaType.activePlaylistLoader, playlistLoader,
     'set active playlist loader for media group');
 });
@@ -380,7 +359,6 @@ function(assert) {
   let mainSegmentLoaderResetCalls = 0;
   let segmentLoaderResetCalls = 0;
   let segmentLoaderPauseCalls = 0;
-  let segmentLoaderLoadCalls = 0;
   let segmentLoaderTrack;
 
   const type = 'AUDIO';
@@ -389,7 +367,7 @@ function(assert) {
   const segmentLoader = {
     abort() {},
     pause: () => segmentLoaderPauseCalls++,
-    load: () => segmentLoaderLoadCalls++,
+    load: () => {},
     playlist() {},
     resetEverything: () => segmentLoaderResetCalls++
   };
@@ -431,7 +409,6 @@ function(assert) {
   assert.equal(segmentLoaderPauseCalls, 1, 'loaders paused on track change');
   assert.equal(mainSegmentLoaderResetCalls, 0, 'no main reset when no active group');
   assert.equal(segmentLoaderResetCalls, 0, 'no reset when no active group');
-  assert.equal(segmentLoaderLoadCalls, 0, 'loaders not restarted');
 
   tracks.en.enabled = true;
 
@@ -442,7 +419,6 @@ function(assert) {
     'main reset changing to group with no playlist loader');
   assert.equal(segmentLoaderResetCalls, 0,
     'no reset changing to group with no playlist loader');
-  assert.equal(segmentLoaderLoadCalls, 0, 'loaders not restarted');
 
   tracks.en.enabled = false;
   tracks.fr.enabled = true;
@@ -455,7 +431,6 @@ function(assert) {
     'no main reset changing to group with playlist loader');
   assert.equal(segmentLoaderResetCalls, 0,
     'no reset when active group hasn\'t changed');
-  assert.equal(segmentLoaderLoadCalls, 1, 'loaders restarted');
   assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
 
@@ -468,7 +443,6 @@ function(assert) {
     'no main reset changing to group with playlist loader');
   assert.equal(segmentLoaderResetCalls, 1,
     'reset on track change');
-  assert.equal(segmentLoaderLoadCalls, 2, 'loaders restarted');
   assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
 
@@ -485,7 +459,6 @@ function(assert) {
     'no main reset changing to group with playlist loader');
   assert.equal(segmentLoaderResetCalls, 2,
     'reset on track change');
-  assert.equal(segmentLoaderLoadCalls, 3, 'loaders restarted');
   assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
   assert.strictEqual(segmentLoaderTrack, tracks.fr,

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -15,10 +15,10 @@ QUnit.module('MediaGroups', {
   }
 });
 
-QUnit.test('createMediaGroups creates skeleton object for all supported media groups',
+QUnit.test('createMediaTypes creates skeleton object for all supported media groups',
 function(assert) {
   const noopToString = 'function noop() {}';
-  const result = MediaGroups.createMediaGroups();
+  const result = MediaGroups.createMediaTypes();
 
   assert.ok(result.AUDIO, 'created AUDIO media group object');
   assert.equal(JSON.stringify(result.AUDIO.groups), '{}',
@@ -82,22 +82,22 @@ function(assert) {
   const playlistLoader = {
     pause: () => playlistLoaderPauseCalls++
   };
-  const mediaGroup = { activePlaylistLoader: null };
+  const mediaType = { activePlaylistLoader: null };
 
-  MediaGroups.stopLoaders(segmentLoader, mediaGroup);
+  MediaGroups.stopLoaders(segmentLoader, mediaType);
 
   assert.equal(segmentLoaderAbortCalls, 1, 'aborted segment loader');
   assert.equal(segmentLoaderPauseCalls, 1, 'paused segment loader');
   assert.equal(playlistLoaderPauseCalls, 0, 'no pause when no active playlist loader');
 
-  mediaGroup.activePlaylistLoader = playlistLoader;
+  mediaType.activePlaylistLoader = playlistLoader;
 
-  MediaGroups.stopLoaders(segmentLoader, mediaGroup);
+  MediaGroups.stopLoaders(segmentLoader, mediaType);
 
   assert.equal(segmentLoaderAbortCalls, 2, 'aborted segment loader');
   assert.equal(segmentLoaderPauseCalls, 2, 'paused segment loader');
   assert.equal(playlistLoaderPauseCalls, 1, 'pause active playlist loader');
-  assert.equal(mediaGroup.activePlaylistLoader, null,
+  assert.equal(mediaType.activePlaylistLoader, null,
     'clears active playlist loader for media group');
 });
 
@@ -116,34 +116,34 @@ function(assert) {
     load: () => playlistLoaderLoadCalls++,
     media: () => media
   };
-  const mediaGroup = { activePlaylistLoader: null };
+  const mediaType = { activePlaylistLoader: null };
 
-  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaGroup);
+  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaType);
 
   assert.equal(playlistLoaderLoadCalls, 1, 'called load on playlist loader');
   assert.equal(segmentLoaderLoadCalls, 0,
     'did not call load on segment loader when no media yet on playlist loader');
   assert.equal(typeof segmentLoaderPlaylist, 'undefined',
     'no playlist set on segment loader when no media yet on playlist loader');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, playlistLoader,
     'set active playlist loader for media group');
 
-  mediaGroup.activePlaylistLoader = null;
+  mediaType.activePlaylistLoader = null;
   media = { uri: 'index.m3u8' };
 
-  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaGroup);
+  MediaGroups.startLoaders(segmentLoader, playlistLoader, mediaType);
 
   assert.equal(playlistLoaderLoadCalls, 2, 'called load on playlist loader');
   assert.equal(segmentLoaderLoadCalls, 1, 'called load on segment loader');
   assert.strictEqual(segmentLoaderPlaylist, media, 'set playlist on segment loader');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, playlistLoader,
     'set active playlist loader for media group');
 });
 
 QUnit.test('activeTrack returns the correct audio track', function(assert) {
   const type = 'AUDIO';
-  const settings = { mediaGroups: MediaGroups.createMediaGroups() };
-  const tracks = settings.mediaGroups[type].tracks;
+  const settings = { mediaTypes: MediaGroups.createMediaTypes() };
+  const tracks = settings.mediaTypes[type].tracks;
   const activeTrack = MediaGroups.activeTrack[type](type, settings);
 
   assert.equal(activeTrack(), null, 'returns null when empty track list');
@@ -167,8 +167,8 @@ QUnit.test('activeTrack returns the correct audio track', function(assert) {
 
 QUnit.test('activeTrack returns the correct subtitle track', function(assert) {
   const type = 'SUBTITLES';
-  const settings = { mediaGroups: MediaGroups.createMediaGroups() };
-  const tracks = settings.mediaGroups[type].tracks;
+  const settings = { mediaTypes: MediaGroups.createMediaTypes() };
+  const tracks = settings.mediaTypes[type].tracks;
   const activeTrack = MediaGroups.activeTrack[type](type, settings);
 
   assert.equal(activeTrack(), null, 'returns null when empty track list');
@@ -194,13 +194,13 @@ QUnit.test('activeGroup returns the correct audio group', function(assert) {
   const type = 'AUDIO';
   let media = null;
   const settings = {
-    mediaGroups: MediaGroups.createMediaGroups(),
+    mediaTypes: MediaGroups.createMediaTypes(),
     masterPlaylistLoader: {
       media: () => media
     }
   };
-  const groups = settings.mediaGroups[type].groups;
-  const tracks = settings.mediaGroups[type].tracks;
+  const groups = settings.mediaTypes[type].groups;
+  const tracks = settings.mediaTypes[type].tracks;
   const activeTrack = MediaGroups.activeTrack[type](type, settings);
   const activeGroup = MediaGroups.activeGroup(type, settings);
 
@@ -234,13 +234,13 @@ QUnit.test('activeGroup returns the correct subtitle group', function(assert) {
   const type = 'SUBTITLES';
   let media = null;
   const settings = {
-    mediaGroups: MediaGroups.createMediaGroups(),
+    mediaTypes: MediaGroups.createMediaTypes(),
     masterPlaylistLoader: {
       media: () => media
     }
   };
-  const groups = settings.mediaGroups[type].groups;
-  const tracks = settings.mediaGroups[type].tracks;
+  const groups = settings.mediaTypes[type].groups;
+  const tracks = settings.mediaTypes[type].tracks;
   const activeTrack = MediaGroups.activeTrack[type](type, settings);
   const activeGroup = MediaGroups.activeGroup(type, settings);
 
@@ -298,12 +298,12 @@ function(assert) {
       AUDIO: segmentLoader,
       main: mainSegmentLoader
     },
-    mediaGroups: MediaGroups.createMediaGroups(),
+    mediaTypes: MediaGroups.createMediaTypes(),
     masterPlaylistLoader
   };
-  const mediaGroup = settings.mediaGroups[type];
-  const groups = mediaGroup.groups;
-  const tracks = mediaGroup.tracks;
+  const mediaType = settings.mediaTypes[type];
+  const groups = mediaType.groups;
+  const tracks = mediaType.tracks;
 
   groups.main = [
     { id: 'en', playlistLoader: null },
@@ -313,8 +313,8 @@ function(assert) {
   tracks.en = { id: 'en', enabled: false };
   tracks.fr = { id: 'fr', enabled: false };
   tracks.es = { id: 'es', enabled: false };
-  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
-  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
+  mediaType.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaType.activeGroup = MediaGroups.activeGroup(type, settings);
 
   const onGroupChanged = MediaGroups.onGroupChanged(type, settings);
 
@@ -334,7 +334,7 @@ function(assert) {
   assert.equal(segmentLoaderResyncCalls, 0,
     'no resync changing to group with no playlist loader');
 
-  mediaGroup.activePlaylistLoader = groups.main[1].playlistLoader;
+  mediaType.activePlaylistLoader = groups.main[1].playlistLoader;
 
   onGroupChanged();
 
@@ -346,7 +346,7 @@ function(assert) {
 
   tracks.en.enabled = false;
   tracks.fr.enabled = true;
-  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+  mediaType.activePlaylistLoader = groups.main[2].playlistLoader;
 
   onGroupChanged();
 
@@ -355,7 +355,7 @@ function(assert) {
     'no reset changing to group with playlist loader');
   assert.equal(segmentLoaderResyncCalls, 1,
     'resync changing to group with playlist loader');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
 });
 
@@ -390,12 +390,12 @@ function(assert) {
       AUDIO: segmentLoader,
       main: mainSegmentLoader
     },
-    mediaGroups: MediaGroups.createMediaGroups(),
+    mediaTypes: MediaGroups.createMediaTypes(),
     masterPlaylistLoader
   };
-  const mediaGroup = settings.mediaGroups[type];
-  const groups = mediaGroup.groups;
-  const tracks = mediaGroup.tracks;
+  const mediaType = settings.mediaTypes[type];
+  const groups = mediaType.groups;
+  const tracks = mediaType.tracks;
 
   groups.main = [
     { id: 'en', playlistLoader: null },
@@ -405,8 +405,8 @@ function(assert) {
   tracks.en = { id: 'en', enabled: false };
   tracks.fr = { id: 'fr', enabled: false };
   tracks.es = { id: 'es', enabled: false };
-  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
-  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
+  mediaType.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaType.activeGroup = MediaGroups.activeGroup(type, settings);
 
   const onTrackChanged = MediaGroups.onTrackChanged(type, settings);
 
@@ -430,7 +430,7 @@ function(assert) {
 
   tracks.en.enabled = false;
   tracks.fr.enabled = true;
-  mediaGroup.activePlaylistLoader = groups.main[1].playlistLoader;
+  mediaType.activePlaylistLoader = groups.main[1].playlistLoader;
 
   onTrackChanged();
 
@@ -440,10 +440,10 @@ function(assert) {
   assert.equal(segmentLoaderResetCalls, 0,
     'no reset when active group hasnt changed');
   assert.equal(segmentLoaderLoadCalls, 1, 'loaders restarted');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
 
-  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+  mediaType.activePlaylistLoader = groups.main[2].playlistLoader;
 
   onTrackChanged();
 
@@ -453,14 +453,14 @@ function(assert) {
   assert.equal(segmentLoaderResetCalls, 1,
     'reset on track change');
   assert.equal(segmentLoaderLoadCalls, 2, 'loaders restarted');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
 
   // setting the track on the segment loader only applies to the SUBTITLES case.
   // even though this test is testing type AUDIO, aside from this difference of setting
   // the track, the functionality between the types is the same.
   segmentLoader.track = (track) => segmentLoaderTrack = track;
-  mediaGroup.activePlaylistLoader = groups.main[2].playlistLoader;
+  mediaType.activePlaylistLoader = groups.main[2].playlistLoader;
 
   onTrackChanged();
 
@@ -470,7 +470,7 @@ function(assert) {
   assert.equal(segmentLoaderResetCalls, 2,
     'reset on track change');
   assert.equal(segmentLoaderLoadCalls, 3, 'loaders restarted');
-  assert.strictEqual(mediaGroup.activePlaylistLoader, groups.main[1].playlistLoader,
+  assert.strictEqual(mediaType.activePlaylistLoader, groups.main[1].playlistLoader,
     'sets the correct active playlist loader');
   assert.strictEqual(segmentLoaderTrack, tracks.fr,
     'set the correct track on the segment loader');
@@ -490,17 +490,17 @@ function(assert) {
   };
   const settings = {
     segmentLoaders: { AUDIO: segmentLoader },
-    mediaGroups: MediaGroups.createMediaGroups(),
+    mediaTypes: MediaGroups.createMediaTypes(),
     blacklistCurrentPlaylist: () => blacklistCurrentPlaylistCalls++,
     masterPlaylistLoader
   };
-  const mediaGroup = settings.mediaGroups[type];
-  const groups = mediaGroup.groups;
-  const tracks = mediaGroup.tracks;
+  const mediaType = settings.mediaTypes[type];
+  const groups = mediaType.groups;
+  const tracks = mediaType.tracks;
 
-  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
-  mediaGroup.activeGroup = MediaGroups.activeGroup(type, settings);
-  mediaGroup.onTrackChanged = () => onTrackChangedCalls++;
+  mediaType.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaType.activeGroup = MediaGroups.activeGroup(type, settings);
+  mediaType.onTrackChanged = () => onTrackChangedCalls++;
 
   const onError = MediaGroups.onError[type](type, settings);
 
@@ -535,13 +535,13 @@ QUnit.test('disables subtitle track when an error is encountered', function(asse
   const segmentLoader = { abort() {}, pause() {} };
   const settings = {
     segmentLoaders: { SUBTITLES: segmentLoader },
-    mediaGroups: MediaGroups.createMediaGroups()
+    mediaTypes: MediaGroups.createMediaTypes()
   };
-  const mediaGroup = settings.mediaGroups[type];
-  const tracks = mediaGroup.tracks;
+  const mediaType = settings.mediaTypes[type];
+  const tracks = mediaType.tracks;
 
-  mediaGroup.activeTrack = MediaGroups.activeTrack[type](type, settings);
-  mediaGroup.onTrackChanged = () => onTrackChangedCalls++;
+  mediaType.activeTrack = MediaGroups.activeTrack[type](type, settings);
+  mediaType.onTrackChanged = () => onTrackChangedCalls++;
 
   const onError = MediaGroups.onError[type](type, settings);
 
@@ -565,7 +565,7 @@ QUnit.test('setupListeners adds correct playlist loader listeners', function(ass
 
 QUnit.module('MediaGroups - initialize', {
   beforeEach(assert) {
-    this.mediaGroups = MediaGroups.createMediaGroups();
+    this.mediaTypes = MediaGroups.createMediaTypes();
     this.master = {
       mediaGroups: {
         'AUDIO': {},
@@ -587,7 +587,7 @@ QUnit.module('MediaGroups - initialize', {
       },
       requestOptions: { withCredentials: false, timeout: 10 },
       master: this.master,
-      mediaGroups: this.mediaGroups,
+      mediaTypes: this.mediaTypes,
       blacklistCurrentPlaylist() {}
     };
   }
@@ -601,10 +601,10 @@ function(assert) {
 
   assert.deepEqual(this.master.mediaGroups[type],
     { main: { default: { default: true } } }, 'forced default audio group');
-  assert.deepEqual(this.mediaGroups[type].groups,
+  assert.deepEqual(this.mediaTypes[type].groups,
     { main: [ { id: 'default', playlistLoader: null, default: true } ] },
     'creates group properites and no playlist loader');
-  assert.ok(this.mediaGroups[type].tracks.default, 'created default track');
+  assert.ok(this.mediaTypes[type].tracks.default, 'created default track');
 });
 
 QUnit.test('initialize audio correctly generates tracks and playlist loaders',
@@ -623,7 +623,7 @@ function(assert) {
   MediaGroups.initialize[type](type, this.settings);
 
   assert.notOk(this.master.mediaGroups[type].main, 'no default main group added');
-  assert.deepEqual(this.mediaGroups[type].groups,
+  assert.deepEqual(this.mediaTypes[type].groups,
     {
       aud1: [
         { id: 'en', default: true, language: 'en', playlistLoader: null },
@@ -631,7 +631,7 @@ function(assert) {
           // just so deepEqual passes since there is no other way to get the object
           // reference for the playlist loader. Assertions below will confirm that this is
           // not null.
-          playlistLoader: this.mediaGroups[type].groups.aud1[1].playlistLoader }
+          playlistLoader: this.mediaTypes[type].groups.aud1[1].playlistLoader }
       ],
       aud2: [
         { id: 'en', default: true, language: 'en', playlistLoader: null },
@@ -639,15 +639,15 @@ function(assert) {
           // just so deepEqual passes since there is no other way to get the object
           // reference for the playlist loader. Assertions below will confirm that this is
           // not null.
-          playlistLoader: this.mediaGroups[type].groups.aud2[1].playlistLoader }
+          playlistLoader: this.mediaTypes[type].groups.aud2[1].playlistLoader }
       ]
     }, 'creates group properites');
-  assert.ok(this.mediaGroups[type].groups.aud1[1].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.aud1[1].playlistLoader,
     'playlistLoader created for non muxed audio group');
-  assert.ok(this.mediaGroups[type].groups.aud2[1].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.aud2[1].playlistLoader,
     'playlistLoader created for non muxed audio group');
-  assert.ok(this.mediaGroups[type].tracks.en, 'created audio track');
-  assert.ok(this.mediaGroups[type].tracks.fr, 'created audio track');
+  assert.ok(this.mediaTypes[type].tracks.en, 'created audio track');
+  assert.ok(this.mediaTypes[type].tracks.fr, 'created audio track');
 });
 
 QUnit.test('initialize subtitles correctly generates tracks and playlist loaders',
@@ -667,31 +667,31 @@ function(assert) {
 
   MediaGroups.initialize[type](type, this.settings);
 
-  assert.deepEqual(this.mediaGroups[type].groups,
+  assert.deepEqual(this.mediaTypes[type].groups,
     {
       sub1: [
         { id: 'en', language: 'en', resolvedUri: 'sub1/en.m3u8',
-          playlistLoader: this.mediaGroups[type].groups.sub1[0].playlistLoader },
+          playlistLoader: this.mediaTypes[type].groups.sub1[0].playlistLoader },
         { id: 'fr', language: 'fr', resolvedUri: 'sub1/fr.m3u8',
-          playlistLoader: this.mediaGroups[type].groups.sub1[1].playlistLoader }
+          playlistLoader: this.mediaTypes[type].groups.sub1[1].playlistLoader }
       ],
       sub2: [
         { id: 'en', language: 'en', resolvedUri: 'sub2/en.m3u8',
-          playlistLoader: this.mediaGroups[type].groups.sub2[0].playlistLoader },
+          playlistLoader: this.mediaTypes[type].groups.sub2[0].playlistLoader },
         { id: 'fr', language: 'fr', resolvedUri: 'sub2/fr.m3u8',
-          playlistLoader: this.mediaGroups[type].groups.sub2[1].playlistLoader }
+          playlistLoader: this.mediaTypes[type].groups.sub2[1].playlistLoader }
       ]
     }, 'creates group properites');
-  assert.ok(this.mediaGroups[type].groups.sub1[0].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.sub1[0].playlistLoader,
     'playlistLoader created');
-  assert.ok(this.mediaGroups[type].groups.sub1[1].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.sub1[1].playlistLoader,
     'playlistLoader created');
-  assert.ok(this.mediaGroups[type].groups.sub2[0].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.sub2[0].playlistLoader,
     'playlistLoader created');
-  assert.ok(this.mediaGroups[type].groups.sub2[1].playlistLoader,
+  assert.ok(this.mediaTypes[type].groups.sub2[1].playlistLoader,
     'playlistLoader created');
-  assert.ok(this.mediaGroups[type].tracks.en, 'created text track');
-  assert.ok(this.mediaGroups[type].tracks.fr, 'created text track');
+  assert.ok(this.mediaTypes[type].tracks.en, 'created text track');
+  assert.ok(this.mediaTypes[type].tracks.fr, 'created text track');
 });
 
 QUnit.test('initialize closed-captions correctly generates tracks and NO laoders',
@@ -707,13 +707,13 @@ function(assert) {
 
   MediaGroups.initialize[type](type, this.settings);
 
-  assert.deepEqual(this.mediaGroups[type].groups,
+  assert.deepEqual(this.mediaTypes[type].groups,
     {
       CCs: [
         { id: 'en608', language: 'en', instreamId: 'CC1' },
         { id: 'fr608', language: 'fr', instreamId: 'CC3' }
       ]
     }, 'creates group properites');
-  assert.ok(this.mediaGroups[type].tracks.en608, 'created text track');
-  assert.ok(this.mediaGroups[type].tracks.fr608, 'created text track');
+  assert.ok(this.mediaTypes[type].tracks.en608, 'created text track');
+  assert.ok(this.mediaTypes[type].tracks.fr608, 'created text track');
 });

--- a/test/media-groups.test.js
+++ b/test/media-groups.test.js
@@ -367,7 +367,6 @@ function(assert) {
   const segmentLoader = {
     abort() {},
     pause: () => segmentLoaderPauseCalls++,
-    load: () => {},
     playlist() {},
     resetEverything: () => segmentLoaderResetCalls++
   };

--- a/test/videojs-contrib-hls.test.js
+++ b/test/videojs-contrib-hls.test.js
@@ -2697,7 +2697,7 @@ QUnit.test('when mediaGroup changes enabled track should not change', function(a
 
   assert.notEqual(oldMediaGroup, hls.playlists.media().attributes.AUDIO, 'selected a new playlist');
   audioTracks = this.player.audioTracks();
-  let activeGroup = mpc.mediaGroups_.AUDIO.activeGroup(audioTracks[0]);
+  let activeGroup = mpc.mediaTypes_.AUDIO.activeGroup(audioTracks[0]);
 
   assert.equal(audioTracks.length, 3, 'three audio tracks after changing mediaGroup');
   assert.ok(activeGroup.default, 'track one should be the default');


### PR DESCRIPTION
## Description

This PR is a WIP. Tests still need to be written.

There are some issues with the way we currently handle media groups. A big issue is that when switching to a new track, the `PlaylistLoader` is disposed of and a fresh one is created. The problem there is that the `PlaylistLoader` also holds onto the playlist object reference. When we dispose of the loader, we lose any sync information we have learned about that stream, so returning to it is basically starting fresh. 
Alternate audio was also using incorrect sync information causing delayed switches, and sometimes desync of audio and video. 
This also removes the Firefox 48 check for for supporting a change in audio info

## Specific Changes proposed
* Pull setup of MediaGroups out of `MasterPlaylistController` and into its own module. 
* Fix delayed switching between audio tracks and intermittent desync.
* removes the Firefox 48 check for for supporting a change in audio info