### PR TITLE
use webwackify for webworkers to support webpack bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2796,15 +2796,6 @@
         }
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
-      }
-    },
     "babelify": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-6.4.0.tgz",
@@ -7162,11 +7153,6 @@
         }
       }
     },
-    "core-js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-    },
     "cowsay": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/cowsay/-/cowsay-1.1.9.tgz",
@@ -7375,24 +7361,6 @@
         }
       }
     },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
-    "es5-shim": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
-      "integrity": "sha1-Kh4rnlg/9f7Qwgo+4svz91IwpcA="
-    },
-    "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "requires": {
-        "is-function": "1.0.1"
-      }
-    },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
@@ -7526,16 +7494,6 @@
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
       "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
       "dev": true
-    },
-    "individual": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c="
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "isparta": {
       "version": "4.0.0",
@@ -12960,14 +12918,6 @@
       "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-2.1.0.tgz",
       "integrity": "sha1-yBcDKewc1RXQ1Yu4t2LamJbLA2g="
     },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "0.1.1"
-      }
-    },
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -16095,15 +16045,6 @@
         }
       }
     },
-    "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "requires": {
-        "for-each": "0.3.2",
-        "trim": "0.0.1"
-      }
-    },
     "portscanner": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
@@ -16120,11 +16061,6 @@
           "dev": true
         }
       }
-    },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "qunitjs": {
       "version": "2.4.0",
@@ -18341,27 +18277,6 @@
         }
       }
     },
-    "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-    },
-    "rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha1-NMdbLm3Dn+WHXlveyFteD5FTb3I=",
-      "requires": {
-        "individual": "2.0.0"
-      }
-    },
-    "safe-json-parse": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
-      "integrity": "sha1-fA9XjPzNEtM6ccDgVBPi7KFx6qw=",
-      "requires": {
-        "rust-result": "1.0.0"
-      }
-    },
     "serve-static": {
       "version": "1.12.4",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
@@ -18522,16 +18437,6 @@
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
       "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
       "dev": true
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-    },
-    "tsml": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tsml/-/tsml-1.0.1.tgz",
-      "integrity": "sha1-ifghi52eJX9H1/a1bQHFpNLGj8M="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -18872,43 +18777,14 @@
       }
     },
     "videojs-contrib-media-sources": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.6.2.tgz",
-      "integrity": "sha512-DSfAK0s4wB+lYD6w59bwalchdWzlUm7fbn+tGuzfZ4YZtTjIIkEnymyjhsLoeEnjNjAuG/p7Ri/6xeoaMhme9Q==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/videojs-contrib-media-sources/-/videojs-contrib-media-sources-4.7.0.tgz",
+      "integrity": "sha512-RdjegTilaEsUD8S4uT50yzSpPASsG8IQCERp71bC4pxvo8PRCSZGrZWhMCnPanxnqiqHOp8eJbHl6cuacdU8lw==",
       "requires": {
         "global": "4.3.2",
         "mux.js": "4.3.2",
-        "video.js": "5.20.4",
-        "webworkify": "1.0.2"
-      },
-      "dependencies": {
-        "video.js": {
-          "version": "5.20.4",
-          "resolved": "https://registry.npmjs.org/video.js/-/video.js-5.20.4.tgz",
-          "integrity": "sha512-DkwZcYDN5+qNp3c1y+9N6cQ3XSoFin1dEsEstIRGmALtmh71M8JIPage0S/AC5HzCc7QdUBeeTYHLKZectB2TA==",
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "global": "4.3.0",
-            "safe-json-parse": "4.0.0",
-            "tsml": "1.0.1",
-            "videojs-font": "2.0.0",
-            "videojs-ie8": "1.1.2",
-            "videojs-swf": "5.4.1",
-            "videojs-vtt.js": "0.12.4",
-            "xhr": "2.2.2"
-          },
-          "dependencies": {
-            "global": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/global/-/global-4.3.0.tgz",
-              "integrity": "sha1-737EvurVebRU9evV5/MD21T0Kis=",
-              "requires": {
-                "min-document": "2.19.0",
-                "process": "0.5.2"
-              }
-            }
-          }
-        }
+        "video.js": "6.2.5",
+        "webwackify": "0.1.3"
       }
     },
     "videojs-flash": {
@@ -18920,19 +18796,6 @@
         "global": "4.3.2",
         "video.js": "6.2.5",
         "videojs-swf": "5.4.1"
-      }
-    },
-    "videojs-font": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-2.0.0.tgz",
-      "integrity": "sha1-r3Rh751LleAzS/+3iy8v8DZKkDQ="
-    },
-    "videojs-ie8": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/videojs-ie8/-/videojs-ie8-1.1.2.tgz",
-      "integrity": "sha1-oj09hgitcZK2nGB3/E64SJmNNdk=",
-      "requires": {
-        "es5-shim": "4.5.9"
       }
     },
     "videojs-standard": {
@@ -20956,15 +20819,8 @@
     "videojs-swf": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/videojs-swf/-/videojs-swf-5.4.1.tgz",
-      "integrity": "sha1-IHfvccdJ8seCPvSbq65N0qywj4c="
-    },
-    "videojs-vtt.js": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.12.4.tgz",
-      "integrity": "sha1-OPJJnjHvs/qTWQ3a1MtmMnWksWE=",
-      "requires": {
-        "global": "4.3.2"
-      }
+      "integrity": "sha1-IHfvccdJ8seCPvSbq65N0qywj4c=",
+      "dev": true
     },
     "watchify": {
       "version": "3.9.0",
@@ -27031,26 +26887,10 @@
         }
       }
     },
