### PR TITLE
fix: flv metadata tags now appened when audio info changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
     "m3u8-parser": "2.1.0",
-    "mux.js": "4.2.0",
+    "mux.js": "4.2.1",
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.5.0",
+    "videojs-contrib-media-sources": "4.5.1",
     "webworkify": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Fixed an issue where changes to audio across variants (e.g. sample rate) caused issues with audio when the flash fallback is being used.