### PR TITLE
Add fix for playlist not updating when only endList changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mux.js": "4.3.2",
     "url-toolkit": "^2.1.3",
     "video.js": "^5.19.1 || ^6.2.0",
-    "videojs-contrib-media-sources": "4.7.2",
+    "videojs-contrib-media-sources": "hpate-omicron/videojs-contrib-media-sources#release/v4.7.3",
     "webwackify": "0.1.6"
   },
   "devDependencies": {

--- a/src/playlist-loader.js
+++ b/src/playlist-loader.js
@@ -69,11 +69,12 @@ export const updateMaster = (master, media) => {
     return null;
   }
 
-  // consider the playlist unchanged if the number of segments is equal and the media
-  // sequence number is unchanged
+  // consider the playlist unchanged if the number of segments is equal, the media
+  // sequence number is unchanged, and this playlist hasn't become the end of the playlist
   if (playlist.segments &&
       media.segments &&
       playlist.segments.length === media.segments.length &&
+      playlist.endList === media.endList &&
       playlist.mediaSequence === media.mediaSequence) {
     return null;
   }

--- a/test/playlist-loader.test.js
+++ b/test/playlist-loader.test.js
@@ -198,6 +198,51 @@ QUnit.test('updateMaster updates master when new media sequence', function(asser
     'updates master when new media sequence');
 });
 
+QUnit.test('updateMaster updates master when endList changes', function(assert) {
+  const playlist = {
+    endList: false,
+    mediaSequence: 0,
+    attributes: {
+      BANDWIDTH: 9
+    },
+    uri: 'playlist-0-uri',
+    resolvedUri: urlTo('playlist-0-uri'),
+    segments: [{
+      duration: 10,
+      uri: 'segment-0-uri',
+      resolvedUri: urlTo('segment-0-uri')
+    }]
+  };
+
+  const master = {
+    playlists: [playlist]
+  };
+
+  const media = Object.assign({}, playlist, {
+    endList: true
+  });
+
+  assert.deepEqual(
+    updateMaster(master, media),
+    {
+      playlists: [{
+        endList: true,
+        mediaSequence: 0,
+        attributes: {
+          BANDWIDTH: 9
+        },
+        uri: 'playlist-0-uri',
+        resolvedUri: urlTo('playlist-0-uri'),
+        segments: [{
+          duration: 10,
+          uri: 'segment-0-uri',
+          resolvedUri: urlTo('segment-0-uri')
+        }]
+      }]
+    },
+    'updates master when endList changes');
+});
+
 QUnit.test('updateMaster retains top level values in master', function(assert) {
   const master = {
     mediaGroups: {


### PR DESCRIPTION
## Description
See videojs/videojs-contrib-hls#1424

Possibly related issues:
videojs/videojs-contrib-hls#442
videojs/videojs-contrib-hls#550
videojs/videojs-contrib-hls#555
videojs/videojs-contrib-hls#111

## Specific Changes proposed
This updates the logic for deciding whether a playlist has changed to check the `endList` property as well.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
