### PR TITLE
Improved seek behaviour

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1026,7 +1026,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
   }
 
   seeking() {
-    return this.seeking_;
+    return this.tech_.el_.seeking || this.seeking_;
   }
 
   onSyncInfoUpdate_() {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -643,6 +643,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.audioSegmentLoader_.on('ended', () => {
       this.onEndOfStream();
     });
+
+    this.mainSegmentLoader_.on('buffered', (event) => {
+      this.tech_.setPlaybackRate(this.playbackRate);
+    });
   }
 
   mediaSecondsLoaded_() {
@@ -953,6 +957,9 @@ export class MasterPlaylistController extends videojs.EventTarget {
     if (buffered && buffered.length && this.mode_ !== 'flash') {
       return currentTime;
     }
+
+    this.playbackRate = this.tech_.playbackRate();
+    this.tech_.setPlaybackRate(0);
 
     // cancel outstanding requests so we begin buffering at the new
     // location

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -1062,7 +1062,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       deadline: this.seekDeadline_,
       currentTimeline: this.mainSegmentLoader_.currentTimeline_,
       syncController: this.syncController_,
-      extraRequests: 1
+      extraRequests
     });
 
     // cancel outstanding requests so we begin buffering at the new

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -645,10 +645,27 @@ export class MasterPlaylistController extends videojs.EventTarget {
       this.onEndOfStream();
     });
 
