### PR TITLE
Fine tune blacklist handling

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -822,6 +822,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // out-of-date in this scenario
     currentPlaylist = error.playlist || this.masterPlaylistLoader_.media();
 
+    blacklistDuration = blacklistDuration ||
+                        error.blacklistDuration ||
+                        this.blacklistDuration;
+
     // If there is no current playlist, then an error occurred while we were
     // trying to load the master OR while we were disposing of the tech
     if (!currentPlaylist) {
@@ -845,8 +849,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       return this.masterPlaylistLoader_.load(isFinalRendition);
     }
     // Blacklist this playlist
-    currentPlaylist.excludeUntil = Date.now() +
-      (blacklistDuration ? blacklistDuration : this.blacklistDuration) * 1000;
+    currentPlaylist.excludeUntil = Date.now() + (blacklistDuration * 1000);
     this.tech_.trigger('blacklistplaylist');
     this.tech_.trigger({type: 'usage', name: 'hls-rendition-blacklisted'});
 

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -399,6 +399,18 @@ export const isBlacklisted = function(playlist) {
 };
 
 /**
+ * Check whether the playlist is compatible with current playback configuration or has
+ * been blacklisted permanently for being incompatible.
+ *
+ * @param {Object} playlist the media playlist object
+ * @return {boolean} whether the playlist is incompatible or not
+ * @function isIncompatible
+ */
+export const isIncompatible = function(playlist) {
+  return playlist.excludeUntil && playlist.excludeUntil === Infinity;
+};
+
+/**
  * Check whether the playlist is enabled or not.
  *
  * @param {Object} playlist the media playlist object
@@ -409,6 +421,17 @@ export const isEnabled = function(playlist) {
   const blacklisted = isBlacklisted(playlist);
 
   return (!playlist.disabled && !blacklisted);
+};
+
+/**
+ * Check whether the playlist has been manually disabled through the representations api.
+ *
+ * @param {Object} playlist the media playlist object
+ * @return {boolean} whether the playlist is disabled manually or not
+ * @function isDisabled
+ */
+export const isDisabled = function(playlist) {
+  return playlist.disabled;
 };
 
 /**
@@ -487,7 +510,9 @@ Playlist.duration = duration;
 Playlist.seekable = seekable;
 Playlist.getMediaInfoForTime = getMediaInfoForTime;
 Playlist.isEnabled = isEnabled;
+Playlist.isDisabled = isDisabled;
 Playlist.isBlacklisted = isBlacklisted;
+Playlist.isIncompatible = isIncompatible;
 Playlist.playlistEnd = playlistEnd;
 Playlist.isAes = isAes;
 Playlist.isFmp4 = isFmp4;

--- a/src/rendition-mixin.js
+++ b/src/rendition-mixin.js
@@ -1,20 +1,20 @@
-import { isBlacklisted, isEnabled } from './playlist.js';
+import { isIncompatible, isEnabled } from './playlist.js';
+
 /**
- * Enable/disable playlist function. It is intended to have the first two
- * arguments partially-applied in order to create the final per-playlist
- * function.
+ * Returns a function that acts as the Enable/disable playlist function.
  *
- * @param {PlaylistLoader} playlist - The rendition or media-playlist
+ * @param {PlaylistLoader} loader - The master playlist loader
+ * @param {String} playlistUri - uri of the playlist
  * @param {Function} changePlaylistFn - A function to be called after a
  * playlist's enabled-state has been changed. Will NOT be called if a
  * playlist's enabled-state is unchanged
  * @param {Boolean=} enable - Value to set the playlist enabled-state to
  * or if undefined returns the current enabled-state for the playlist
- * @return {Boolean} The current enabled-state of the playlist
+ * @return {Function} Function for setting/getting enabled
  */
