### PR TITLE
Fix issue 963: error on SourceBuffer creation

### DIFF
--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -130,7 +130,7 @@ export default class SourceUpdater {
     } else if (mediaSource.readyState === 'closed') {
       mediaSource.addEventListener('sourceopen', createSourceBufferDeferred);
     } else {
-      throw new Error('MediaSource in illegal ready-state: ' + mediaSource.readyState)
+      throw new Error('MediaSource in illegal ready-state: ' + mediaSource.readyState);
     }
   }
 

--- a/src/source-updater.js
+++ b/src/source-updater.js
@@ -84,12 +84,41 @@ export default class SourceUpdater {
     createSourceBufferDeferred =
       (() => setTimeout(createSourceBuffer, ADD_SOURCE_BUFFER_RETRY_DEFER_MS));
 
+    /**
+     * @private
+     * @member {Array<function>}
+     */
     this.callbacks_ = [];
+
+    /**
+     * @private
+     * @member {function}
+     */
     this.pendingCallback_ = null;
+
+    /**
+     * @private
+     * @member {number}
+     */
     this.timestampOffset_ = 0;
+
+    /**
+     * @public
+     * @member {MediaSource}
+     */
     this.mediaSource = mediaSource;
+
+    /**
+     * @public
+     * @member {boolean}
+     */
     this.processedAppend_ = false;
 
+    /**
+     * @private
+     * @member {SourceBuffer} sourceBuffer_
+     */
+    this.sourceBuffer_ = null;
 
     if (mediaSource.readyState === 'ended') {
       throw new Error('Cant create SourceBuffers on ended MediaSource');


### PR DESCRIPTION
## Description

Fixes https://github.com/videojs/videojs-contrib-hls/issues/963, see history/triage there.

Defers creation of SourceBuffer and retries as necessary (see comments in code).

Trying to deal with apparent uncertainty coming from lower layers (MediaSource wrappers or actually browsers implementations).

TODO:

- [ ] Adapt tests to check for creation of SourceBuffer asynchroneously

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