-    this.mainSegmentLoader_.on('buffered', (event) => {
-      this.seeking_ = false;
-      this.tech_.setPlaybackRate(this.playbackRate);
+    this.mainSegmentLoader_.on('buffered', this.seeked_.bind(this));
+    this.tech_.on('seeked', () => {
+      if (this.seeking_ && !this.tech_.seeking()) {
+        // we've got an old version of videojs that doesn't support deferring
+        // seeking to the source handler, so resume immediately
+        this.seeked_();
+      }
     });
+  }
+
+  /**
+   * Restore playback rate and set seeking to false
+   *
+   * @private
+   */
+  seeked_() {
+    if (!this.seeking_) {
+      return;
+    }
+    this.seeking_ = false;
+    this.tech_.setPlaybackRate(this.playbackRate_);
   }
 
   mediaSecondsLoaded_() {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -297,7 +297,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
       mediaSource: this.mediaSource,
       currentTime: this.tech_.currentTime.bind(this.tech_),
       seekable: () => this.seekable(),
-      seeking: () => this.tech_.seeking(),
+      seeking: () => this.seeking(),
       duration: () => this.mediaSource.duration,
       hasPlayed: () => this.hasPlayed_(),
       goalBufferLength: () => this.goalBufferLength(),
@@ -941,6 +941,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   setCurrentTime(currentTime) {
     this.seeking_ = true;
+
     let buffered = Ranges.findRange(this.tech_.buffered(), currentTime);
 
     if (!(this.masterPlaylistLoader_ && this.masterPlaylistLoader_.media())) {

--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -281,6 +281,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     this.mediaSource.addEventListener('sourceopen', this.handleSourceOpen_.bind(this));
 
     this.seekable_ = videojs.createTimeRanges();
+    this.seeking_ = false;
     this.hasPlayed_ = () => false;
 
     this.syncController_ = new SyncController(options);
@@ -645,6 +646,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
     });
 
     this.mainSegmentLoader_.on('buffered', (event) => {
+      this.seeking_ = false;
       this.tech_.setPlaybackRate(this.playbackRate);
     });
   }
@@ -938,6 +940,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
    * @return {TimeRange} the current time
    */
   setCurrentTime(currentTime) {
+    this.seeking_ = true;
     let buffered = Ranges.findRange(this.tech_.buffered(), currentTime);
 
     if (!(this.masterPlaylistLoader_ && this.masterPlaylistLoader_.media())) {
@@ -1002,6 +1005,10 @@ export class MasterPlaylistController extends videojs.EventTarget {
    */
   seekable() {
     return this.seekable_;
+  }
+
+  seeking() {
+    return this.seeking_;
   }
 
   onSyncInfoUpdate_() {

--- a/src/playback-watcher.js
+++ b/src/playback-watcher.js
@@ -241,8 +241,8 @@ export default class PlaybackWatcher {
       return true;
     }
 
-    if (this.tech_.seeking() || this.timer_ !== null) {
-      // Tech is seeking or already waiting on another action, no action needed
+    if (this.tech_.seeking() || this.tech_.playbackRate() === 0 || this.timer_ !== null) {
+      // Tech is seeking, filling buffer post-seek, or already waiting on another action; no action needed
       return true;
     }
 

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1216,6 +1216,14 @@ export default class SegmentLoader extends videojs.EventTarget {
     // point would mean that this was the perfect segment to fetch
     this.trigger('syncinfoupdate');
 
+    if (this.loaderType_ === 'main' && this.hls_.tech_.playbackRate() === 0) {
+      let buffered = this.buffered_();
+
+      if ((buffered.end(0) - this.currentTime_()) >= this.playlist_.targetDuration) {
+        this.trigger('buffered');
+      }
+    }
+
     // If we previously appended a segment that ends more than 3 targetDurations before
     // the currentTime_ that means that our conservative guess was too conservative.
     // In that case, reset the loader state so that we try to use any information gained

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -1219,7 +1219,7 @@ export default class SegmentLoader extends videojs.EventTarget {
     if (this.loaderType_ === 'main' && this.hls_.tech_.playbackRate() === 0) {
       let buffered = this.buffered_();
 
-      if ((buffered.end(0) - this.currentTime_()) >= this.playlist_.targetDuration) {
+      if ((buffered.end(0) - this.currentTime_()) >= (this.roundTrip / 1000) + 1) {
         this.trigger('buffered');
       }
     }

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -513,7 +513,6 @@ export default class SegmentLoader extends videojs.EventTarget {
    * Useful for fast quality changes
    */
   resetLoader() {
-    this.logger_('resetLoader');
     this.fetchAtBuffer_ = false;
     this.resyncLoader();
   }
@@ -523,7 +522,6 @@ export default class SegmentLoader extends videojs.EventTarget {
    * before returning to the simple walk-forward method
    */
   resyncLoader() {
-    this.logger_('resyncLoader');
     this.mediaIndex = null;
     this.syncPoint_ = null;
     this.abort();

--- a/src/segment-loader.js
+++ b/src/segment-loader.js
@@ -632,7 +632,7 @@ export default class SegmentLoader extends videojs.EventTarget {
       segmentInfo.timestampOffset = segmentInfo.startOfSegment;
     }
 
-    if (this.seeking_()) {
+    if (this.seeking_() && !this.seekStartedAt_) {
       this.seekStartedAt_ = new Date();
     }
 
@@ -1230,6 +1230,7 @@ export default class SegmentLoader extends videojs.EventTarget {
 
       if ((buffered.end(0) - this.currentTime_()) >= (this.roundTrip / 1000) + 1) {
         this.trigger('buffered');
+        this.seekStartedAt_ = null;
       }
     }
 

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -494,6 +494,10 @@ class HlsHandler extends Component {
     return this.masterPlaylistController_.seekable();
   }
 
+  seeking() {
+    return this.masterPlaylistController_.seeking();
+  }
+
   /**
   * Abort all outstanding work and cleanup.
   */

--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -266,6 +266,10 @@ class HlsHandler extends Component {
       }
     });
 
+    if (typeof this.options_.seekDeadline !== 'number') {
+      this.options_.seekDeadline = 5;
+    }
+
     this.bandwidth = this.options_.bandwidth;
   }
   /**

--- a/test/playback-watcher.test.js
+++ b/test/playback-watcher.test.js
@@ -497,7 +497,8 @@ QUnit.test('corrects seek outside of seekable', function(assert) {
     currentTime: () => currentTime,
     // mocked out
     paused: () => false,
-    buffered: () => videojs.createTimeRanges()
+    buffered: () => videojs.createTimeRanges(),
+    playbackRate: () => {}
   };
 
   // waiting


### PR DESCRIPTION
## Description

This change requires videojs/video.js#5024, which takes care of the UI and API aspects of buffering.

SourceHandlers that use MSE have a problem: if they push a segment into a `SourceBuffer` and then seek close to the end, playback will stall and/or there will be a massive downswitch in quality. The general approach to fixing this that was discussed on slack was by setting the playback rate of the player to zero, buffering all that was required, and then restoring the previous playback rate. In my implementation, I've done this in the source handler.

Additionally, there is a new `seekDeadline` option for the source handler which controls how long a seek should take to resume. When seeking, the master playlist controller calculates the maximum bandwidth playlist for all requests needed to complete a full seek. The calculations are done using `minRebufferMaxBandwidthSelector` (renamed to `maxBandwidthForDeadlineSelector`).

Besides being a generally good change, this was somewhat needed for backwards compatibility with older video.js versions. Because of [this](https://github.com/videojs/video.js/blob/c98912fd92090e81feba3236f0f8d5b4e8c58b03/src/js/player.js#L1295), if you cause playback to stall after seek by seeking too close to the end of a segment, the second segment will have its spinner disappear (since you'll get a `timeupdate` after the `waiting`). This error is currently masked because seek quality is trashed when seeking, so you'll always be able to buffer the second segment before the spinner disappears from the `timeupdate`.

With the seek deadline enforcement, although not a _real_ fix, it is significantly mitigated since you'll be kicked down to a lower rate for seeks which require downloading two segments. So you probably won't end up with any noticeable delay between spinner disappearing and playback resuming. For that reason, I think the "buffer appropriate number of segments" and the "seek deadline enforcement" should be considered a single PR.

When combined with #1239, this makes the seeking behavior vastly improved:
- playback is on highest rate
- seek is requested by client to right before the end of a segment
- playback pauses, spinner appears, `player.seeking()` is now true
- buffer is sufficiently filled at new time in reasonable timeframe, downswitching if necessary
- two segments at lower rate are now in buffer
- playback resumes, spinner disappears, player fires playback events, `player.seeking()` is now false
- next segment download is at highest rate

videojs/videojs-contrib-hls#1239 has been reviewed, but I don't believe it's been tested. Let me know if you want me to stage the changes here so it can all be considered as part of a single PR. 

## Specific Changes proposed
- Added `seekDeadline` option for controlling how long a seek should take to resume
- `seeking()` is deferred from the tech to the SourceHandler
- `setCurrentTime` stores the current playback rate and set the tech's playback rate to zero
- Inside `SegmentLoader#handleUpdateEnd_`, if we have enough buffer that we can make another request in that time, fire `buffered` on `this`
- The `MasterPlaylistController` receives the `buffered` event and restores the previous playback rate
- `minRebufferMaxBandwidthSelector` has been renamed to `maxBandwidthForDeadlineSelector`, and made more generic
  - it now accepts an `extraRequests` parameter which is added to the `numRequests` for the segment
  - instead of returning `rebufferingImpact`, it now just returns `requestTimeEstimate`
- For the deadline passed to `maxBandwidthForDeadlineSelector`, `abortRequestEarly_` uses either the current calculation (when not seeking) or the time elapsed since seeking started
- Math inside `abortRequestEarly_` is now a bit simpler because it's now using the `requestTimeEstimate` instead of `rebufferingImpact`
- The quality used when seeking is determined by how long it will take to get the number of segments needed to fill the buffer after the seek 
- The MPC's `fastQualityChange_` now accepts a `nextPlaylist` option which will be used instead of `this.selectPlaylist()` when given
- The playback watcher has been modified to not bork when the playback rate is zero and nothing is happening

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors

## Notes
This is implemented assuming that the video segment loader will always finish after the other segment loaders. I also made [an implementation that guarantees all segment loaders have enough data](https://github.com/videojs/videojs-contrib-hls/compare/master...squarebracket:fix/full-buffer-seek-fix), if you want to compare what that would be like. I found this to be much more concise which is why it gets the PR.

Figuring out some of the testing stuff was becoming troublesome. It'll probably take me a while to get through adding all the tests.