### PR TITLE
Blacklist audio only playlists on probe if already playing video

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -51,7 +51,7 @@ export const illegalMediaSwitch = (loaderType, startingMedia, newSegmentMedia) =
   // Although these checks should most likely cover non 'main' types, for now it narrows
   // the scope of our checks.
   if (loaderType !== 'main' || !startingMedia || !newSegmentMedia) {
-    return;
+    return null;
   }
 
   if (!newSegmentMedia.containsAudio && !newSegmentMedia.containsVideo) {
@@ -69,6 +69,8 @@ export const illegalMediaSwitch = (loaderType, startingMedia, newSegmentMedia) =
       ' We can\'t switch to a stream with video from an audio only stream.' +
       ' To get rid of this message, please add codec information to the manifest.';
   }
+
+  return null;
 };
 
 /**

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -66,7 +66,7 @@ export const illegalMediaSwitch = (loaderType, startingMedia, newSegmentMedia) =
 
   if (!startingMedia.containsVideo && newSegmentMedia.containsVideo) {
     return 'Video found in segment when we expected only audio.' +
-      ' We can\'t switch to a stream with video from a stream that only had audio.' +
+      ' We can\'t switch to a stream with video from an audio only stream.' +
       ' To get rid of this message, please add codec information to the manifest.';
   }
 };
@@ -1091,7 +1091,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       };
     }
 
-    let illegalMediaSwitchError =
+    const illegalMediaSwitchError =
       illegalMediaSwitch(this.loaderType_, this.startingMedia_, timingInfo);
 
     if (illegalMediaSwitchError) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -58,36 +58,16 @@ export const illegalMediaSwitch = (loaderType, startingMedia, newSegmentMedia) =
     return 'Neither audio nor video found in segment.';
   }
 
-  if (startingMedia.containsAudio && startingMedia.containsVideo &&
-      newSegmentMedia.containsAudio && !newSegmentMedia.containsVideo) {
-    return 'Only audio found in segment when we expected audio and video.' +
-      ' We can\'t switch to audio only from audio and video.' +
+  if (startingMedia.containsVideo && !newSegmentMedia.containsVideo) {
+    return 'Only audio found in segment when we expected video.' +
+      ' We can\'t switch to audio only from a stream that had video.' +
       ' To get rid of this message, please add codec information to the manifest.';
   }
 
-  if (!startingMedia.containsAudio && startingMedia.containsVideo &&
-      newSegmentMedia.containsAudio && !newSegmentMedia.containsVideo) {
-    return 'Only audio found in segment when we expected video only.' +
-      ' We can\'t switch to audio only from video only.' +
+  if (!startingMedia.containsVideo && newSegmentMedia.containsVideo) {
+    return 'Video found in segment when we expected only audio.' +
+      ' We can\'t switch to a stream with video from a stream that only had audio.' +
       ' To get rid of this message, please add codec information to the manifest.';
-  }
-
-  if (startingMedia.containsAudio && !startingMedia.containsVideo) {
-    let errorMessage;
-
-    if (newSegmentMedia.containsAudio && newSegmentMedia.containsVideo) {
-      errorMessage = 'Audio and video found in segment when we expected audio only.';
-    }
-
-    if (!newSegmentMedia.containsAudio && newSegmentMedia.containsVideo) {
-      errorMessage =
-        'Only video found in segment when we expected audio only.';
-    }
-
-    if (errorMessage) {
-      return errorMessage + ' We can\'t switch since we started on audio only.' +
-        ' To get rid of this message, please add codec information to the manifest.';
-    }
   }
 };
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -372,6 +372,8 @@ export default class SyncController extends videojs.EventTarget {
         this.saveDiscontinuitySyncInfo_(segmentInfo);
       }
     }
+
+    return timingInfo;
   }
 
   /**
@@ -409,6 +411,7 @@ export default class SyncController extends videojs.EventTarget {
     let timeInfo = tsprobe(segmentInfo.bytes, this.inspectCache_);
     let segmentStartTime;
     let segmentEndTime;
+    let source;
 
     if (!timeInfo) {
       return null;
@@ -418,15 +421,18 @@ export default class SyncController extends videojs.EventTarget {
       this.inspectCache_ = timeInfo.video[1].dts;
       segmentStartTime = timeInfo.video[0].dtsTime;
       segmentEndTime = timeInfo.video[1].dtsTime;
+      source = 'video';
     } else if (timeInfo.audio && timeInfo.audio.length === 2) {
       this.inspectCache_ = timeInfo.audio[1].dts;
       segmentStartTime = timeInfo.audio[0].dtsTime;
       segmentEndTime = timeInfo.audio[1].dtsTime;
+      source = 'audio';
     }
 
     return {
       start: segmentStartTime,
-      end: segmentEndTime
+      end: segmentEndTime,
+      source
     };
   }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -411,8 +411,6 @@ export default class SyncController extends videojs.EventTarget {
     let timeInfo = tsprobe(segmentInfo.bytes, this.inspectCache_);
     let segmentStartTime;
     let segmentEndTime;
-    let containsAudio = false;
-    let containsVideo = false;
 
     if (!timeInfo) {
       return null;
@@ -422,19 +420,17 @@ export default class SyncController extends videojs.EventTarget {
       this.inspectCache_ = timeInfo.video[1].dts;
       segmentStartTime = timeInfo.video[0].dtsTime;
       segmentEndTime = timeInfo.video[1].dtsTime;
-      containsVideo = true;
     } else if (timeInfo.audio && timeInfo.audio.length === 2) {
       this.inspectCache_ = timeInfo.audio[1].dts;
       segmentStartTime = timeInfo.audio[0].dtsTime;
       segmentEndTime = timeInfo.audio[1].dtsTime;
-      containsAudio = true;
     }
 
     return {
       start: segmentStartTime,
       end: segmentEndTime,
-      containsAudio,
-      containsVideo
+      containsVideo: timeInfo.video && timeInfo.video.length === 2,
+      containsAudio: timeInfo.audio && timeInfo.audio.length === 2
     };
   }
 

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -411,7 +411,8 @@ export default class SyncController extends videojs.EventTarget {
     let timeInfo = tsprobe(segmentInfo.bytes, this.inspectCache_);
     let segmentStartTime;
     let segmentEndTime;
-    let source;
+    let containsAudio = false;
+    let containsVideo = false;
 
     if (!timeInfo) {
       return null;
@@ -421,18 +422,19 @@ export default class SyncController extends videojs.EventTarget {
       this.inspectCache_ = timeInfo.video[1].dts;
       segmentStartTime = timeInfo.video[0].dtsTime;
       segmentEndTime = timeInfo.video[1].dtsTime;
-      source = 'video';
+      containsVideo = true;
     } else if (timeInfo.audio && timeInfo.audio.length === 2) {
       this.inspectCache_ = timeInfo.audio[1].dts;
       segmentStartTime = timeInfo.audio[0].dtsTime;
       segmentEndTime = timeInfo.audio[1].dtsTime;
-      source = 'audio';
+      containsAudio = true;
     }
 
     return {
       start: segmentStartTime,
       end: segmentEndTime,
-      source
+      containsAudio,
+      containsVideo
     };
   }
 

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -685,7 +685,7 @@ QUnit.module('SegmentLoader', function(hooks) {
       assert.equal(errors.length, 0, 'no errors');
     });
 
-    QUnit.test('does not error when going from audio only to avoid and video',
+    QUnit.test('does not error when going from audio only to audio and video',
     function(assert) {
       const playlist = playlistWithDuration(40);
       const errors = [];

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -59,6 +59,18 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
                'error when neither audio nor video');
 
   startingMedia = { containsAudio: true, containsVideo: false };
+  newSegmentMedia = { containsAudio: false, containsVideo: false };
+  assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
+               'Neither audio nor video found in segment.',
+               'error when audio only to neither audio nor video');
+
+  startingMedia = { containsAudio: false, containsVideo: true };
+  newSegmentMedia = { containsAudio: false, containsVideo: false };
+  assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
+               'Neither audio nor video found in segment.',
+               'error when video only to neither audio nor video');
+
+  startingMedia = { containsAudio: true, containsVideo: false };
   newSegmentMedia = { containsAudio: true, containsVideo: true };
   assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
                'Video found in segment when we expected only audio.' +
@@ -75,12 +87,6 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
                'error when muxed to audio only');
-
-  startingMedia = { containsAudio: true, containsVideo: true };
-  newSegmentMedia = { containsAudio: false, containsVideo: false };
-  assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
-               'Neither audio nor video found in segment.',
-               'error when muxed to neither audio nor video');
 
   startingMedia = { containsAudio: true, containsVideo: false };
   newSegmentMedia = { containsAudio: false, containsVideo: true };

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -50,8 +50,9 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
   startingMedia = { containsAudio: true, containsVideo: false };
   newSegmentMedia = { containsAudio: true, containsVideo: true };
   assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
-               'Audio and video found in segment when we expected audio only.' +
-               ' We can\'t switch since we started on audio only.' +
+               'Video found in segment when we expected only audio.' +
+               ' We can\'t switch to a stream with video from a stream that only had' +
+               ' audio.' +
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
                'error when audio only to muxed');
@@ -59,8 +60,8 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
   startingMedia = { containsAudio: true, containsVideo: true };
   newSegmentMedia = { containsAudio: true, containsVideo: false };
   assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
-               'Only audio found in segment when we expected audio and video.' +
-               ' We can\'t switch to audio only from audio and video.' +
+               'Only audio found in segment when we expected video.' +
+               ' We can\'t switch to audio only from a stream that had video.' +
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
                'error when muxed to audio only');
@@ -74,8 +75,9 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
   startingMedia = { containsAudio: true, containsVideo: false };
   newSegmentMedia = { containsAudio: false, containsVideo: true };
   assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
-               'Only video found in segment when we expected audio only.' +
-               ' We can\'t switch since we started on audio only.' +
+               'Video found in segment when we expected only audio.' +
+               ' We can\'t switch to a stream with video from a stream that only had' +
+               ' audio.' +
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
                'error when audio only to video only');
@@ -83,8 +85,8 @@ QUnit.test('illegalMediaSwitch detects illegal media switches', function(assert)
   startingMedia = { containsAudio: false, containsVideo: true };
   newSegmentMedia = { containsAudio: true, containsVideo: false };
   assert.equal(illegalMediaSwitch('main', startingMedia, newSegmentMedia),
-               'Only audio found in segment when we expected video only.' +
-               ' We can\'t switch to audio only from video only.' +
+               'Only audio found in segment when we expected video.' +
+               ' We can\'t switch to audio only from a stream that had video.' +
                ' To get rid of this message, please add codec information to the' +
                ' manifest.',
                'error when video only to audio only');
@@ -714,8 +716,8 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       assert.equal(errors.length, 1, 'one error');
       assert.equal(errors[0].message,
-                   'Only audio found in segment when we expected audio and video.' +
-                   ' We can\'t switch to audio only from audio and video.' +
+                   'Only audio found in segment when we expected video.' +
+                   ' We can\'t switch to audio only from a stream that had video.' +
                    ' To get rid of this message, please add codec information to the' +
                    ' manifest.',
                    'correct error message');


### PR DESCRIPTION
## Description
When a master playlist doesn't contain codec info, we have to wait until we probe to know if a rendition is audio only. Because we can't switch from audio and video to audio only, blacklist that playlist if we're already playing video.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
