### PR TITLE
Fix: SyncController.selectSyncPoint_ and segment-loader properly handling gaps in live mode

### DIFF
--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -648,9 +648,11 @@ export default class SegmentLoader extends videojs.EventTarget {
    */
   checkBuffer_(buffered, playlist, mediaIndex, hasPlayed, currentTime, syncPoint) {
     let lastBufferedEnd = 0;
+    let lastBufferedStart = 0;
     let startOfSegment;
 
     if (buffered.length) {
+      lastBufferedStart = buffered.start(buffered.length - 1);
       lastBufferedEnd = buffered.end(buffered.length - 1);
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -647,8 +647,8 @@ export default class SegmentLoader extends videojs.EventTarget {
    * @returns {Object} a segment request object that describes the segment to load
    */
   checkBuffer_(buffered, playlist, mediaIndex, hasPlayed, currentTime, syncPoint) {
-    let lastBufferedEnd = 0;
     let lastBufferedStart = 0;
+    let lastBufferedEnd = 0;
     let startOfSegment;
 
     if (buffered.length) {

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -687,9 +687,11 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       syncPointError = lastBufferedStart - currentTime;
 
-      videojs.log.warn('Your playlist might be having a gap or the initial sync-point was bad for another reason.', 
-        'Sync-error is:', syncPointError
-      );
+      videojs.log.warn('The playlist might have an unexpected gap.', 
+        'Seek point is behind buffered time-range start by:', 
+        syncPointError,
+        'seconds.',
+        'Trying to correct buffering range based on current sync-point.');
 
       // try to enforce loading at sync-point
       mediaIndex = null;

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -682,8 +682,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       'fetchAtBuffer:', this.fetchAtBuffer_,
       'bufferedTime:', bufferedTime);
 
-    console.log('lastBufferedStart:', lastBufferedStart)
-
     let syncPointError = 0;
     if (currentTime < lastBufferedStart) {
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -685,24 +685,17 @@ export default class SegmentLoader extends videojs.EventTarget {
     console.log('lastBufferedStart:', lastBufferedStart)
 
     let syncPointError = 0;
-    if (currentTime < syncPoint.time) {
-      console.warn('Sync-point is beyond currentTime!');
+    if (currentTime < lastBufferedStart) {
 
-      syncPointError = syncPoint.time - currentTime;
+      syncPointError = lastBufferedStart - currentTime;
 
-      if (currentTime < lastBufferedStart) {
-        console.log('We are slightly off the trail (your playlist might be missing a segment).', 
-          'Sync-error is:', syncPointError,
-          'Last buffered start delta to current time:', lastBufferedStart - currentTime
-        );
-        
-        // NICE hack but stalls everything 1 out of 5 times
-        // fix it or otherwise: trigger event to master-controller to seek after sync-point
-        mediaIndex = null;
-        currentTime -= playlist.targetDuration;
-        this.fetchAtBuffer_ = false;
-      } 
+      videojs.log.warn('We are slightly off the trail. Your playlist might be having a gap or the initial sync-point was bad for another reason.', 
+        'Sync-error is:', syncPointError
+      );
 
+      // try to enforce loading at sync-point
+      mediaIndex = null;
+      currentTime = lastBufferedEnd = syncPoint.time;
     }
 
     // When the syncPoint is null, there is no way of determining a good

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -687,7 +687,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       syncPointError = lastBufferedStart - currentTime;
 
-      videojs.log.warn('We are slightly off the trail. Your playlist might be having a gap or the initial sync-point was bad for another reason.', 
+      videojs.log.warn('Your playlist might be having a gap or the initial sync-point was bad for another reason.', 
         'Sync-error is:', syncPointError
       );
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1134,14 +1134,21 @@ export default class SegmentLoader extends videojs.EventTarget {
       return;
     }
 
-    if (segmentInfo.timestampOffset !== null &&
-        segmentInfo.timestampOffset !== this.sourceUpdater_.timestampOffset()) {
-      this.sourceUpdater_.timestampOffset(segmentInfo.timestampOffset);
+    const timelineMapping = this.syncController_.mappingForTimeline(segmentInfo.timeline);
+    const absoluteTimestampOffset = segmentInfo.timestampOffset - timelineMapping;
+
+    ///*
+    if (segmentInfo.timestampOffset !== null 
+      //&& this.sourceUpdater_.timestampOffset() !== 0
+      && absoluteTimestampOffset !== this.sourceUpdater_.timestampOffset()) {
+
+      console.log('setting timestamp offset (resolved to timeline):', absoluteTimestampOffset);
+
+      this.sourceUpdater_.timestampOffset(absoluteTimestampOffset);
       // fired when a timestamp offset is set in HLS (can also identify discontinuities)
       this.trigger('timestampoffset');
     }
-
-    const timelineMapping = this.syncController_.mappingForTimeline(segmentInfo.timeline);
+    //*/
 
     if (timelineMapping !== null) {
       this.trigger({

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1153,9 +1153,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     const timelineMapping = this.syncController_.mappingForTimeline(segmentInfo.timeline);
     const absoluteTimestampOffset = segmentInfo.timestampOffset - timelineMapping;
 
-    ///*
     if (segmentInfo.timestampOffset !== null 
-      //&& this.sourceUpdater_.timestampOffset() !== 0
       && absoluteTimestampOffset !== this.sourceUpdater_.timestampOffset()) {
 
       console.log('setting timestamp offset (resolved to timeline):', absoluteTimestampOffset);
@@ -1164,7 +1162,6 @@ export default class SegmentLoader extends videojs.EventTarget {
       // fired when a timestamp offset is set in HLS (can also identify discontinuities)
       this.trigger('timestampoffset');
     }
-    //*/
 
     if (timelineMapping !== null) {
       this.trigger({

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -680,6 +680,29 @@ export default class SegmentLoader extends videojs.EventTarget {
       'fetchAtBuffer:', this.fetchAtBuffer_,
       'bufferedTime:', bufferedTime);
 
+    console.log('lastBufferedStart:', lastBufferedStart)
+
+    let syncPointError = 0;
+    if (currentTime < syncPoint.time) {
+      console.warn('Sync-point is beyond currentTime!');
+
+      syncPointError = syncPoint.time - currentTime;
+
+      if (currentTime < lastBufferedStart) {
+        console.log('We are slightly off the trail (your playlist might be missing a segment).', 
+          'Sync-error is:', syncPointError,
+          'Last buffered start delta to current time:', lastBufferedStart - currentTime
+        );
+        
+        // NICE hack but stalls everything 1 out of 5 times
+        // fix it or otherwise: trigger event to master-controller to seek after sync-point
+        mediaIndex = null;
+        currentTime -= playlist.targetDuration;
+        this.fetchAtBuffer_ = false;
+      } 
+
+    }
+
     // When the syncPoint is null, there is no way of determining a good
     // conservative segment index to fetch from
     // The best thing to do here is to get the kind of sync-point data by

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1152,13 +1152,16 @@ export default class SegmentLoader extends videojs.EventTarget {
 
     const timelineMapping = this.syncController_.mappingForTimeline(segmentInfo.timeline);
     const absoluteTimestampOffset = segmentInfo.timestampOffset - timelineMapping;
+    // resolve to absolute offset only for live playlists
+    const resolvedTimestampOffset = this.playlist_.endList ? segmentInfo.timestampOffset : absoluteTimestampOffset;
 
     if (segmentInfo.timestampOffset !== null 
-      && absoluteTimestampOffset !== this.sourceUpdater_.timestampOffset()) {
+      && resolvedTimestampOffset !== this.sourceUpdater_.timestampOffset()) {
+
 
       console.log('setting timestamp offset (resolved to timeline):', absoluteTimestampOffset);
+      this.sourceUpdater_.timestampOffset(resolvedTimestampOffset);
 
-      this.sourceUpdater_.timestampOffset(absoluteTimestampOffset);
       // fired when a timestamp offset is set in HLS (can also identify discontinuities)
       this.trigger('timestampoffset');
     }

--- a/src/sync-controller.js
+++ b/src/sync-controller.js
@@ -285,7 +285,7 @@ export default class SyncController extends videojs.EventTarget {
     let bestDistance = Math.abs(syncPoints[0].syncPoint[target.key] - target.value);
     let bestStrategy = syncPoints[0].strategy;
 
-    for (let i = 1; i < syncPoints.length; i++) {
+    for (let i = 0; i < syncPoints.length; i++) {
       let newDistance = Math.abs(syncPoints[i].syncPoint[target.key] - target.value);
 
       if (newDistance < bestDistance) {


### PR DESCRIPTION
## Description
Please describe the change as necessary.
If it's a feature or enhancement please be as detailed as possible.
If it's a bug fix, please link the issue that it fixes or describe the bug in as much detail.

## Specific Changes proposed

We didn't handle unadvertised gaps in playlists in live cases yet where we were sync'ing in playlist-mode.

This adds handling the case where the initial guess was wrong and we have started loading to far ahead and not on the target time.

Also, we generally should append with the actual timestamps offset, as otherwise we are not able for handling timestamp gaps at all properly.

Also, there seemed to be a bug in the SyncController, where we were iterating from 1 instead of 0 on the sync methods.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
