### PR TITLE
Use default audio codec if none specified by playlist

### DIFF
--- a/src/master-playlist-controller.js
+++ b/src/master-playlist-controller.js
@@ -162,12 +162,9 @@ export const mimeTypesForPlaylist_ = function(master, media) {
     }
   }
 
-  // HLS with multiple-audio tracks must always get an audio codec.
-  // Put another way, there is no way to have a video-only multiple-audio HLS!
-  if (isMaat && !codecInfo.audioProfile) {
-    videojs.log.warn(
-      'Multiple audio tracks present but no audio codec string is specified. ' +
-      'Attempting to use the default audio codec (mp4a.40.2)');
+  // Use default audio profile if none specified by playlist
+  if (!codecInfo.audioProfile) {
+    videojs.log.warn('Attempting to use the default audio codec (mp4a.40.2)');
     codecInfo.audioProfile = defaultCodecs.audioProfile;
   }
 


### PR DESCRIPTION
@imbcmdth @gesinger @mjneil In this PR https://github.com/videojs/videojs-contrib-hls/pull/1099/files you put falling back to default audio codec only if multiple audio streams were found https://github.com/videojs/videojs-contrib-hls/pull/1099/files#diff-3f8fe2d6cf175982cf8257063da92a81R206 - up until then the default codec was always used if none was specified by the manifest.

For us this specifically breaks audio playback when we get manifests like https://user-images.githubusercontent.com/904818/37703814-cba60ae2-2cee-11e8-9167-e35a8a3b5734.png that do not explicitly specify audio codecs (but do have audio).

I'll happily update tests or whatever, just wanted to make sure you agree with the fix first.

FYI @lachilles @robinmaben @practual