### PR TITLE
Provide previous segment index on exact time match to be conservative

### DIFF
--- a/src/playlist.js
+++ b/src/playlist.js
@@ -348,7 +348,9 @@ export const getMediaInfoForTime = function(playlist,
 
   let time = currentTime - startTime;
 
-  if (time < 0) {
+  // when the time is an exact match, this will choose the previous segment in order to be
+  // conservative
+  if (time <= 0) {
     // Walk backward from startIndex in the playlist, adding durations
     // until we find a segment that contains `time` and return it
     if (startIndex > 0) {

--- a/test/playlist.test.js
+++ b/test/playlist.test.js
@@ -1021,10 +1021,17 @@ function(assert) {
 
   assert.equal(Playlist.getMediaInfoForTime(media, 4, 0, 0).mediaIndex, 0,
     'rounds down exact matches');
+  assert.equal(Playlist.getMediaInfoForTime(media, 4, 1, 4).mediaIndex, 0,
+    'rounds down exact matches on sync points');
   assert.equal(Playlist.getMediaInfoForTime(media, 3.7, 0, 0).mediaIndex, 0,
     'rounds down');
   assert.equal(Playlist.getMediaInfoForTime(media, 4.5, 0, 0).mediaIndex, 1,
     'rounds up at 0.5');
+  // Sync points should be accurate, and though we may want to consider a fudge factor in
+  // the future, if we do, this function should not manage the fudge. This function should
+  // provide as accurate an answer as reasonable.
+  assert.equal(Playlist.getMediaInfoForTime(media, 4.01, 1, 4).mediaIndex, 1,
+    'does not account for any fudge factor');
 });
 
 QUnit.test(


### PR DESCRIPTION
## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [X] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