-const enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
+const enableFunction = (loader, playlistUri, changePlaylistFn) => (enable) => {
   const playlist = loader.master.playlists[playlistUri];
-  const blacklisted = isBlacklisted(playlist);
+  const incompatible = isIncompatible(playlist);
   const currentlyEnabled = isEnabled(playlist);
 
   if (typeof enable === 'undefined') {
@@ -27,7 +27,7 @@ const enableFunction = (loader, playlistUri, changePlaylistFn, enable) => {
     playlist.disabled = true;
   }
 
-  if (enable !== currentlyEnabled && !blacklisted) {
+  if (enable !== currentlyEnabled && !incompatible) {
     // Ensure the outside world knows about our changes
     changePlaylistFn();
     if (enable) {
@@ -70,10 +70,9 @@ class Representation {
 
     // Partially-apply the enableFunction to create a playlist-
     // specific variant
-    this.enabled = enableFunction.bind(this,
-                                       hlsHandler.playlists,
-                                       playlist.uri,
-                                       fastChangeFunction);
+    this.enabled = enableFunction(hlsHandler.playlists,
+                                  playlist.uri,
+                                  fastChangeFunction);
   }
 }
 
@@ -91,7 +90,7 @@ let renditionSelectionMixin = function(hlsHandler) {
     return playlists
       .master
       .playlists
-      .filter((media) => !isBlacklisted(media))
+      .filter((media) => !isIncompatible(media))
       .map((e, i) => new Representation(hlsHandler, e, e.uri));
   };
 };

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1098,7 +1098,8 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     if (illegalMediaSwitchError) {
       this.error({
-        message: illegalMediaSwitchError
+        message: illegalMediaSwitchError,
+        blacklistDuration: Infinity
       });
       this.trigger('error');
       return;

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -700,79 +700,65 @@ QUnit.test('determines if a playlist is incompatible', function(assert) {
   // incompatible means that the playlist was blacklisted due to incompatible
   // configuration e.g. audio only stream when trying to playback audio and video.
   // incompaatibility is denoted by a blacklist of Infinity.
-  const playlist = {};
-
-  assert.notOk(Playlist.isIncompatible(playlist),
+  assert.notOk(Playlist.isIncompatible({}),
     'playlist not incompatible if no excludeUntil');
 
-  playlist.excludeUntil = 1;
-  assert.notOk(Playlist.isIncompatible(playlist),
+  assert.notOk(Playlist.isIncompatible({ excludeUntil: 1 }),
     'playlist not incompatible if expired blacklist');
 
-  playlist.excludeUntil = Date.now() + 9999;
-  assert.notOk(Playlist.isIncompatible(playlist),
+  assert.notOk(Playlist.isIncompatible({ excludeUntil: Date.now() + 9999 }),
     'playlist not incompatible if temporarily blacklisted');
 
-  playlist.excludeUntil = Infinity;
-  assert.ok(Playlist.isIncompatible(playlist),
+  assert.ok(Playlist.isIncompatible({ excludeUntil: Infinity }),
     'playlist is incompatible if excludeUntil is Infinity');
 });
 
 QUnit.test('determines if a playlist is blacklisted', function(assert) {
-  const playlist = {};
-
-  assert.notOk(Playlist.isBlacklisted(playlist),
+  assert.notOk(Playlist.isBlacklisted({}),
     'playlist not blacklisted if no excludeUntil');
 
-  playlist.excludeUntil = Date.now() - 1;
-  assert.notOk(Playlist.isBlacklisted(playlist),
+  assert.notOk(Playlist.isBlacklisted({ excludeUntil: Date.now() - 1 }),
     'playlist not blacklisted if expired excludeUntil');
 
-  playlist.excludeUntil = Date.now() + 9999;
-  assert.ok(Playlist.isBlacklisted(playlist),
+  assert.ok(Playlist.isBlacklisted({ excludeUntil: Date.now() + 9999 }),
     'playlist is blacklisted');
 
-  playlist.excludeUntil = Infinity;
-  assert.ok(Playlist.isBlacklisted(playlist),
+  assert.ok(Playlist.isBlacklisted({ excludeUntil: Infinity }),
     'playlist is blacklisted if excludeUntil is Infinity');
 });
 
 QUnit.test('determines if a playlist is disabled', function(assert) {
-  const playlist = {};
+  assert.notOk(Playlist.isDisabled({}), 'playlist not disabled');
 
-  assert.notOk(Playlist.isDisabled(playlist), 'playlist not disabled');
-
-  playlist.disabled = true;
-  assert.ok(Playlist.isDisabled(playlist), 'playlist is disabled');
+  assert.ok(Playlist.isDisabled({ disabled: true }), 'playlist is disabled');
 });
 
-QUnit.test('determines if a playlist is enabled', function(assert) {
+QUnit.test('playlists with no or expired blacklist are enabled', function(assert) {
   // enabled means not blacklisted and not disabled
-  const playlist = {};
+  assert.ok(Playlist.isEnabled({}), 'playlist with no blacklist is enabled');
+  assert.ok(Playlist.isEnabled({ excludeUntil: Date.now() - 1 }),
+    'playlist with expired blacklist is enabled');
+});
 
-  assert.ok(Playlist.isEnabled(playlist), 'playlist is enabled');
+QUnit.test('blacklisted playlists are not enabled', function(assert) {
+  // enabled means not blacklisted and not disabled
+  assert.notOk(Playlist.isEnabled({ excludeUntil: Date.now() + 9999 }),
+    'playlist with temporary blacklist is not enabled');
+  assert.notOk(Playlist.isEnabled({ excludeUntil: Infinity }),
+    'playlist with permanent is not enabled');
+});
 
-  playlist.excludeUntil = Date.now() - 1;
-  assert.ok(Playlist.isEnabled(playlist), 'playlist is enabled');
-
-  playlist.excludeUntil = Date.now() + 9999;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
-
-  playlist.excludeUntil = Infinity;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
-
-  delete playlist.excludeUntil;
-  playlist.disabled = true;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
-
-  playlist.excludeUntil = 1;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
-
-  playlist.excludeUntil = Date.now() + 9999;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
-
-  playlist.excludeUntil = Infinity;
-  assert.notOk(Playlist.isEnabled(playlist), 'playlist is not enabled');
+QUnit.test('manually disabled playlists are not enabled regardless of blacklist state',
+function(assert) {
+  // enabled means not blacklisted and not disabled
+  assert.notOk(Playlist.isEnabled({ disabled: true }),
+    'disabled playlist with no blacklist is not enabled');
+  assert.notOk(Playlist.isEnabled({ disabled: true, excludeUntil: Date.now() - 1 }),
+    'disabled playlist with expired blacklist is not enabled');
+  assert.notOk(Playlist.isEnabled({ disabled: true, excludeUntil: Date.now() + 9999 }),
+    'disabled playlist with temporary blacklist is not enabled');
+  assert.notOk(Playlist.isEnabled({ disabled: true, excludeUntil: Infinity }),
+    'disabled playlist with permanent blacklist is not enabled');
 });
 
 QUnit.module('Playlist isAes and isFmp4', {

--- a/test/rendition-mixin.test.js
+++ b/test/rendition-mixin.test.js
@@ -61,7 +61,8 @@ const makeMockHlsHandler = function(playlistOptions) {
     hlsHandler.playlists.master.playlists[i] = makeMockPlaylist(playlist);
 
     if (playlist.uri) {
-      hlsHandler.playlists.master.playlists[playlist.uri] = hlsHandler.playlists.master.playlists[i];
+      hlsHandler.playlists.master.playlists[playlist.uri] =
+        hlsHandler.playlists.master.playlists[i];
     }
   });
 
@@ -77,7 +78,8 @@ QUnit.test('adds the representations API to HlsHandler', function(assert) {
 
   RenditionMixin(hlsHandler);
 
-  assert.equal(typeof hlsHandler.representations, 'function', 'added the representations API');
+  assert.equal(typeof hlsHandler.representations, 'function',
+    'added the representations API');
 });
 
 QUnit.test('returns proper number of representations', function(assert) {
@@ -143,7 +145,8 @@ QUnit.test('returns representations with width and height if present', function(
   assert.equal(renditions[2].height, undefined, 'rendition has a height of undefined');
 });
 
-QUnit.test('blacklisted playlists are not included in the representations list', function(assert) {
+QUnit.test('incompatible playlists are not included in the representations list',
+function(assert) {
   let hlsHandler = makeMockHlsHandler([
     {
       bandwidth: 0,
@@ -175,13 +178,15 @@ QUnit.test('blacklisted playlists are not included in the representations list',
 
   let renditions = hlsHandler.representations();
 
-  assert.equal(renditions.length, 3, 'blacklisted rendition not added');
+  assert.equal(renditions.length, 4, 'incompatible rendition not added');
   assert.equal(renditions[0].id, 'media1.m3u8', 'rendition is enabled');
-  assert.equal(renditions[1].id, 'media3.m3u8', 'rendition is enabled');
-  assert.equal(renditions[2].id, 'media4.m3u8', 'rendition is enabled');
+  assert.equal(renditions[1].id, 'media2.m3u8', 'rendition is enabled');
+  assert.equal(renditions[2].id, 'media3.m3u8', 'rendition is enabled');
+  assert.equal(renditions[3].id, 'media4.m3u8', 'rendition is enabled');
 });
 
-QUnit.test('setting a representation to disabled sets disabled to true', function(assert) {
+QUnit.test('setting a representation to disabled sets disabled to true',
+function(assert) {
   let renditiondisabled = 0;
   let hlsHandler = makeMockHlsHandler([
     {
@@ -211,11 +216,14 @@ QUnit.test('setting a representation to disabled sets disabled to true', functio
   assert.equal(renditiondisabled, 1, 'renditiondisabled event has been triggered');
   assert.equal(playlists[0].disabled, true, 'rendition has been disabled');
   assert.equal(playlists[1].disabled, undefined, 'rendition has not been disabled');
-  assert.equal(playlists[0].excludeUntil, 0, 'excludeUntil not touched when disabling a rendition');
-  assert.equal(playlists[1].excludeUntil, 0, 'excludeUntil not touched when disabling a rendition');
+  assert.equal(playlists[0].excludeUntil, 0,
+    'excludeUntil not touched when disabling a rendition');
+  assert.equal(playlists[1].excludeUntil, 0,
+    'excludeUntil not touched when disabling a rendition');
 });
 
-QUnit.test('changing the enabled state of a representation calls fastQualityChange_', function(assert) {
+QUnit.test('changing the enabled state of a representation calls fastQualityChange_',
+function(assert) {
   let renditionEnabledEvents = 0;
   let hlsHandler = makeMockHlsHandler([
     {
@@ -239,12 +247,14 @@ QUnit.test('changing the enabled state of a representation calls fastQualityChan
   let renditions = hlsHandler.representations();
 
   assert.equal(mpc.fastQualityChange_.calls, 0, 'fastQualityChange_ was never called');
-  assert.equal(renditionEnabledEvents, 0, 'renditionenabled event has not been triggered');
+  assert.equal(renditionEnabledEvents, 0,
+    'renditionenabled event has not been triggered');
 
   renditions[0].enabled(true);
 
   assert.equal(mpc.fastQualityChange_.calls, 1, 'fastQualityChange_ was called once');
-  assert.equal(renditionEnabledEvents, 1, 'renditionenabled event has been triggered once');
+  assert.equal(renditionEnabledEvents, 1,
+    'renditionenabled event has been triggered once');
 
   renditions[1].enabled(false);
 


### PR DESCRIPTION
## Description
Currently it doesn't really matter whether a representation is disabled through user interaction via the representations api, or blacklisted internally because of network or playback errors. This can cause undefined references in our playlist selector (https://github.com/videojs/videojs-contrib-hls/issues/1206 https://github.com/videojs/videojs-contrib-hls/issues/1267)  when whatever playlists have not been manually disabled are all blacklisted internally due to errors.

## Specific Changes proposed
* never allow playlist selector to select a playlist that has been permanently blacklisted due to incompatible configuration
* When filtering playlists within the playlist selectors, if there are no enabled playlists (i.e. not blacklisted internally AND not disabled by the user) available, then fall back to using the list of playlists not disabled by the user regardless of blacklist state.
* make sure playlists blacklisted from an illegal media switch is permanently blacklisted, as there is no reason to try it again at a later time.
* The representation api will return a list that filters out just incompatible playlists instead of both incompatible playlists and temporary blacklisted playlists.
