### PR TITLE
Fix video corruption on rendition switches in IE11 Win 8.1+ and Edge 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15677,9 +15677,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.2.2.tgz",
-      "integrity": "sha512-fI4PYV3U6kg6FdNngC1PfmyimwhxET6qYAJbaJdlEzFPgtbj553UxKbGBCb1/El+Z5M8VpBUXyWctI+w/7n5EA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.0.tgz",
+      "integrity": "sha512-QTS3OINAFT8wR8Gw52AS1enrKe8EpvT942MUILbHsQnAaQBWrbnMKF4MvfBoNeXjwZLswLOEIVOGsHyqRsMarA=="
     },
     "nodemon": {
       "version": "1.11.0",
@@ -21620,12 +21620,12 @@
       }
     },
     "videojs-contrib-media-sources": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.5.3.tgz",
-      "integrity": "sha512-0ktLhSXnSE3pabUvsFv04esllWYWqHOm1pnDGjBqFshSoVkqK9RZ0P6WhDFDdq4q43jdFdNJXngqxySXwCyVhA==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.6.0.tgz",
+      "integrity": "sha512-XxIEbqbh3np5YuzjnJMgN6Ym5NhwSv2mYfFUantMihTp4aVdoYiVkuRJCsiB9rOuT/n/E1XLZn6KWyRYJDM3Yw==",
       "requires": {
         "global": "4.3.2",
-        "mux.js": "4.2.2",
+        "mux.js": "4.3.0",
         "video.js": "5.20.4",
         "webworkify": "1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
     "m3u8-parser": "2.1.0",
-    "mux.js": "4.2.2",
+    "mux.js": "4.3.0",
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.5.3",
+    "videojs-contrib-media-sources": "4.6.0",
     "webworkify": "1.0.2"
   },
   "devDependencies": {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -612,6 +612,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.tech_.trigger('hls-reset');
     });
 