-    "webworkify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.0.2.tgz",
-      "integrity": "sha1-thapWmIlJJvyWpHpbglCxmUVWZU="
-    },
-    "xhr": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.2.2.tgz",
-      "integrity": "sha1-LuclcYafhobUFVmp6ihsGJcUNf8=",
-      "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    "webwackify": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/webwackify/-/webwackify-0.1.3.tgz",
+      "integrity": "sha512-ttgVaQAd+9kYmZxgAuP8LMlYQRwDa8CujTEIxjXzb/XzMkF9Rg5jN7J4tus1kJvFHeINDa0MlM3pZqR+iRmkAg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "mux.js": "4.3.2",
     "url-toolkit": "^2.1.3",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.6.2",
-    "webworkify": "1.0.2"
+    "videojs-contrib-media-sources": "4.7.0",
+    "webwackify": "0.1.3"
   },
   "devDependencies": {
     "babel": "^5.8.0",

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -10,7 +10,7 @@ import videojs from 'video.js';
 import AdCueTags from './ad-cue-tags';
 import SyncController from './sync-controller';
 import { translateLegacyCodecs } from 'videojs-contrib-media-sources/es5/codec-utils';
-import worker from 'webworkify';
+import worker from 'webwackify';
 import Decrypter from './decrypter-worker';
 import Config from './config';
 import { parseCodecs } from './util/codecs.js';
@@ -41,6 +41,18 @@ const loaderStats = [
 const sumLoaderStat = function(stat) {
   return this.audioSegmentLoader_[stat] +
          this.mainSegmentLoader_[stat];
+};
+
+const resolveDecrypterWorker = () => {
+  let result;
+
+  try {
+    result = require.resolve('./decrypter-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
 };
 
 /**
@@ -275,7 +287,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       label: 'segment-metadata'
     }, false).track;
 
-    this.decrypter_ = worker(Decrypter);
+    this.decrypter_ = worker(Decrypter, resolveDecrypterWorker());
 
     const segmentLoaderSettings = {
       hls: this.hls_,

--- a/test/loader-common.js
+++ b/test/loader-common.js
@@ -10,7 +10,19 @@ import {
 import { MasterPlaylistController } from '../src/master-playlist-controller';
 import SyncController from '../src/sync-controller';
 import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+import worker from 'webwackify';
+
+const resolveDecrypterWorker = () => {
+  let result;
+
+  try {
+    result = require.resolve('../src/decrypter-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 /**
  * beforeEach and afterEach hooks that should be run segment loader tests regardless of
@@ -44,7 +56,7 @@ export const LoaderCommonHooks = {
     this.mediaSource = new videojs.MediaSource();
     this.mediaSource.trigger('sourceopen');
     this.syncController = new SyncController();
-    this.decrypter = worker(Decrypter);
+    this.decrypter = worker(Decrypter, resolveDecrypterWorker());
   },
   afterEach(assert) {
     this.env.restore();

--- a/test/media-segment-request.test.js
+++ b/test/media-segment-request.test.js
@@ -3,7 +3,19 @@ import {mediaSegmentRequest, REQUEST_ERRORS} from '../src/media-segment-request'
 import xhrFactory from '../src/xhr';
 import {useFakeEnvironment} from './test-helpers';
 import Decrypter from '../src/decrypter-worker';
-import worker from 'webworkify';
+import worker from 'webwackify';
+
+const resolveDecrypterWorker = () => {
+  let result;
+
+  try {
+    result = require.resolve('../src/decrypter-worker');
+  } catch (e) {
+    // no result
+  }
+
+  return result;
+};
 
 QUnit.module('Media Segment Request', {
   beforeEach(assert) {
@@ -11,7 +23,7 @@ QUnit.module('Media Segment Request', {
     this.clock = this.env.clock;
     this.requests = this.env.requests;
     this.xhr = xhrFactory();
-    this.realDecrypter = worker(Decrypter);
+    this.realDecrypter = worker(Decrypter, resolveDecrypterWorker());
     this.mockDecrypter = {
       listeners: [],
       postMessage(message) {


### PR DESCRIPTION
Regarding the require.resolve:

webpack resolves module names to ids during compile time. One of the issues with webworkify-webpack-dropin was that it used regex to search for the require statements to get the resolved module id so it could properly setup the bootstrapfn to start at the right module. This broke in some cases with minification because the regex would get messed up. By passing the module id directly from require.resolve, you dont have to do any of the regex work, and can just build the entire module list and have the starting id given to you. This problem is described in more detail here https://github.com/videojs/videojs-contrib-hls/issues/600#issuecomment-293550845