### PR TITLE
WIP: proper syncing for non-muxed HLS live feeds

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -253,6 +253,7 @@ export class MasterPlaylistController extends videojs.EventTarget {
 
     Hls = externHls;
 
+    this.dtsSync_ = null;
     this.withCredentials = withCredentials;
     this.tech_ = tech;
     this.hls_ = tech.hls;
@@ -638,8 +639,24 @@ export class MasterPlaylistController extends videojs.EventTarget {
       });
     });
 
+    this.mainSegmentLoader_.on('firststarttime', this.handleFirstStartTime_.bind(this));
+    this.audioSegmentLoader_.on('firststarttime', this.handleFirstStartTime_.bind(this));
+    this.subtitleSegmentLoader_.on('firststarttime', this.handleFirstStartTime_.bind(this));
+
     this.audioSegmentLoader_.on('ended', () => {
       this.onEndOfStream();
+    });
+  }
+
+  handleFirstStartTime_(event) {
+    if (this.dtsSync_ === null) {
+      this.dtsSync_ = event.start;
+    }
+    event.dtsSync = this.dtsSync_;
+    event.target.trigger({
+      dtsSync: this.dtsSync_,
+      start: event.start,
+      type: 'dtsSync',
     });
   }
 


### PR DESCRIPTION
## Description
Corrects a/v desync for non-muxed live feeds by properly syncing the `timestampOffset` of segment loaders when corresponding segments have different starting DTSs. Note that, since VODs don't call `timestampOffset`, this only affects live feeds.

I get sporadic sync problems so I'll still need to look into that.

## Specific Changes proposed
- Use the `timingInfo` of the first finished segment to dispatch a `firststarttime` event to the master playlist controller
- Set the `dtsSync_` of the MPC if it's null (from the event data), then dispatch a `dtsSync` to the calling segment loader with the received `start` and `this.dtsSync_`.
- The `dtsSync` event handler on the segment loader sets the timestamp offset from the reference

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
