### PR TITLE
Fix tech.play() throwing unresolved promise errors on Chrome

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -771,7 +771,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
       // Catch/silence error when a pause interrupts a play request
       // on browsers which return a promise
-      if (playPromise !== undefined && typeof playPromise.then === 'function') {
+      if (typeof playPromise !== 'undefined' && typeof playPromise.then === 'function') {
         playPromise.then(null, (e) => {});
       }
     }

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -767,7 +767,13 @@ export class MasterPlaylistController extends videojs.EventTarget {
     // code in video.js but is required because play() must be invoked
     // *after* the media source has opened.
     if (this.tech_.autoplay()) {
-      this.tech_.play();
+      const playPromise = this.tech_.play();
+
+      // Catch/silence error when a pause interrupts a play request
+      // on browsers which return a promise
+      if (playPromise !== undefined && typeof playPromise.then === 'function') {
+        playPromise.then(null, (e) => {});
+      }
     }
 
     this.trigger('sourceopen');

--- a/test/master-playlist-controller.test.js
+++ b/test/master-playlist-controller.test.js
@@ -2299,6 +2299,21 @@ QUnit.test('calculates dynamic BUFFER_LOW_WATER_LINE', function(assert) {
   Object.keys(configOld).forEach((key) => Config[key] = configOld[key]);
 });
 
+QUnit.test('Exception in play promise should be caught', function(assert) {
+  const mpc = this.masterPlaylistController;
+
+  mpc.setupSourceBuffers = () => true;
+  mpc.tech_ = {
+    autoplay: () => true,
+    play: () => new Promise(function(resolve, reject) {
+      reject(new DOMException());
+    })
+  };
+  mpc.handleSourceOpen_();
+
+  assert.ok(true, 'rejects dom exception');
+});
+
 QUnit.module('Codec to MIME Type Conversion');
 
 const testMimeTypes = function(assert, isFMP4) {


### PR DESCRIPTION
## Description
This is an enhancement that fixes errors being thrown by videojs-contrib-hls on Chrome. While the error does not impact player functionality, it pollutes the console log, which may result in confusion or time wasted during manual/automated testing. The error is caused by the media `.play()` event returning a Promise in Chrome, which throws the error `The play() request was interrupted by a call to pause()`.

The fix is mirrored from [a similar fix in the video.js core repo](https://github.com/videojs/video.js/pull/3518), which simply wraps the return value of `.play()` in a promise if necessary.

## Specific Changes proposed
This fix proposes to wrap the `this.tech_.play()` call in `handleSourceOpen_()` in the `master-playlist-controller` with a `.then()`, so that Chrome does not show a Promise-based error.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [x] Reviewed by Two Core Contributors
