### PR TITLE
update contrib-media-sources to 4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@ CHANGELOG
 =========
 
 --------------------
+## HEAD (Unreleased)
+* update contrib-media-sources to 4.6.1 [#1284](https://github.com/videojs/videojs-contrib-hls/pull/1284)
+  * update mux.js to 4.3.1
+    * Set active data channel per-field instead of globally for CEA-608
+    * Fixed an issue with captions being placed in the wrong CC
+
+--------------------
 ## 5.12.0 (2017-10-19)
 * use `lastSegmentDuration + 2 * targetDuration` for safe live point instead of 3 segments [#1271](https://github.com/videojs/videojs-contrib-hls/pull/1271)
   * do not let back buffer trimming remove within target duration of current time

--- a/package-lock.json
+++ b/package-lock.json
@@ -15677,9 +15677,9 @@
       "dev": true
     },
     "mux.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.0.tgz",
-      "integrity": "sha512-QTS3OINAFT8wR8Gw52AS1enrKe8EpvT942MUILbHsQnAaQBWrbnMKF4MvfBoNeXjwZLswLOEIVOGsHyqRsMarA=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-4.3.1.tgz",
+      "integrity": "sha512-Ups1dVqPx3kYhsi72HJFfESqHnxJcy2XKjjuXRwxbEeu/2G7s3of1azQSdJx91sMcwRl7kcwUMXVYi2Gmlge6A=="
     },
     "nodemon": {
       "version": "1.11.0",
@@ -21620,12 +21620,12 @@
       }
     },
     "videojs-contrib-media-sources": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.6.0.tgz",
-      "integrity": "sha512-XxIEbqbh3np5YuzjnJMgN6Ym5NhwSv2mYfFUantMihTp4aVdoYiVkuRJCsiB9rOuT/n/E1XLZn6KWyRYJDM3Yw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.6.1.tgz",
+      "integrity": "sha512-LGab5bYp2JZp4RHUgnQoWee2Ff43mqD0eZzbg6ry26DQUJYQ6fRKSepvepkxANeBd242w858v+pe/SYj70xleQ==",
       "requires": {
         "global": "4.3.2",
-        "mux.js": "4.3.0",
+        "mux.js": "4.3.1",
         "video.js": "5.20.4",
         "webworkify": "1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -92,10 +92,10 @@
     "aes-decrypter": "1.0.3",
     "global": "^4.3.0",
     "m3u8-parser": "2.1.0",
-    "mux.js": "4.3.0",
+    "mux.js": "4.3.1",
     "url-toolkit": "1.0.9",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.6.0",
+    "videojs-contrib-media-sources": "4.6.1",
     "webworkify": "1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
* update mux.js to 4.3.1
  * Set active data channel per-field instead of globally for CEA-608
    * Fixed an issue with captions being placed in the wrong CC