+    this.mainSegmentLoader_.on('segmenttimemapping', (event) => {
+      this.tech_.trigger({
+        type: 'hls-segment-time-mapping',
+        mapping: event.mapping
+      });
+    });
+
     this.audioSegmentLoader_.on('ended', () => {
       this.onEndOfStream();
     });

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -609,10 +609,14 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('reseteverything', () => {
+      // If playing an MTS stream, a videojs.MediaSource is listening for
+      // hls-reset to reset caption parsing state in the transmuxer
       this.tech_.trigger('hls-reset');
     });
 
     this.mainSegmentLoader_.on('segmenttimemapping', (event) => {
+      // If playing an MTS stream in html, a videojs.MediaSource is listening for
+      // hls-segment-time-mapping update its internal mapping of stream to display time
       this.tech_.trigger({
         type: 'hls-segment-time-mapping',
         mapping: event.mapping

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1119,7 +1119,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.trigger('timestampoffset');
     }
 
-    if (timingInfo.hasMapping) {
+    if (timingInfo && timingInfo.hasMapping) {
       this.trigger({
         type: 'segmenttimemapping',
         mapping: this.syncController_.timelines[segmentInfo.timeline].mapping

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1105,8 +1105,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    this.state = 'APPENDING';
-
     if (segmentInfo.isSyncRequest) {
       this.trigger('syncinfoupdate');
       this.pendingSegment_ = null;
@@ -1120,6 +1118,16 @@ export default class SegmentLoader extends videojs.EventTarget {
       // fired when a timestamp offset is set in HLS (can also identify discontinuities)
       this.trigger('timestampoffset');
     }
+
+    if (timingInfo.hasMapping) {
+      // successful probe of segment
+      this.trigger({
+        type: 'segmenttimemapping',
+        mapping: this.syncController_.timelines[segmentInfo.timeline].mapping
+      });
+    }
+
+    this.state = 'APPENDING';
 
     // if the media initialization segment is changing, append it
     // before the content segment

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1119,10 +1119,12 @@ export default class SegmentLoader extends videojs.EventTarget {
       this.trigger('timestampoffset');
     }
 
-    if (timingInfo && timingInfo.hasMapping) {
+    const timelineMapping = this.syncController_.mappingForTimeline(segmentInfo.timeline);
+
+    if (timelineMapping !== null) {
       this.trigger({
         type: 'segmenttimemapping',
-        mapping: this.syncController_.timelines[segmentInfo.timeline].mapping
+        mapping: timelineMapping
       });
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1120,7 +1120,6 @@ export default class SegmentLoader extends videojs.EventTarget {
     }
 
     if (timingInfo.hasMapping) {
-      // successful probe of segment
       this.trigger({
         type: 'segmenttimemapping',
         mapping: this.syncController_.timelines[segmentInfo.timeline].mapping

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -26,11 +26,18 @@ export default class SourceUpdater {
       // events fire
       this.onUpdateendCallback_ = () => {
         let pendingCallback = this.pendingCallback_;
-
+        console.log('>>> updateend callback happening now');
         this.pendingCallback_ = null;
 
         if (pendingCallback) {
+          if (pendingCallback.fnName_) {
+            console.log('>>> pendingCallback', pendingCallback.fnName_);
+          } else {
+            console.log('>>> pendingCallback', pendingCallback.toString());
+          }
           pendingCallback();
+        } else {
+          console.log('pendingCallback undefined');
         }
 
         this.runCallback_();
@@ -77,7 +84,7 @@ export default class SourceUpdater {
    */
   appendBuffer(bytes, done) {
     this.processedAppend_ = true;
-
+    done.fnName_ = 'handleUpdateEnd_';
     this.queueCallback_(() => {
       this.sourceBuffer_.appendBuffer(bytes);
     }, done);

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -26,18 +26,11 @@ export default class SourceUpdater {
       // events fire
       this.onUpdateendCallback_ = () => {
         let pendingCallback = this.pendingCallback_;
-        console.log('>>> updateend callback happening now');
+
         this.pendingCallback_ = null;
 
         if (pendingCallback) {
-          if (pendingCallback.fnName_) {
-            console.log('>>> pendingCallback', pendingCallback.fnName_);
-          } else {
-            console.log('>>> pendingCallback', pendingCallback.toString());
-          }
           pendingCallback();
-        } else {
-          console.log('pendingCallback undefined');
         }
 
         this.runCallback_();
@@ -84,7 +77,6 @@ export default class SourceUpdater {
    */
   appendBuffer(bytes, done) {
     this.processedAppend_ = true;
-    done.fnName_ = 'handleUpdateEnd_';
     this.queueCallback_(() => {
       this.sourceBuffer_.appendBuffer(bytes);
     }, done);

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -360,6 +360,7 @@ export default class SyncController extends videojs.EventTarget {
   probeSegmentInfo(segmentInfo) {
     const segment = segmentInfo.segment;
     const playlist = segmentInfo.playlist;
+    let hasMapping = false;
     let timingInfo;
 
     if (segment.map) {
@@ -380,8 +381,12 @@ export default class SyncController extends videojs.EventTarget {
             time: segment.start
           };
         }
+
+        hasMapping = true;
       }
     }
+
+    timingInfo.hasMapping = hasMapping;
 
     return timingInfo;
   }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -360,7 +360,6 @@ export default class SyncController extends videojs.EventTarget {
   probeSegmentInfo(segmentInfo) {
     const segment = segmentInfo.segment;
     const playlist = segmentInfo.playlist;
-    let hasMapping = false;
     let timingInfo;
 
     if (segment.map) {
@@ -382,11 +381,9 @@ export default class SyncController extends videojs.EventTarget {
           };
         }
 
-        hasMapping = true;
+        timingInfo.hasMapping = true;
       }
     }
-
-    timingInfo.hasMapping = hasMapping;
 
     return timingInfo;
   }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -380,8 +380,6 @@ export default class SyncController extends videojs.EventTarget {
             time: segment.start
           };
         }
-
-        timingInfo.hasMapping = true;
       }
     }
 
@@ -451,6 +449,13 @@ export default class SyncController extends videojs.EventTarget {
       return null;
     }
     return this.timelines[timeline].time;
+  }
+
+  mappingForTimeline(timeline) {
+    if (typeof this.timelines[timeline] === 'undefined') {
+      return null;
+    }
+    return this.timelines[timeline].mapping;
   }
 
   /**

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -349,9 +349,9 @@ QUnit.module('SegmentLoader', function(hooks) {
     function(assert) {
       let playlist = playlistWithDuration(20);
       let segmenttimemappings = 0;
-      let probeSuccess = false;
+      let timingInfo = { hasMapping: false };
 
-      this.syncController.probeSegmentInfo = () => probeSuccess;
+      this.syncController.probeSegmentInfo = () => timingInfo;
 
       loader.on('segmenttimemapping', function() {
         segmenttimemappings++;
@@ -376,7 +376,7 @@ QUnit.module('SegmentLoader', function(hooks) {
 
       assert.equal(segmenttimemappings, 0, 'no events before segment downloaded');
 
-      probeSuccess = true;
+      timingInfo.hasMapping = true;
       this.syncController.timelines[0] = { mapping: 0 };
 
       // some time passes and a response is received

--- a/test/segment-loader.test.js
+++ b/test/segment-loader.test.js
@@ -345,6 +345,48 @@ QUnit.module('SegmentLoader', function(hooks) {
       assert.equal(loader.mediaRequests, 1, '1 request');
     });
 
+    QUnit.test('loader triggers segmenttimemapping before appending segment',
+    function(assert) {
+      let playlist = playlistWithDuration(20);
+      let segmenttimemappings = 0;
+      let probeSuccess = false;
+
+      this.syncController.probeSegmentInfo = () => probeSuccess;
+
+      loader.on('segmenttimemapping', function() {
+        segmenttimemappings++;
+      });
+
+      loader.playlist(playlist);
+      loader.mimeType(this.mimeType);
+      loader.load();
+      this.clock.tick(1);
+
+      assert.equal(segmenttimemappings, 0, 'no events before segment downloaded');
+
+      // some time passes and a response is received
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(segmenttimemappings, 0,
+        'did not trigger segmenttimemappings with unsuccessful probe');
+
+      this.updateend();
+      this.clock.tick(1);
+
+      assert.equal(segmenttimemappings, 0, 'no events before segment downloaded');
+
+      probeSuccess = true;
+      this.syncController.timelines[0] = { mapping: 0 };
+
+      // some time passes and a response is received
+      this.requests[0].response = new Uint8Array(10).buffer;
+      this.requests.shift().respond(200, null, '');
+
+      assert.equal(segmenttimemappings, 1,
+        'triggered segmenttimemappings with successful probe');
+    });
+
     QUnit.test('adds cues with segment information to the segment-metadata track ' +
                'as they are buffered',
       function(assert) {


### PR DESCRIPTION
## Description
Some browsers (cough IE11 and Edge cough) have a more simple, though still spec compliant, implementation of MediaSourceExtensions compared to other browsers. The main issue with this simpler implementation is that MSE will drop data until the next key frame that comes after the time already sent to the decoder. What this means is you cannot append content that overlaps with the playhead (something videojs-contrib-hls relies on for faster mid-segment quality switching) without the risk of visual corruption since the frames needed to decode the new content at the playhead are dropped before being sent to the decoder. 

REQUIRES THE FOLLOWING FOR FULL SUPPORT
https://github.com/videojs/videojs-contrib-media-sources/pull/164
https://github.com/videojs/mux.js/pull/162

## Specific Changes proposed
 * Before appending each segment, `hls-segment-time-mapping` is triggered on the `tech` for `HtmlMediaSource` from videojs-contrib-media-sources to listen to so that the `VirtualSourceBuffer` can properly convert display time to TS time and trim segment appends accordingly.
    * This approach is used so that if native media sources are being used, the event won't have any effect and things will continue working normally.

