### PR TITLE
simplify resolve-url

### DIFF
--- a/src/resolve-url.js
+++ b/src/resolve-url.js
@@ -6,17 +6,9 @@ import URLToolkit from 'url-toolkit';
 import window from 'global/window';
 
 const resolveUrl = function(baseURL, relativeURL) {
-  // return early if we don't need to resolve
-  if ((/^[a-z]+:/i).test(relativeURL)) {
-    return relativeURL;
-  }
-
-  // if the base URL is relative then combine with the current location
-  if (!(/\/\//i).test(baseURL)) {
-    baseURL = URLToolkit.buildAbsoluteURL(window.location.href, baseURL);
-  }
-
-  return URLToolkit.buildAbsoluteURL(baseURL, relativeURL);
+  return URLToolkit.buildAbsoluteURL(
+    URLToolkit.buildAbsoluteURL(window.location.href, baseURL), relativeURL
+  );
 };
 
 export default resolveUrl;


### PR DESCRIPTION
It is possible to remove some of the checks here, because they are already performed in the library.

If the relative url is actually absolute, it returns it [here](https://github.com/tjenkinson/url-toolkit/blob/71441a287aabe535ffac70a380f546cda6719459/src/url-toolkit.js#L46) after running through one regex (which is cached), so it should also improve performance slightly