### PR TITLE
Check plugin reloadSourceOnError is registered or not.

### DIFF
--- a/src/videojs-contrib-hls.js
+++ b/src/videojs-contrib-hls.js
@@ -601,6 +601,9 @@ videojs.m3u8 = m3u8;
 videojs.options.hls = videojs.options.hls || {};
 
 if (videojs.registerPlugin) {
+  if (!videojs.getPlugin('reloadSourceOnError') {
+    videojs.deregisterPlugin('reloadSourceOnError');
+  }
   videojs.registerPlugin('reloadSourceOnError', reloadSourceOnError);
 } else {
   videojs.plugin('reloadSourceOnError', reloadSourceOnError);


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/961094/44894452-5f0d4a80-ad22-11e8-80be-7b517afe7165.png)

`reloadSourceOnError` plugin has already registered.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](http://jsbin.com/liwecukasi/edit?html,output))
- [ ] Reviewed by Two Core Contributors
