### PR TITLE
fix travis config to _actually_ use containerzed infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ before_script:
   - greenkeeper-lockfile-update
   # always install the appropriate version of video.js for the environment
   - npm i "video.js@$VJS";
-  # pulseaudio is needed for dockerized chrome since it has a dummy sink and
-  # the dummy audio ALSA kernel module isn't loaded by Travis
-  # libavcodec54 is needed by firefox for h.264 support
-  - sudo apt-get install --no-install-recommends pulseaudio libavcodec54
   - pulseaudio -D
 after_script: greenkeeper-lockfile-upload
 
@@ -29,5 +25,12 @@ env:
   - VJS=5
   - VJS=6
 addons:
+  apt:
+    # pulseaudio is needed for dockerized chrome since it has a dummy sink and
+    # the dummy audio ALSA kernel module isn't loaded by Travis
+    # libavcodec54 is needed by firefox for h.264 support
+    packages:
+      - pulseaudio
+      - libavcodec54
   chrome: stable
   firefox: latest

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-qunit": "^1.2.1",
     "karma-safari-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.32",
     "lodash": "^4.17.4",
     "lodash-compat": "^3.10.0",
     "minimist": "^1.2.0",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
   let detectBrowsers = {
     usePhantomJS: false,
     // use headless mode automatically for browsers that support it
-    preferHeadless: false,
+    preferHeadless: true,
     // replace chrome headless with one that is suitable for automatic testing
     postDetection: function(availableBrowsers) {
       let browsers = [];

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
     };
     customLaunchers[browser + 'HeadlessWithFlags'] = {
       base: browser + 'Headless',
-      flags: ['--no-sandbox', '--enable-crash-reporter', '--enable-leak-detection', '--crash-on-failure', '--enable-low-end-device-mode']
+      flags: ['--no-sandbox']
     };
   });
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -28,8 +28,10 @@ module.exports = function(config) {
       for (let index in availableBrowsers) {
         let browser = availableBrowsers[index];
 
-        if (/^(Chromium.*|Chrome.*)/.test(browser)) {
+        if (/^(Chromium.*)/.test(browser)) {
           browsers.push(browser + 'WithFlags');
+        } else if (/^(Chrome.*)/.test(browser)) {
+          // do nothing
         } else if (!/Safari/.test(browser)) {
           browsers.push(browser);
         }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,14 +13,14 @@ module.exports = function(config) {
     };
     customLaunchers[browser + 'HeadlessWithFlags'] = {
       base: browser + 'Headless',
-      flags: ['--no-sandbox']
+      flags: ['--no-sandbox', '--enable-low-end-device-mode']
     };
   });
 
   let detectBrowsers = {
     usePhantomJS: false,
     // use headless mode automatically for browsers that support it
-    preferHeadless: true,
+    preferHeadless: false,
     // replace chrome headless with one that is suitable for automatic testing
     postDetection: function(availableBrowsers) {
       let browsers = [];

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
     };
     customLaunchers[browser + 'HeadlessWithFlags'] = {
       base: browser + 'Headless',
-      flags: ['--no-sandbox']
+      flags: ['--no-sandbox', '--enable-crash-reporter', '--enable-leak-detection', '--crash-on-failure', '--enable-low-end-device-mode']
     };
   });
 
@@ -28,10 +28,8 @@ module.exports = function(config) {
       for (let index in availableBrowsers) {
         let browser = availableBrowsers[index];
 
-        if (/^(Chromium.*)/.test(browser)) {
+        if (/^(Chromium.*|Chrome.*)/.test(browser)) {
           browsers.push(browser + 'WithFlags');
-        } else if (/^(Chrome.*)/.test(browser)) {
-          // do nothing
         } else if (!/Safari/.test(browser)) {
           browsers.push(browser);
         }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -92,7 +92,7 @@ module.exports = function(config) {
     },
     customLaunchers,
     detectBrowsers: detectBrowsers,
-    reporters: ['dots'],
+    reporters: ['spec'],
     port: 9876,
     colors: true,
     autoWatch: false,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
     };
     customLaunchers[browser + 'HeadlessWithFlags'] = {
       base: browser + 'Headless',
-      flags: ['--no-sandbox', '--enable-low-end-device-mode']
+      flags: ['--no-sandbox', '--enable-crash-reporter', '--enable-leak-detection', '--crash-on-failure', '--enable-low-end-device-mode']
     };
   });
 


### PR DESCRIPTION
## Description
When I was testing how to get the tests running in the dockerized travis infra, I was running in the travis docker image as root. When moving to the actual travis config, it told me I needed to be root, so without thinking I added `sudo` to the front. I was sure they'd allow package installs, which they do, but only [using the apt addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-on-Container-Based-Infrastructure); having `sudo` in the script [would automatically kick you over to the VM-based infra](https://docs.travis-ci.com/user/reference/overview/#For-a-particular-.travis.yml-configuration).

[Until they broke that yesterday.](https://github.com/travis-ci/travis-ci/issues/9875)

Anyway, now we'll actually be using the containerized infra.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
